### PR TITLE
Added API Function to allow the user to handle file io

### DIFF
--- a/include/file_io.h
+++ b/include/file_io.h
@@ -26,6 +26,7 @@
 #define __FILE_IO_H
 
 #define WM_MAXFILESIZE 0x1fffffff
-extern void *_WM_BufferFile (const char *filename, uint32_t *size);
+extern void *_WM_BufferFileImpl(const char *filename, uint32_t *size);
+extern void * (*_WM_BufferFile)(const char *, uint32_t *);
 
 #endif /* __FILE_IO_H */

--- a/include/file_io.h
+++ b/include/file_io.h
@@ -27,6 +27,8 @@
 
 #define WM_MAXFILESIZE 0x1fffffff
 extern void *_WM_BufferFileImpl(const char *filename, uint32_t *size);
+extern void  _WM_FreeBufferFileImpl(void*);
 extern void * (*_WM_BufferFile)(const char *, uint32_t *);
+extern void   (*_WM_FreeBufferFile)(void*);
 
 #endif /* __FILE_IO_H */

--- a/include/wildmidi_lib.h
+++ b/include/wildmidi_lib.h
@@ -98,18 +98,30 @@ struct _WM_Info {
 
 typedef void midi;
 
-/* A function of this type should allocate a buffer
-which has the size of the requested file plus one (size+1)
-and fill the second parameter with the size of the file.
-The buffer should be allocated with malloc, and is freed
-by wildmidi.
-*/
-typedef void * (*_WM_VIO)(const char *, uint32_t *);
+typedef void * (*_WM_VIO_Allocate)(const char *, uint32_t *);
+typedef void   (*_WM_VIO_Free)(void *);
+
+struct _WM_VIO {
+    /*
+    This function should allocate a buffer which has the size
+    of the requested file plus one (size+1) and fill the second
+    parameter with the size of the file.
+    
+    The buffer is in possession of wildmidi until the free_file
+    function is called with the buffer address as argument.
+    */
+    _WM_VIO_Allocate allocate_file;
+
+    /*
+    This function should free the memory of the given buffer.
+    */
+    _WM_VIO_Free free_file;
+};
 
 WM_SYMBOL const char * WildMidi_GetString (uint16_t info);
 WM_SYMBOL long WildMidi_GetVersion (void);
 WM_SYMBOL int WildMidi_Init (const char *config_file, uint16_t rate, uint16_t mixer_options);
-WM_SYMBOL int WildMidi_InitVIO(_WM_VIO callback, const char *config_file, uint16_t rate, uint16_t mixer_options);
+WM_SYMBOL int WildMidi_InitVIO(struct _WM_VIO * callbacks, const char *config_file, uint16_t rate, uint16_t mixer_options);
 WM_SYMBOL int WildMidi_MasterVolume (uint8_t master_volume);
 WM_SYMBOL midi * WildMidi_Open (const char *midifile);
 WM_SYMBOL midi * WildMidi_OpenBuffer (uint8_t *midibuffer, uint32_t size);

--- a/include/wildmidi_lib.h
+++ b/include/wildmidi_lib.h
@@ -98,9 +98,18 @@ struct _WM_Info {
 
 typedef void midi;
 
+/* A function of this type should allocate a buffer
+which has the size of the requested file plus one (size+1)
+and fill the second parameter with the size of the file.
+The buffer should be allocated with malloc, and is freed
+by wildmidi.
+*/
+typedef void * (*_WM_VIO)(const char *, uint32_t *);
+
 WM_SYMBOL const char * WildMidi_GetString (uint16_t info);
 WM_SYMBOL long WildMidi_GetVersion (void);
 WM_SYMBOL int WildMidi_Init (const char *config_file, uint16_t rate, uint16_t mixer_options);
+WM_SYMBOL int WildMidi_InitVIO(_WM_VIO callback, const char *config_file, uint16_t rate, uint16_t mixer_options);
 WM_SYMBOL int WildMidi_MasterVolume (uint8_t master_volume);
 WM_SYMBOL midi * WildMidi_Open (const char *midifile);
 WM_SYMBOL midi * WildMidi_OpenBuffer (uint8_t *midibuffer, uint32_t size);

--- a/src/file_io.c
+++ b/src/file_io.c
@@ -71,6 +71,7 @@
 
 #include "wm_error.h"
 #include "file_io.h"
+void * (*_WM_BufferFile)(const char *, uint32_t *)=_WM_BufferFileImpl;
 
 #ifdef WILDMIDI_AMIGA
 static long AMIGA_filesize (const char *path) {
@@ -109,7 +110,7 @@ static void AMIGA_close (BPTR fd) {
 }
 #endif
 
-void *_WM_BufferFile(const char *filename, uint32_t *size) {
+void *_WM_BufferFileImpl(const char *filename, uint32_t *size) {
     char *buffer_file = NULL;
     uint8_t *data;
 #ifdef __DJGPP__

--- a/src/file_io.c
+++ b/src/file_io.c
@@ -72,6 +72,7 @@
 #include "wm_error.h"
 #include "file_io.h"
 void * (*_WM_BufferFile)(const char *, uint32_t *)=_WM_BufferFileImpl;
+void(*_WM_FreeBufferFile)(void*) = _WM_FreeBufferFileImpl;
 
 #ifdef WILDMIDI_AMIGA
 static long AMIGA_filesize (const char *path) {
@@ -274,4 +275,8 @@ void *_WM_BufferFileImpl(const char *filename, uint32_t *size) {
 
     data[*size] = '\0';
     return data;
+}
+
+void  _WM_FreeBufferFileImpl(void* data_buffer) {
+    free(data_buffer);
 }

--- a/src/gus_pat.c
+++ b/src/gus_pat.c
@@ -733,23 +733,23 @@ struct _sample * _WM_load_gus_pat(const char *filename, int fix_release) {
     }
     if (gus_size < 239) {
         _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_CORUPT, filename, 0);
-        free(gus_patch);
+        _WM_FreeBufferFile(gus_patch);
         return NULL;
     }
     if (memcmp(gus_patch, "GF1PATCH110\0ID#000002", 22)
             && memcmp(gus_patch, "GF1PATCH100\0ID#000002", 22)) {
         _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_INVALID, filename, 0);
-        free(gus_patch);
+        _WM_FreeBufferFile(gus_patch);
         return NULL;
     }
     if (gus_patch[82] > 1) {
         _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_INVALID, filename, 0);
-        free(gus_patch);
+        _WM_FreeBufferFile(gus_patch);
         return NULL;
     }
     if (gus_patch[151] > 1) {
         _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_INVALID, filename, 0);
-        free(gus_patch);
+        _WM_FreeBufferFile(gus_patch);
         return NULL;
     }
 
@@ -769,7 +769,7 @@ struct _sample * _WM_load_gus_pat(const char *filename, int fix_release) {
         }
         if (gus_sample == NULL) {
             _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_MEM, filename, 0);
-            free(gus_patch);
+            _WM_FreeBufferFile(gus_patch);
             return NULL;
         }
 
@@ -934,7 +934,7 @@ struct _sample * _WM_load_gus_pat(const char *filename, int fix_release) {
         if (do_convert[(((gus_sample->modes & 0x18) >> 1)
                 | (gus_sample->modes & 0x03))](&gus_patch[gus_ptr], gus_sample)
                 == -1) {
-            free(gus_patch);
+            _WM_FreeBufferFile(gus_patch);
             return NULL;
         }
 
@@ -973,6 +973,6 @@ struct _sample * _WM_load_gus_pat(const char *filename, int fix_release) {
         gus_sample->data_length = gus_sample->data_length << 10;
         no_of_samples--;
     }
-    free(gus_patch);
+    _WM_FreeBufferFile(gus_patch);
     return first_gus_sample;
 }

--- a/src/wildmidi_lib.c
+++ b/src/wildmidi_lib.c
@@ -378,7 +378,7 @@ static int WM_LoadConfig(const char *config_file) {
         if (config_dir == NULL) {
             _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_MEM, config_file, errno);
             WM_FreePatches();
-            free(config_buffer);
+            _WM_FreeBufferFile(config_buffer);
             return (-1);
         }
         strncpy(config_dir, config_file, (dir_end - config_file + 1));
@@ -408,13 +408,13 @@ static int WM_LoadConfig(const char *config_file) {
                             _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_INVALID_ARG, "(missing name in dir line)", 0);
                             WM_FreePatches();
                             free(line_tokens);
-                            free(config_buffer);
+                            _WM_FreeBufferFile(config_buffer);
                             return (-1);
                         } else if (!(config_dir = wm_strdup(line_tokens[1]))) {
                             _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_MEM, config_file, errno);
                             WM_FreePatches();
                             free(line_tokens);
