### PR TITLE
AMIGAOS4: Fix compiler error with Seek()

### DIFF
--- a/src/wildmidi.c
+++ b/src/wildmidi.c
@@ -100,6 +100,7 @@ extern int amiga_getch (unsigned char *ch);
 #ifdef AUDIODRV_AHI
 #include <devices/ahi.h>
 #ifdef __amigaos4__
+#include <dos/obsolete.h>
 #define SHAREDMEMFLAG MEMF_SHARED
 #else
 #define SHAREDMEMFLAG MEMF_PUBLIC


### PR DESCRIPTION
Seek() is a dos.library function and deprecated in favour of ChangeFilePosition().

In the latest SDK the obsolete status has been forced by changing the name to OBSOLETESeek().

A proper fix would be to rewrite to use the fseek()/lseek() pair or aforementioned ChangeFilePosition().

A quick workaround is to
#include <dos/obsolete.h>
into
#ifdef __amigaos4__
to compile a working binary again.

Which it does and which I propose.

Thank you