### PR TITLE
Add support for use in Nintendo Wii homebrew (devkitPPC)

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Requirements:
 * DOS port: DJGPP / GNU make
 * OS/2 port: OpenWatcom (tested with version 1.9)
 * Nintendo 3DS port: devkitARM
+* Nintendo Wii port: devkitPPC
 
 CHANGELOG
 
@@ -40,6 +41,7 @@ CHANGELOG
 * File i/o updates.
 * Support for OS/2.
 * Support for Nintendo 3DS
+* Support for Nintendo Wii
 * Support for AmigaOS and its variants like MorphOS and AROS.
 * Fixed a nasty bug in dBm_pan_volume. Other fixes and clean-ups.
 

--- a/src/file_io.c
+++ b/src/file_io.c
@@ -127,7 +127,7 @@ void *_WM_BufferFile(const char *filename, uint32_t *size) {
 #elif defined(WILDMIDI_AMIGA)
     BPTR buffer_fd;
     long filsize;
-#elif defined(_3DS)
+#elif defined(_3DS) || defined(GEKKO)
     int buffer_fd;
     struct stat buffer_stat;
 #else /* unix builds */


### PR DESCRIPTION
Exactly same problem as in devkitARM: getuid missing

We use wildmidi since ca. half a year in the EasyRPG Player port for Wii, just havn't upstreamed the patch yet.
Your code works on big endian 👍 

Should in theory also work on the WiiU, but nobody cares about WiiU homebrew.