### PR TITLE
Cleanup OSS header handling

### DIFF
--- a/android/jni/config.h
+++ b/android/jni/config.h
@@ -62,10 +62,7 @@
 #define HAVE_INTTYPES_H
 
 /* Define our audio drivers */
-/* #undef HAVE_LINUX_SOUNDCARD_H */
 /* #undef HAVE_SYS_SOUNDCARD_H */
-/* #undef HAVE_MACHINE_SOUNDCARD_H */
-/* #undef HAVE_SOUNDCARD_H */
 
 /* #undef AUDIODRV_ALSA */
 /* #undef AUDIODRV_OSS */

--- a/cmake/FindOSS.cmake
+++ b/cmake/FindOSS.cmake
@@ -14,14 +14,11 @@ SET(OSS_FOUND)
 
 MESSAGE(STATUS "Looking for OSS...")
 
-#CHECK_INCLUDE_FILES(linux/soundcard.h HAVE_LINUX_SOUNDCARD_H) # Linux does provide <sys/soundcard.h>
 CHECK_INCLUDE_FILES(sys/soundcard.h HAVE_SYS_SOUNDCARD_H)
-CHECK_INCLUDE_FILES(machine/soundcard.h HAVE_MACHINE_SOUNDCARD_H)
-CHECK_INCLUDE_FILES(soundcard.h HAVE_SOUNDCARD_H) # less common, but exists.
 
-# NetBSD and OpenBSD uses ossaudio emulation layer,
+# NetBSD uses ossaudio emulation layer,
 # otherwise no link library is needed.
-IF(CMAKE_SYSTEM_NAME MATCHES "kNetBSD.*|NetBSD.*|kOpenBSD.*|OpenBSD.*")  # AND HAVE_SOUNDCARD_H ???
+IF(CMAKE_SYSTEM_NAME MATCHES "kNetBSD.*|NetBSD.*")  # AND HAVE_SOUNDCARD_H ???
   FIND_LIBRARY(OSSAUDIO_LIBRARIES "ossaudio")
   IF(OSSAUDIO_LIBRARIES STREQUAL "OSSAUDIO_LIBRARIES-NOTFOUND")
     SET(OSSAUDIO_LIBRARIES)
@@ -41,14 +38,6 @@ ENDIF()
 IF(HAVE_SYS_SOUNDCARD_H)
     CHECK_C_SOURCE_COMPILES("#include <sys/ioctl.h>
                              #include <sys/soundcard.h>
-                             int main() {return SNDCTL_DSP_RESET;}" OSS_FOUND)
-ELSEIF(HAVE_MACHINE_SOUNDCARD_H)
-    CHECK_C_SOURCE_COMPILES("#include <sys/ioctl.h>
-                             #include <machine/soundcard.h>
-                             int main() {return SNDCTL_DSP_RESET;}" OSS_FOUND)
-ELSEIF(HAVE_SOUNDCARD_H)
-    CHECK_C_SOURCE_COMPILES("#include <sys/ioctl.h>
-                             #include <soundcard.h>
                              int main() {return SNDCTL_DSP_RESET;}" OSS_FOUND)
 ENDIF()
 

--- a/include/config.h.cmake
+++ b/include/config.h.cmake
@@ -62,10 +62,7 @@
 #cmakedefine HAVE_INTTYPES_H
 
 /* Define our audio drivers */
-#cmakedefine HAVE_LINUX_SOUNDCARD_H
 #cmakedefine HAVE_SYS_SOUNDCARD_H
-#cmakedefine HAVE_MACHINE_SOUNDCARD_H
-#cmakedefine HAVE_SOUNDCARD_H
 
 #cmakedefine AUDIODRV_ALSA
 #cmakedefine AUDIODRV_OSS

--- a/src/wildmidi.c
+++ b/src/wildmidi.c
@@ -119,13 +119,7 @@ static int msleep(unsigned long millisec);
 #ifdef AUDIODRV_ALSA
 #  include <alsa/asoundlib.h>
 #elif defined AUDIODRV_OSS
-#   if defined HAVE_SYS_SOUNDCARD_H
-#   include <sys/soundcard.h>
-#   elif defined HAVE_MACHINE_SOUNDCARD_H
-#   include <machine/soundcard.h>
-#   elif defined HAVE_SOUNDCARD_H
-#   include <soundcard.h> /* less common, but exists. */
-#   endif
+#  include <sys/soundcard.h>
 #elif defined AUDIODRV_OPENAL
 #   ifndef __APPLE__
 #   include <al.h>


### PR DESCRIPTION
Remove checking for soundcard.h, OpenBSD has not used OSS in ages.
machine/soundcard.h is for FreeBSD versions that are 18+ years old.
The check for linux/soundcard.h has been disabled as you're supposed
to use sys/soundcard.h anyway.