### PR TITLE
fix integer overflow in midi parser sample count calculation (bug #200)

### DIFF
--- a/src/f_xmidi.c
+++ b/src/f_xmidi.c
@@ -228,6 +228,14 @@ struct _mdi *_WM_ParseNewXmi(uint8_t *xmi_data, uint32_t xmi_size) {
                                 xmi_tmpdata = xmi_delta;
                             }
 
+                            if ((float)xmi_tmpdata >= 0x7fffffff / xmi_samples_per_delta_f) {
+                                //DEBUG
+                                //fprintf(stderr,"INTEGER OVERFLOW (samples_per_delta: %f, smallest_delta: %u)\n",
+                                //        xmi_samples_per_delta_f, xmi_tmpdata);
+                                _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_CORUPT, NULL, 0);
+                                goto _xmi_end;
+                            }
+
                             xmi_sample_count_f= (((float) xmi_tmpdata * xmi_samples_per_delta_f) + xmi_sample_remainder);
 
                             xmi_sample_count = (uint32_t) xmi_sample_count_f;


### PR DESCRIPTION
This fixes the 'impossibly long duration with crafted midi file' issue
as reported in bug #200.  Midi file to test:
https://github.com/SegfaultMasters/covering360/raw/master/wildmidi/1_hang_main_00

Notes:

- About arbitrary upper bounds for unacceptable delta (as noted in #200):
  I changed the smallest_delta initializer from 0xffffffff to 0x7fffffff
  i.e. I decided to use INT32_MAX instead of UINT32_MAX as a reasonable
  upper bound. Rest of the integer overflow checks rely on multiplication
  errors against INT32_MAX.

- Overflow location was discovered when playing with clang's undefined
  behavior sanitizer.

- This does not do anything about the issue reported at bug #176.

Comments?  @chrisisonwildcode, what do you say?

Please review thoroughly.  I'm willing to revise according to critisisms.