-                            free(config_buffer);
+                            _WM_FreeBufferFile(config_buffer);
                             return (-1);
                         }
                         if (!IS_DIR_SEPARATOR(config_dir[strlen(config_dir) - 1])) {
@@ -427,7 +427,7 @@ static int WM_LoadConfig(const char *config_file) {
                             _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_INVALID_ARG, "(missing name in source line)", 0);
                             WM_FreePatches();
                             free(line_tokens);
-                            free(config_buffer);
+                            _WM_FreeBufferFile(config_buffer);
                             return (-1);
                         } else if (!IS_ABSOLUTE_PATH(line_tokens[1]) && config_dir) {
                             new_config = malloc(strlen(config_dir) + strlen(line_tokens[1]) + 1);
@@ -436,7 +436,7 @@ static int WM_LoadConfig(const char *config_file) {
                                 WM_FreePatches();
                                 free(config_dir);
                                 free(line_tokens);
-                                free(config_buffer);
+                                _WM_FreeBufferFile(config_buffer);
                                 return (-1);
                             }
                             strcpy(new_config, config_dir);
@@ -446,14 +446,14 @@ static int WM_LoadConfig(const char *config_file) {
                                 _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_MEM, config_file, errno);
                                 WM_FreePatches();
                                 free(line_tokens);
-                                free(config_buffer);
+                                _WM_FreeBufferFile(config_buffer);
                                 return (-1);
                             }
                         }
                         if (WM_LoadConfig(new_config) == -1) {
                             free(new_config);
                             free(line_tokens);
-                            free(config_buffer);
+                            _WM_FreeBufferFile(config_buffer);
                             free(config_dir);
                             return (-1);
                         }
