### PR TITLE
Adjust loading alloca funcs for (Free,Net)BSD

### DIFF
--- a/src/wildmidi.c
+++ b/src/wildmidi.c
@@ -67,6 +67,8 @@ int msleep(unsigned long millisec);
 #if defined(_MSC_VER)
 #  include <malloc.h>
 #  define alloca _alloca
+# elif defined(__FreeBSD__) || defined(__NetBSD__)
+extern void *alloca(size_t);
 # else
 #   include <alloca.h>
 #endif


### PR DESCRIPTION
On NetBSD and FreeBSD, alloca(3) is defined at stdlib.h,
and they do not have alloca.h.
