### PR TITLE
Add XFM to Arena's music formats.

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,8 +58,8 @@ CHANGELOG
 * API change: WildMidi_GetError() and WildMidi_ClearError() added to
   cleanly check for, retrieve and clear error messages. They no longer
   go to stderr.
-* Support for loading XMI (XMIDI format) files, such as from Arena. Thanks
-  Ryan Nunn for releasing his code under the LGPL.
+* Support for loading XMI (XMIDI format) and XFM files, such as from Arena.
+  Thanks Ryan Nunn for releasing his code under the LGPL.
 * Support for loading MUS (MUS Id format) files, such as from Doom.
 * Support for loading HMP/HMI files, such as from Daggerfall.
 * Support for loading KAR (MIDI with Lyrics) and Type 2 MIDI files.


### PR DESCRIPTION
The addition of XMI support in 0.4.0 apparently also allows XFM files from Arena to be played. It seems that the XFM format is simply XMI but slightly modified to sound better with FM synths. I didn't expect it to work because of the differing extensions, but it plays just fine.