@@ -464,7 +464,7 @@ static int WM_LoadConfig(const char *config_file) {
                             WM_FreePatches();
                             free(config_dir);
                             free(line_tokens);
-                            free(config_buffer);
+                            _WM_FreeBufferFile(config_buffer);
                             return (-1);
                         }
                         patchid = (atoi(line_tokens[1]) & 0xFF) << 8;
@@ -474,7 +474,7 @@ static int WM_LoadConfig(const char *config_file) {
                             WM_FreePatches();
                             free(config_dir);
                             free(line_tokens);
-                            free(config_buffer);
+                            _WM_FreeBufferFile(config_buffer);
                             return (-1);
                         }
                         patchid = ((atoi(line_tokens[1]) & 0xFF) << 8) | 0x80;
@@ -484,7 +484,7 @@ static int WM_LoadConfig(const char *config_file) {
                             WM_FreePatches();
                             free(config_dir);
                             free(line_tokens);
-                            free(config_buffer);
+                            _WM_FreeBufferFile(config_buffer);
                             return (-1);
                         }
                         _WM_reverb_room_width = (float) atof(line_tokens[1]);
@@ -501,7 +501,7 @@ static int WM_LoadConfig(const char *config_file) {
                             WM_FreePatches();
                             free(config_dir);
                             free(line_tokens);
-                            free(config_buffer);
+                            _WM_FreeBufferFile(config_buffer);
                             return (-1);
                         }
                         _WM_reverb_room_length = (float) atof(line_tokens[1]);
