### PR TITLE
Clamp MUS volume commands

### DIFF
--- a/src/f_mus.c
+++ b/src/f_mus.c
@@ -163,6 +163,9 @@ _WM_ParseNewMus(uint8_t *mus_data, uint32_t mus_size) {
                     mus_event[0] = 0x90 | (mus_data[mus_data_ofs] & 0x0f);
                     mus_event[1] = mus_data[mus_data_ofs + 1] & 0x7f;
                     mus_event[2] = mus_data[mus_data_ofs + 2];
+                    // The maximum volume is 127, but it is encoded as a byte. Some songs
+                    // erroneously use values higher than 127, so we have to clamp them down.
+                    // https://github.com/Mindwerks/wildmidi/pull/226
                     if (mus_event[2] > 0x7f) mus_event[2] = 0x7f;
                     mus_event[3] = 0;
                     mus_prev_vol[mus_data[mus_data_ofs] & 0x0f] = mus_event[2];
@@ -260,6 +263,9 @@ _WM_ParseNewMus(uint8_t *mus_data, uint32_t mus_size) {
                         mus_event[0] = 0xb0 | (mus_data[mus_data_ofs] & 0x0f);
                         mus_event[1] = 7;
                         mus_event[2] = mus_data[mus_data_ofs + 2];
+                        // The maximum volume is 127, but it is encoded as a byte. Some songs
+                        // erroneously use values higher than 127, so we have to clamp them down.
+                        // https://github.com/Mindwerks/wildmidi/pull/226
                         if (mus_event[2] > 0x7f) mus_event[2] = 0x7f;
                         mus_event[3] = 0;
                         break;

--- a/src/f_mus.c
+++ b/src/f_mus.c
@@ -163,6 +163,7 @@ _WM_ParseNewMus(uint8_t *mus_data, uint32_t mus_size) {
                     mus_event[0] = 0x90 | (mus_data[mus_data_ofs] & 0x0f);
                     mus_event[1] = mus_data[mus_data_ofs + 1] & 0x7f;
                     mus_event[2] = mus_data[mus_data_ofs + 2];
+                    if (mus_event[2] > 0x7f) mus_event[2] = 0x7f;
                     mus_event[3] = 0;
                     mus_prev_vol[mus_data[mus_data_ofs] & 0x0f] = mus_event[2];
                 } else {
@@ -259,6 +260,7 @@ _WM_ParseNewMus(uint8_t *mus_data, uint32_t mus_size) {
                         mus_event[0] = 0xb0 | (mus_data[mus_data_ofs] & 0x0f);
                         mus_event[1] = 7;
                         mus_event[2] = mus_data[mus_data_ofs + 2];
+                        if (mus_event[2] > 0x7f) mus_event[2] = 0x7f;
                         mus_event[3] = 0;
                         break;
                     case 4: // Pan

--- a/src/mus2mid.c
+++ b/src/mus2mid.c
@@ -353,6 +353,9 @@ int _WM_mus2midi(const uint8_t *in, uint32_t insize,
                 bit1 = *cur & 127;
                 if (*cur++ & 128) {   /* volume bit? */
                     channel_volume[channelMap[channel]] = *cur++;
+                    /* The maximum volume is 127, but it is encoded as a byte. Some songs
+                       erroneously use values higher than 127, so we have to clamp them down.
+                       https://github.com/Mindwerks/wildmidi/pull/226 */
                     if (channel_volume[channelMap[channel]] > 127) channel_volume[channelMap[channel]] = 127;
                 }
                 bit2 = channel_volume[channelMap[channel]];
@@ -388,6 +391,9 @@ int _WM_mus2midi(const uint8_t *in, uint32_t insize,
                     }
                     bit1 = midimap[*cur++];
                     bit2 = *cur++;
+                    /* The maximum volume is 127, but it is encoded as a byte. Some songs
+                       erroneously use values higher than 127, so we have to clamp them down.
+                       https://github.com/Mindwerks/wildmidi/pull/226 */
                     if (bit1 == 0x07 && bit2 > 127) bit2 = 127;
                 }
                 break;

--- a/src/mus2mid.c
+++ b/src/mus2mid.c
@@ -351,8 +351,10 @@ int _WM_mus2midi(const uint8_t *in, uint32_t insize,
             case MUSEVENT_KEYON:
                 status |= 0x90;
                 bit1 = *cur & 127;
-                if (*cur++ & 128)   /* volume bit? */
+                if (*cur++ & 128) {   /* volume bit? */
                     channel_volume[channelMap[channel]] = *cur++;
+                    if (channel_volume[channelMap[channel]] > 127) channel_volume[channelMap[channel]] = 127;
+                }
                 bit2 = channel_volume[channelMap[channel]];
                 break;
             case MUSEVENT_PITCHWHEEL:
@@ -386,6 +388,7 @@ int _WM_mus2midi(const uint8_t *in, uint32_t insize,
                     }
                     bit1 = midimap[*cur++];
                     bit2 = *cur++;
+                    if (bit1 == 0x07 && bit2 > 127) bit2 = 127;
                 }
                 break;
             case MUSEVENT_END:  /* End */


### PR DESCRIPTION
As documented [here](https://doomwiki.org/wiki/MUS), the MUS format allows for values above 127 to be present in files. Supposedly, the original DMX library would clamp them back down to 127. Without this behaviour, the song "Smells like Burning Corpse" from Final Doom has extremely loud instruments.