### PR TITLE
Add Switch and Vita support (Homebrew)

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ Requirements:
 * OS/2 port: OpenWatcom (tested with version 1.9)
 * Nintendo 3DS port: devkitARM
 * Nintendo Wii port: devkitPPC
+* Nintendo Switch port: devkitA64
+* PSVita port: Vitasdk
 
 CHANGELOG
 
@@ -40,6 +42,8 @@ CHANGELOG
 * Fixed a thinko in one of the buffer size checks added in v0.4.2.
 * Fix possible out of bounds reads in sysex commands. (Bug #190).
 * Fix invalid reads during config parse with short patch file names.
+* Support for Nintendo Switch
+* Support for PS Vita
 
 0.4.2
 * Fixed CVE-2017-11661, CVE-2017-11662, CVE-2017-11663, CVE-2017-11664

--- a/src/file_io.c
+++ b/src/file_io.c
@@ -127,7 +127,7 @@ void *_WM_BufferFile(const char *filename, uint32_t *size) {
 #elif defined(WILDMIDI_AMIGA)
     BPTR buffer_fd;
     long filsize;
-#elif defined(_3DS) || defined(GEKKO)
+#elif defined(_3DS) || defined(GEKKO) || defined(__vita__) || defined(__SWITCH__)
     int buffer_fd;
     struct stat buffer_stat;
 #else /* unix builds */

--- a/src/lock.c
+++ b/src/lock.c
@@ -33,6 +33,10 @@
 #include <os2.h>
 #elif defined(WILDMIDI_AMIGA)
 #include <proto/dos.h>
+#elif defined(__vita__)
+#include <psp2/kernel/processmgr.h>
+#elif defined(__SWITCH__)
+#include <switch.h>
 #else /* unixish ... */
 #define _GNU_SOURCE
 #include <unistd.h> /* usleep() */
@@ -70,6 +74,10 @@ void _WM_Lock(int * wmlock) {
     DosSleep(10);
 #elif defined(WILDMIDI_AMIGA)
     Delay(1);
+#elif defined(__vita__)
+    sceKernelDelayThread(500);
+#elif defined(__SWITCH__)
+    svcSleepThread(500 * 1000);
 #else
     usleep(500);
 #endif


### PR DESCRIPTION
Same story as for my older 3DS and Wii PRs: Just upstreaming a patch we use since a while.

Exactly same problem as everywhere: getuid missing (and usleep)