@@ -518,7 +518,7 @@ static int WM_LoadConfig(const char *config_file) {
                             WM_FreePatches();
                             free(config_dir);
                             free(line_tokens);
-                            free(config_buffer);
+                            _WM_FreeBufferFile(config_buffer);
                             return (-1);
                         }
                         _WM_reverb_listen_posx = (float) atof(line_tokens[1]);
@@ -534,7 +534,7 @@ static int WM_LoadConfig(const char *config_file) {
                             WM_FreePatches();
                             free(config_dir);
                             free(line_tokens);
-                            free(config_buffer);
+                            _WM_FreeBufferFile(config_buffer);
                             return (-1);
                         }
                         _WM_reverb_listen_posy = (float) atof(line_tokens[1]);
@@ -560,7 +560,7 @@ static int WM_LoadConfig(const char *config_file) {
                                 WM_FreePatches();
                                 free(config_dir);
                                 free(line_tokens);
-                                free(config_buffer);
+                                _WM_FreeBufferFile(config_buffer);
                                 return (-1);
                             }
                             tmp_patch = _WM_patch[(patchid & 0x7F)];
@@ -592,7 +592,7 @@ static int WM_LoadConfig(const char *config_file) {
                                             WM_FreePatches();
                                             free(config_dir);
                                             free(line_tokens);
-                                            free(config_buffer);
+                                            _WM_FreeBufferFile(config_buffer);
                                             return (-1);
                                         }
                                         tmp_patch = tmp_patch->next;
@@ -619,7 +619,7 @@ static int WM_LoadConfig(const char *config_file) {
                                         WM_FreePatches();
                                         free(config_dir);
                                         free(line_tokens);
-                                        free(config_buffer);
+                                        _WM_FreeBufferFile(config_buffer);
                                         return (-1);
                                     }
                                     tmp_patch = tmp_patch->next;
@@ -639,7 +639,7 @@ static int WM_LoadConfig(const char *config_file) {
                             WM_FreePatches();
                             free(config_dir);
                             free(line_tokens);
-                            free(config_buffer);
+                            _WM_FreeBufferFile(config_buffer);
                             return (-1);
                         } else if (!IS_ABSOLUTE_PATH(line_tokens[1]) && config_dir) {
                             tmp_patch->filename = malloc(strlen(config_dir) + strlen(line_tokens[1]) + 5);
@@ -648,7 +648,7 @@ static int WM_LoadConfig(const char *config_file) {
                                 WM_FreePatches();
                                 free(config_dir);
                                 free(line_tokens);
-                                free(config_buffer);
+                                _WM_FreeBufferFile(config_buffer);
                                 return (-1);
                             }
                             strcpy(tmp_patch->filename, config_dir);
@@ -659,7 +659,7 @@ static int WM_LoadConfig(const char *config_file) {
                                 WM_FreePatches();
                                 free(config_dir);
                                 free(line_tokens);
-                                free(config_buffer);
+                                _WM_FreeBufferFile(config_buffer);
                                 return (-1);
                             }
                         }
@@ -745,7 +745,7 @@ static int WM_LoadConfig(const char *config_file) {
                 else if (_WM_Global_ErrorI) { /* malloc() failure in WM_LC_Tokenize_Line() */
                     WM_FreePatches();
                     free(line_tokens);
-                    free(config_buffer);
+                    _WM_FreeBufferFile(config_buffer);
                     return (-1);
                 }
                 /* free up tokens */
@@ -756,7 +756,7 @@ static int WM_LoadConfig(const char *config_file) {
         config_ptr++;
     }
 
-    free(config_buffer);
+    _WM_FreeBufferFile(config_buffer);
     free(config_dir);
 
     return (0);
@@ -1514,7 +1514,7 @@ WM_SYMBOL int WildMidi_ConvertToMidi (const char *file, uint8_t **out, uint32_t 
     }
 
     ret = WildMidi_ConvertBufferToMidi(buf, *size, out, size);
-    free(buf);
+    _WM_FreeBufferFile(buf);
     return ret;
 }
 
