### PR TITLE
Windows: Replace FindFirstFile with GetFileAttributesExA and fix UNICODE builds

### DIFF
--- a/src/file_io.c
+++ b/src/file_io.c
@@ -117,8 +117,7 @@ void *_WM_BufferFile(const char *filename, uint32_t *size) {
     struct ffblk f;
 #elif defined(_WIN32)
     int buffer_fd;
-    HANDLE h;
-    WIN32_FIND_DATA wfd;
+    WIN32_FILE_ATTRIBUTE_DATA wfd;
 #elif defined(__OS2__) || defined(__EMX__)
     int buffer_fd;
     HDIR h = HDIR_CREATE;
@@ -186,12 +185,11 @@ void *_WM_BufferFile(const char *filename, uint32_t *size) {
     }
     *size = f.ff_fsize;
 #elif defined(_WIN32)
-    if ((h = FindFirstFile(buffer_file, &wfd)) == INVALID_HANDLE_VALUE) {
+    if (!GetFileAttributesExA(buffer_file, GetFileExInfoStandard, &wfd)) {
         _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_STAT, filename, ENOENT);
         free(buffer_file);
         return NULL;
     }
-    FindClose(h);
     if (wfd.nFileSizeHigh != 0) /* too big */
         *size = 0xffffffff;
     else *size = wfd.nFileSizeLow;


### PR DESCRIPTION
Replaced FindFirstFile with FileAttributesEx because the API is more suitable for quering information.


When WildMidi is compiled with UNICODE defined the WinApi functions expect UTF16 strings and FindFirstFile fails. I explictly use the A (ANSI) Api to mitigate this. (this matches the remaining functions like "open" a few lines later.

Only limitation is that wildmidi.cfg can't be in a path that has special characters outside of the current "local codepage" (see MSDN). Don't think it makes sense to make the API Unicode aware, who would put wildmidi in C:\日本\йцук\wildmidi.cfg.


