### PR TITLE
Add support for use in Nintendo 3DS homebrew (devkitARM)

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Requirements:
 * GCC or clang / Xcode / VisualStudio / MinGW or MinGW-w64
 * DOS port: DJGPP / GNU make
 * OS/2 port: OpenWatcom (tested with version 1.9)
+* Nintendo 3DS port: devkitARM
 
 CHANGELOG
 
@@ -38,6 +39,7 @@ CHANGELOG
   such as Linux. New android ndk makefile.
 * File i/o updates.
 * Support for OS/2.
+* Support for Nintendo 3DS
 * Support for AmigaOS and its variants like MorphOS and AROS.
 * Fixed a nasty bug in dBm_pan_volume. Other fixes and clean-ups.
 

--- a/src/file_io.c
+++ b/src/file_io.c
@@ -127,6 +127,9 @@ void *_WM_BufferFile(const char *filename, uint32_t *size) {
 #elif defined(WILDMIDI_AMIGA)
     BPTR buffer_fd;
     long filsize;
+#elif defined(_3DS)
+    int buffer_fd;
+    struct stat buffer_stat;
 #else /* unix builds */
     int buffer_fd;
     struct stat buffer_stat;


### PR DESCRIPTION
The 3DS homebrew SDK is based on newlib and lacks getpwuid and getuid.

And stat has a bug:
For accesing devices with the full path they are prefixed with a device name (sd-card is "sdmc:/") and stat will fail with "invalid device" when doing this. Surprisingly only "stat" exposes this problem, other IO functions work, that's why I use normal stdio to work around.