@@ -1569,22 +1569,36 @@ WM_SYMBOL int WildMidi_Init(const char *config_file, uint16_t rate, uint16_t mix
     }
 
     _WM_BufferFile = _WM_BufferFileImpl;
+    _WM_FreeBufferFile = _WM_FreeBufferFileImpl;
 
     return _WM_Init(config_file, rate, mixer_options);
 }
 
-WM_SYMBOL int WildMidi_InitVIO(_WM_VIO callback, const char *config_file, uint16_t rate, uint16_t mixer_options) {
+WM_SYMBOL int WildMidi_InitVIO(struct _WM_VIO * callbacks, const char *config_file, uint16_t rate, uint16_t mixer_options) {
     if (WM_Initialized) {
         _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_ALR_INIT, NULL, 0);
         return (-1);
     }
 
-    if (callback == NULL) {
+    if (callbacks == NULL) {
         _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_INVALID_ARG,
-            "(NULL callback pointer)", 0);
+            "(NULL callbacks pointer)", 0);
         return (-1);
     }
-    _WM_BufferFile = callback;
+
+    if (callbacks->allocate_file == NULL) {
+        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_INVALID_ARG,
+            "(NULL allocate callback pointer)", 0);
+        return (-1);
+    }
+
+    if (callbacks->free_file == NULL) {
+        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_INVALID_ARG,
+            "(NULL allocate callback pointer)", 0);
+        return (-1);
+    }
+    _WM_BufferFile = callbacks->allocate_file;
+    _WM_FreeBufferFile = callbacks->free_file;
 
     return _WM_Init(config_file, rate, mixer_options);
 }
@@ -1680,7 +1694,7 @@ WM_SYMBOL midi *WildMidi_Open(const char *midifile) {
     } else {
         ret = (void *) _WM_ParseNewMidi(mididata, midisize);
     }
-    free(mididata);
+    _WM_FreeBufferFile(mididata);
 
     if (ret) {
         if (add_handle(ret) != 0) {


### PR DESCRIPTION
Hello, 
I hope  a unrequested pull request is welcome on this repo? (And sorry if my english sounds unpolite, i'm non native, and it is definitly not meant so!)

**Why?**

This library is used in the linux version of the game engine [EasyRPG ](https://easyrpg.org/). 
There im currently trying to abstract all filesystem accesses, in order to load all files used from a compressed file. (EasyRPG/Player#1085)

Other used libraries like libmpg123 allow to override their file accesses by user defined functions.

It would be very helpful if wildmidi has this possibility too, in order to pack a game with pats files and wildmidi.cfg inside a zip file, and play it for example on android.

**How?**

As you already abstracted you filesystem accesses, i just added a Wildmidi_InitVIO function which allows the user to supply a custom file read function.

Internally i replaced _WM_BufferFile in file_io.c through a Function pointer which per default points to the current implementation. But if the user Inits with Wildmidi_InitVIO, the function overrides the pointer by the one supplied.

LG Christian Breitwieser

CI-Status:

AppVeyor Build:
[![Build status](https://ci.appveyor.com/api/projects/status/oq09wagj5lveabah?svg=true)](https://ci.appveyor.com/project/ChristianBreitwieser/wildmidi)

Travis Build: (Hangs on two of five builds, because some xcode image is no longer supported.)
[![Build Status](https://travis-ci.org/ChristianBreitwieser/wildmidi.svg?branch=master)](https://travis-ci.org/ChristianBreitwieser/wildmidi)