### PR TITLE
A bugfix, some const-ifying, and some portability improvements

### DIFF
--- a/amiga/vbcc_aos3.cfg
+++ b/amiga/vbcc_aos3.cfg
@@ -4,5 +4,3 @@ LDFLAGS+= -lm881
 CFLAGS += -cpu=68020 -fpu=68881
 CFLAGS += -D__AMIGA__
 CFLAGS += -DWORDS_BIGENDIAN=1
-# bullshit -- until the code is adjusted
-CFLAGS += -D__FUNCTION__=__func__

--- a/include/f_hmi.h
+++ b/include/f_hmi.h
@@ -24,6 +24,6 @@
 #ifndef __HMI_H
 #define __HMI_H
 
-extern struct _mdi *_WM_ParseNewHmi(uint8_t *hmi_data, uint32_t hmi_size);
+extern struct _mdi *_WM_ParseNewHmi(const uint8_t *hmi_data, uint32_t hmi_size);
 
 #endif /* __HMI_H */

--- a/include/f_hmp.h
+++ b/include/f_hmp.h
@@ -24,6 +24,6 @@
 #ifndef __HMP_H
 #define __HMP_H
 
-extern struct _mdi *_WM_ParseNewHmp(uint8_t *hmp_data, uint32_t hmp_size);
+extern struct _mdi *_WM_ParseNewHmp(const uint8_t *hmp_data, uint32_t hmp_size);
 
 #endif /* __HMP_H */

--- a/include/f_midi.h
+++ b/include/f_midi.h
@@ -24,7 +24,7 @@
 #ifndef __MIDI_H
 #define __MIDI_H
 
-extern struct _mdi *_WM_ParseNewMidi(uint8_t *midi_data, uint32_t midi_size);
+extern struct _mdi *_WM_ParseNewMidi(const uint8_t *midi_data, uint32_t midi_size);
 extern int _WM_Event2Midi(struct _mdi *mdi, uint8_t **out, uint32_t *outsize);
 
 #endif /* __MIDI_H */

--- a/include/f_mus.h
+++ b/include/f_mus.h
@@ -24,6 +24,6 @@
 #ifndef __MUS_WM_H
 #define __MUS_WM_H
 
-extern struct _mdi *_WM_ParseNewMus(uint8_t *mus_data, uint32_t mus_size);
+extern struct _mdi *_WM_ParseNewMus(const uint8_t *mus_data, uint32_t mus_size);
 
 #endif /* __MUS_WM_H */

--- a/include/f_xmidi.h
+++ b/include/f_xmidi.h
@@ -24,6 +24,6 @@
 #ifndef __XMI_H
 #define __XMI_H
 
-extern struct _mdi *_WM_ParseNewXmi(uint8_t *xmi_data, uint32_t xmi_size);
+extern struct _mdi *_WM_ParseNewXmi(const uint8_t *xmi_data, uint32_t xmi_size);
 
 #endif /* __XMI_H */

--- a/include/internal_midi.h
+++ b/include/internal_midi.h
@@ -240,7 +240,7 @@ extern int _WM_midi_setup_divisions(struct _mdi *mdi, uint32_t divisions);
 
 extern struct _mdi * _WM_initMDI(void);
 extern void _WM_freeMDI(struct _mdi *mdi);
-extern uint32_t _WM_SetupMidiEvent(struct _mdi *mdi, uint8_t *event_data, uint32_t inlen, uint8_t running_event);
+extern uint32_t _WM_SetupMidiEvent(struct _mdi *mdi, const uint8_t *event_data, uint32_t inlen, uint8_t running_event);
 extern void _WM_ResetToStart(struct _mdi *mdi);
 extern void _WM_do_pan_adjust(struct _mdi *mdi, uint8_t ch);
 extern void _WM_do_note_off_extra(struct _note *nte);

--- a/include/wildmidi_lib.h
+++ b/include/wildmidi_lib.h
@@ -125,7 +125,7 @@ WM_SYMBOL int WildMidi_Init (const char *config_file, uint16_t rate, uint16_t mi
 WM_SYMBOL int WildMidi_InitVIO(struct _WM_VIO * callbacks, const char *config_file, uint16_t rate, uint16_t mixer_options);
 WM_SYMBOL int WildMidi_MasterVolume (uint8_t master_volume);
 WM_SYMBOL midi * WildMidi_Open (const char *midifile);
-WM_SYMBOL midi * WildMidi_OpenBuffer (uint8_t *midibuffer, uint32_t size);
+WM_SYMBOL midi * WildMidi_OpenBuffer (const uint8_t *midibuffer, uint32_t size);
 WM_SYMBOL int WildMidi_GetMidiOutput (midi *handle, int8_t **buffer, uint32_t *size);
 WM_SYMBOL int WildMidi_GetOutput (midi *handle, int8_t *buffer, uint32_t size);
 WM_SYMBOL int WildMidi_SetOption (midi *handle, uint16_t options, uint16_t setting);

--- a/include/wildmidi_lib.h
+++ b/include/wildmidi_lib.h
@@ -131,7 +131,7 @@ WM_SYMBOL int WildMidi_GetOutput (midi *handle, int8_t *buffer, uint32_t size);
 WM_SYMBOL int WildMidi_SetOption (midi *handle, uint16_t options, uint16_t setting);
 WM_SYMBOL int WildMidi_SetCvtOption (uint16_t tag, uint16_t setting);
 WM_SYMBOL int WildMidi_ConvertToMidi (const char *file, uint8_t **out, uint32_t *size);
-WM_SYMBOL int WildMidi_ConvertBufferToMidi (uint8_t *in, uint32_t insize,
+WM_SYMBOL int WildMidi_ConvertBufferToMidi (const uint8_t *in, uint32_t insize,
                                             uint8_t **out, uint32_t *size);
 WM_SYMBOL struct _WM_Info * WildMidi_GetInfo (midi * handle);
 WM_SYMBOL int WildMidi_FastSeek (midi * handle, unsigned long int *sample_pos);

--- a/include/wm_error.h
+++ b/include/wm_error.h
@@ -50,7 +50,7 @@ enum {
 extern char * _WM_Global_ErrorS;
 extern int _WM_Global_ErrorI;
 
-#define _WM_GLOBAL_ERROR(wmerno, wmfor, error) _WM_GLOBAL_ERROR_INTERNAL(__FUNCTION__, __LINE__, wmerno, wmfor, error)
+#define _WM_GLOBAL_ERROR(wmerno, wmfor, error) _WM_GLOBAL_ERROR_INTERNAL(__func__, __LINE__, wmerno, wmfor, error)
 extern void _WM_GLOBAL_ERROR_INTERNAL(const char *func, int lne, int wmerno, const char * wmfor, int error);
 
 /* sets the global error string to a custom msg */

--- a/include/wm_error.h
+++ b/include/wm_error.h
@@ -50,7 +50,7 @@ enum {
 extern char * _WM_Global_ErrorS;
 extern int _WM_Global_ErrorI;
 
-#define _WM_GLOBAL_ERROR(wmerno, wmfor, error) _WM_GLOBAL_ERROR_INTERNAL(__func__, __LINE__, wmerno, wmfor, error)
+#define _WM_GLOBAL_ERROR(wmerno, wmfor, error) _WM_GLOBAL_ERROR_INTERNAL(__FILE__, __LINE__, wmerno, wmfor, error)
 extern void _WM_GLOBAL_ERROR_INTERNAL(const char *func, int lne, int wmerno, const char * wmfor, int error);
 
 /* sets the global error string to a custom msg */

--- a/include/wm_error.h
+++ b/include/wm_error.h
@@ -50,7 +50,8 @@ enum {
 extern char * _WM_Global_ErrorS;
 extern int _WM_Global_ErrorI;
 
-extern void _WM_GLOBAL_ERROR(const char *func, int lne, int wmerno, const char * wmfor, int error);
+#define _WM_GLOBAL_ERROR(wmerno, wmfor, error) _WM_GLOBAL_ERROR_INTERNAL(__FUNCTION__, __LINE__, wmerno, wmfor, error)
+extern void _WM_GLOBAL_ERROR_INTERNAL(const char *func, int lne, int wmerno, const char * wmfor, int error);
 
 /* sets the global error string to a custom msg */
 extern void _WM_ERROR_NEW(const char * wmfmt, ...)

--- a/src/DevTest.c
+++ b/src/DevTest.c
@@ -267,7 +267,7 @@ static int check_midi_event (unsigned char *midi_data, unsigned long int midi_si
             printf("Expected MIDI event\n");
             return -1;
         }
-//      printf("Unsing running event 0x%2x\n", running_event);
+/*      printf("Unsing running event 0x%2x\n", running_event); */
     } else {
         event = *midi_data++;
         midi_size--;
@@ -523,7 +523,7 @@ static int check_midi_event (unsigned char *midi_data, unsigned long int midi_si
                 sysex_store = NULL;
                 rtn_cnt += sysex_size;
             } else if ((event <= 0xFE) && (event >= 0xF1)) {
-                // Added just in case
+                /* Added just in case */
                 printf("Realtime Event: 0x%.2x ** NOTE: Not expected in midi file type data\n",event);
             } else if (event == 0xFF) {
                 /*
@@ -701,7 +701,7 @@ static int check_midi_event (unsigned char *midi_data, unsigned long int midi_si
             }
             break;
     }
-//  printf("Return Count: %i\n", rtn_cnt);
+/*  printf("Return Count: %i\n", rtn_cnt); */
     return rtn_cnt;
 }
 
@@ -752,8 +752,8 @@ static int8_t test_mus(unsigned char * mus_data, unsigned long mus_size, uint32_
     uint32_t mus_data_ofs = 0;
     uint32_t mus_song_ofs = 0;
     uint32_t mus_song_len = 0;
-//  uint16_t mus_ch_cnt1 = 0;
-//  uint16_t mus_ch_cnt2 = 0;
+/*  uint16_t mus_ch_cnt1 = 0; */
+/*  uint16_t mus_ch_cnt2 = 0; */
     uint16_t mus_no_instr = 0;
     uint16_t mus_instr_cnt = 0;
     uint8_t mus_event_size = 0;
@@ -761,37 +761,37 @@ static int8_t test_mus(unsigned char * mus_data, unsigned long mus_size, uint32_
     uint8_t mus_prev_vol[] = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
     uint32_t mus_ticks = 0;
 
-    // Check that we have enough data to check the header
+    /* Check that we have enough data to check the header */
     if (mus_size < 17) {
         printf("Not a valid MUS file: File too short\n");
         return -1;
     }
 
-    // Check Header
+    /* Check Header */
     if (strncmp((char *) mus_data, (char *) mus_hdr, 4) != 0) {
         printf("Not a valid MUS file: expected MUS followed by 0x1A\n");
         return -1;
     }
 
-    // Get Song Length
+    /* Get Song Length */
     mus_song_len = (mus_data[5] << 8) | mus_data[4];
-    // Get Song Offset
+    /* Get Song Offset */
     mus_song_ofs = (mus_data[7] << 8) | mus_data[6];
 
     if (verbose) printf("Song Offset: %i, Length: %i\n", mus_song_ofs, mus_song_len);
 
-    // Have yet to determine what this actually is.
-    // mus_ch_cnt1 = (mus_data[9] << 8) | mus_data[8];
-    // mus_ch_cnt2 = (mus_data[11] << 8) | mus_data[10];
+    /* Have yet to determine what this actually is. */
+    /* mus_ch_cnt1 = (mus_data[9] << 8) | mus_data[8]; */
+    /* mus_ch_cnt2 = (mus_data[11] << 8) | mus_data[10]; */
 
-    // Number of instruments defined
+    /* Number of instruments defined */
     mus_no_instr = (mus_data[13] << 8) | mus_data[12];
     if (verbose) printf("Number of Instruments: %i\n", mus_no_instr);
 
-    // Skip next 2 data bytes
+    /* Skip next 2 data bytes */
     mus_data_ofs = 16;
 
-    // Check that we have enough data to check the rest
+    /* Check that we have enough data to check the rest */
     if (mus_size < (mus_data_ofs + (mus_no_instr << 1) + mus_song_len)) {
         printf("Not a valid MUS file: File too short\n");
         return -1;
@@ -805,28 +805,28 @@ static int8_t test_mus(unsigned char * mus_data, unsigned long mus_size, uint32_
         } while (mus_instr_cnt != mus_no_instr);
     }
 
-    // make sure we are at song offset
+    /* make sure we are at song offset */
     mus_data_ofs = mus_song_ofs;
 
     if (verbose) {
-        // Setup secs_per_tick
+        /* Setup secs_per_tick */
         if (frequency == 0.0) frequency = 140.0;
         set_secs_per_tick (60, (uint32_t)(60000000.0f / frequency));
         add_and_display_time(0);
     }
 
     do {
-        // Read Event
+        /* Read Event */
     _WM_READ_MUS_EVENT:
         if (verbose) {
             display_time();
         }
         switch ((mus_data[mus_data_ofs] >> 4) & 0x07) {
-            case 0: // note off
+            case 0: /* note off */
                 mus_event_size = 2;
                 if (verbose) printf("Note Off 0x%.2x\n", mus_data[mus_data_ofs + 1]);
                 break;
-            case 1: // note on
+            case 1: /* note on */
                 if (mus_data[mus_data_ofs + 1] & 0x80) {
                     mus_event_size = 3;
                     if (verbose) printf("Note On (0x%.2x): 0x%.2x\n", (mus_data[mus_data_ofs + 1] & 0x7f), mus_data[mus_data_ofs + 2]);
@@ -836,11 +836,11 @@ static int8_t test_mus(unsigned char * mus_data, unsigned long mus_size, uint32_
                     if (verbose) printf("Note On (0x%.2x): [0x%.2x]\n", mus_data[mus_data_ofs + 1], mus_prev_vol[mus_data[mus_data_ofs] & 0x0f]);
                 }
                 break;
-            case 2: // pitch bend
+            case 2: /* pitch bend */
                 mus_event_size = 2;
                 if (verbose) printf("Pitch Bend 0x%.2x\n", mus_data[mus_data_ofs + 1]);
                 break;
-            case 3: // system controller
+            case 3: /* system controller */
                 mus_event_size = 2;
                 if (verbose) {
                     printf("System Controller: ");
@@ -851,10 +851,10 @@ static int8_t test_mus(unsigned char * mus_data, unsigned long mus_size, uint32_
                         case 11:
                             printf("All Notes Off\n");
                             break;
-                        case 12: // Not supported by WildMidi. Parsed for compatability
+                        case 12: /* Not supported by WildMidi. Parsed for compatability */
                             printf("Mono\n");
                             break;
-                        case 13:  // Not supported by WildMidi. Parsed for compatability
+                        case 13:  /* Not supported by WildMidi. Parsed for compatability */
                             printf("Poly\n");
                             break;
                         case 14:
@@ -865,7 +865,7 @@ static int8_t test_mus(unsigned char * mus_data, unsigned long mus_size, uint32_
                     }
                 }
                 break;
-            case 4: // controller
+            case 4: /* controller */
                 mus_event_size = 3;
                 if (verbose) {
                     printf("Controller: ");
@@ -905,22 +905,22 @@ static int8_t test_mus(unsigned char * mus_data, unsigned long mus_size, uint32_
                     }
                 }
                 break;
-            case 5: // ??
+            case 5: /* ?? */
                 mus_event_size = 1;
                 if (verbose) printf("0x%.2x\n", mus_data[mus_data_ofs]);
                 break;
-            case 6: // End Of Song
-                //mus_event_size = 1;
+            case 6: /* End Of Song */
+                /* mus_event_size = 1; */
                 if (verbose) printf("End Of Song\n");
                 goto _WM_MUS_EOS;
                 break;
-            case 7: // ??
+            case 7: /* ?? */
                 mus_event_size = 1;
                 if (verbose) printf("0x%.2x\n", mus_data[mus_data_ofs]);
                 break;
         }
 #if 0
-        // DEBUG
+        /* DEBUG */
         if (verbose)
         {
             uint8_t i = 0;
@@ -936,7 +936,7 @@ static int8_t test_mus(unsigned char * mus_data, unsigned long mus_size, uint32_
         }
         mus_data_ofs += mus_event_size;
 
-        // Read Time (140 ticks per minute)
+        /* Read Time (140 ticks per minute) */
         mus_ticks = 0;
         do {
             mus_ticks = (mus_ticks << 7) | (mus_data[mus_data_ofs] & 0x7f);
@@ -947,14 +947,14 @@ static int8_t test_mus(unsigned char * mus_data, unsigned long mus_size, uint32_
         }
     } while (mus_data_ofs < mus_size);
 
-    // Song End
+    /* Song End */
 _WM_MUS_EOS:
     return 0;
 }
 
 static int test_hmi(unsigned char * hmi_data, unsigned long int hmi_size, int verbose) {
     uint16_t hmi_division = 0;
-    //uint32_t hmi_duration_secs = 0;
+    /* uint32_t hmi_duration_secs = 0; */
     uint32_t hmi_track_cnt = 0;
     uint32_t i = 0;
     uint32_t *hmi_track_offset = NULL;
@@ -966,7 +966,7 @@ static int test_hmi(unsigned char * hmi_data, unsigned long int hmi_size, int ve
     uint32_t hmi_track_header_length = 0;
     uint32_t hmi_file_end = (uint32_t)hmi_size;
 
-    // Check header
+    /* Check header */
     if (strncmp((char *) hmi_data,"HMI-MIDISONG061595", 18) != 0) {
         printf("Not a valid HMI file: expected HMI-MIDISONG061595\n");
         return -1;
@@ -997,16 +997,16 @@ static int test_hmi(unsigned char * hmi_data, unsigned long int hmi_size, int ve
     hmi_size -= 141;
     hmi_dbg += 141;
 
-    hmi_track_offset[0] = *hmi_data; // To keep Xcode happy
+    hmi_track_offset[0] = *hmi_data; /* To keep Xcode happy */
 
     for (i = 0; i < hmi_track_cnt; i++) {
-//      printf("DEBUG @ %.8x\n",hmi_dbg);
+/*      printf("DEBUG @ %.8x\n",hmi_dbg); */
         hmi_track_offset[i] = *hmi_data++;
         hmi_track_offset[i] += (*hmi_data++ << 8);
         hmi_track_offset[i] += (*hmi_data++ << 16);
         hmi_track_offset[i] += (*hmi_data++ << 24);
         hmi_size -= 4;
-        //FIXME: These are absolute data offsets?
+        /* FIXME: These are absolute data offsets? */
         if (verbose) printf("Track %i offset: %.8x\n",i,hmi_track_offset[i]);
         hmi_dbg += 4;
     }
@@ -1044,7 +1044,7 @@ static int test_hmi(unsigned char * hmi_data, unsigned long int hmi_size, int ve
         } else {
             hmi_track_end = hmi_file_end;
         }
-//      printf("DEBUG: 0x%.8x\n",hmi_track_end);
+/*      printf("DEBUG: 0x%.8x\n",hmi_track_end); */
         if (verbose) {
             reset_time();
         }
@@ -1094,18 +1094,18 @@ static int test_hmi(unsigned char * hmi_data, unsigned long int hmi_size, int ve
                     return -1;
                 }
 
-                // Running event
-                // 0xff does not alter running event
+                /* Running event */
+                /* 0xff does not alter running event */
                 if ((*hmi_data == 0xF0) || (*hmi_data == 0xF7)) {
-                    // Sysex resets running event data
+                    /* Sysex resets running event data */
                     hmi_running_event = 0;
                 } else if (*hmi_data < 0xF0) {
-                    // MIDI events 0x80 to 0xEF set running event
+                    /* MIDI events 0x80 to 0xEF set running event */
                     if (*hmi_data >= 0x80) {
                         hmi_running_event = *hmi_data;
                     }
                 }
-            //  if (verbose) printf("Running Event: 0x%.2x\n",hmi_running_event);
+            /*  if (verbose) printf("Running Event: 0x%.2x\n",hmi_running_event); */
 
                 if ((hmi_data[0] == 0xff) && (hmi_data[1] == 0x2f) && (hmi_data[2] == 0x00)) {
                     hmi_data += check_ret;
@@ -1115,7 +1115,7 @@ static int test_hmi(unsigned char * hmi_data, unsigned long int hmi_size, int ve
                 }
 
                 if ((hmi_running_event & 0xf0) == 0x90) {
-                    // note on has extra data to specify how long the note is.
+                    /* note on has extra data to specify how long the note is. */
                     hmi_data += check_ret;
                     hmi_size -= check_ret;
                     hmi_dbg += check_ret;
@@ -1162,7 +1162,7 @@ static int test_hmp(unsigned char * hmp_data, unsigned long int hmp_size, int ve
     uint32_t hmp_var_len_val = 0;
     int32_t check_ret = 0;
 
-    // check the header
+    /* check the header */
     if (strncmp((char *) hmp_data,"HMIMIDIP", 8) != 0) {
         printf("Not a valid HMP file: expected HMIMIDIP\n");
         return -1;
@@ -1177,14 +1177,14 @@ static int test_hmp(unsigned char * hmp_data, unsigned long int hmp_size, int ve
         if (verbose) printf("HMPv2 format detected\n");
     }
 
-    // should be a bunch of \0's
+    /* should be a bunch of \0's */
     if (is_hmq) {
         zero_cnt = 18;
     } else {
         zero_cnt = 24;
     }
     for (i = 0; i < zero_cnt; i++) {
-//      printf("DEBUG (%.2x): %.2x\n",i, hmp_data[i]);
+/*      printf("DEBUG (%.2x): %.2x\n",i, hmp_data[i]); */
         if (hmp_data[i] != 0) {
             printf("Not a valid HMP file\n");
             return -1;
@@ -1198,7 +1198,7 @@ static int test_hmp(unsigned char * hmp_data, unsigned long int hmp_size, int ve
     hmp_file_length += (*hmp_data++ << 16);
     hmp_file_length += (*hmp_data++ << 24);
     if (verbose) printf("File length: %u\n", hmp_file_length);
-    // Next 12 bytes are normally \0 so skipping over them
+    /* Next 12 bytes are normally \0 so skipping over them */
     hmp_data += 12;
     hmp_size -= 16;
 
@@ -1207,7 +1207,7 @@ static int test_hmp(unsigned char * hmp_data, unsigned long int hmp_size, int ve
     hmp_chunks += (*hmp_data++ << 16);
     hmp_chunks += (*hmp_data++ << 24);
     if (verbose) printf("Number of chunks: %u\n", hmp_chunks);
-    // Unsure of what next 4 bytes are so skip over them
+    /* Unsure of what next 4 bytes are so skip over them */
     hmp_data += 4;
     hmp_size -= 8;
 
@@ -1261,13 +1261,13 @@ static int test_hmp(unsigned char * hmp_data, unsigned long int hmp_size, int ve
         hmp_size -= 4;
         if (verbose) printf("Track Number: %u\n", hmp_track);
 
-        // Start of Midi Data
+        /* Start of Midi Data */
 
-        // because chunk length includes chunk header
-        // remove header length from chunk length
+        /* because chunk length includes chunk header */
+        /* remove header length from chunk length */
         hmp_chunk_length -= 12;
 
-        // Start of Midi Data
+        /* Start of Midi Data */
         for (j = 0; j < hmp_chunk_length; j++) {
             uint32_t var_len_shift = 0;
             hmp_var_len_val = 0;
@@ -1289,7 +1289,7 @@ static int test_hmp(unsigned char * hmp_data, unsigned long int hmp_size, int ve
                 printf("Missing or Corrupt MIDI Data\n");
                 return -1;
             }
-            // Display loop start/end
+            /* Display loop start/end */
             if ((hmp_chunk_num == 1) && ((hmp_data[0] & 0xf0) == 0xb0)) {
                 if ((hmp_data[1] == 110) && (hmp_data[2] == 255) && (verbose)) printf("HMP Loop Start\n");
                 if ((hmp_data[1] == 111) && (hmp_data[2] == 128) && (verbose)) printf("HMP Loop End\n");
@@ -1327,7 +1327,7 @@ static int test_xmidi(unsigned char * xmidi_data, unsigned long int xmidi_size,
     xmidi_data += 4;
     xmidi_size -= 4;
 
-    // bytes until next entry
+    /* bytes until next entry */
     tmp_val = *xmidi_data++ << 24;
     tmp_val |= *xmidi_data++ << 16;
     tmp_val |= *xmidi_data++ << 8;
@@ -1348,7 +1348,7 @@ static int test_xmidi(unsigned char * xmidi_data, unsigned long int xmidi_size,
     xmidi_data += 4;
     xmidi_size -= 4;
 
-    // number of forms contained after this point
+    /* number of forms contained after this point */
     form_cnt = *xmidi_data++;
 
     if (verbose)
@@ -1369,7 +1369,7 @@ static int test_xmidi(unsigned char * xmidi_data, unsigned long int xmidi_size,
     xmidi_data += 4;
     xmidi_size -= 4;
 
-    // stored just in case it means something
+    /* stored just in case it means something */
     cat_len = *xmidi_data++ << 24;
     cat_len |= *xmidi_data++ << 16;
     cat_len |= *xmidi_data++ << 8;
@@ -1385,7 +1385,7 @@ static int test_xmidi(unsigned char * xmidi_data, unsigned long int xmidi_size,
     xmidi_data += 4;
     xmidi_size -= 4;
 
-    // Start of FORM data which contains the songs
+    /* Start of FORM data which contains the songs */
     for (i = 0; i < form_cnt; i++) {
         if (strncmp((char *) xmidi_data,"FORM", 4) != 0) {
             printf("Not a valid xmidi file: expected FORM\n");
@@ -1396,7 +1396,7 @@ static int test_xmidi(unsigned char * xmidi_data, unsigned long int xmidi_size,
         xmidi_data += 4;
         xmidi_size -= 4;
 
-        // stored just in case it means something
+        /* stored just in case it means something */
         subform_len = *xmidi_data++ << 24;
         subform_len |= *xmidi_data++ << 16;
         subform_len |= *xmidi_data++ << 8;
@@ -1465,8 +1465,8 @@ static int test_xmidi(unsigned char * xmidi_data, unsigned long int xmidi_size,
                 if (verbose)
                     printf("RBRN length: %u\n",event_len);
 
-                // TODO: still have to work out what this is.
-                // Does not seem to be needed for midi playback.
+                /* TODO: still have to work out what this is. */
+                /* Does not seem to be needed for midi playback. */
                 xmidi_data += event_len;
                 subform_len -= event_len;
 
@@ -1488,14 +1488,14 @@ static int test_xmidi(unsigned char * xmidi_data, unsigned long int xmidi_size,
 
                 do {
                     if (*xmidi_data < 0x80) {
-                        // Delta until next event?
+                        /* Delta until next event? */
                         tmp_val = 0;
                         tmp_val = (tmp_val << 7) | (*xmidi_data++ & 0x7F);
                         xmidi_size--;
                         event_len--;
                         subform_len--;
                         if (verbose) {
-                            // printf ("Intervals: %u\n", tmp_val);
+                            /* printf ("Intervals: %u\n", tmp_val); */
                             add_time(tmp_val);
                         }
 
@@ -1712,7 +1712,7 @@ static int test_midi(unsigned char * midi_data, unsigned long int midi_size,
             return -1;
         }
         
-        // Ignore EOT check for type 0
+        /* Ignore EOT check for type 0 */
         if (midi_type != 0) {
             if ((midi_data[track_size - 3] != 0xFF)
                     || (midi_data[track_size - 2] != 0x2F)
@@ -1725,10 +1725,10 @@ static int test_midi(unsigned char * midi_data, unsigned long int midi_size,
 
         while (midi_data < next_track) {
             delta = 0;
-//          printf("Get Delta: ");
+/*          printf("Get Delta: "); */
             while (*midi_data > 0x7F) {
                 delta = (delta << 7) | (*midi_data & 0x7F);
-//              printf("0x%.2x ",*midi_data);
+/*              printf("0x%.2x ",*midi_data); */
                 midi_data++;
                 midi_size--;
                 total_count++;
@@ -1780,7 +1780,7 @@ static int test_midi(unsigned char * midi_data, unsigned long int midi_size,
                 }
             }
 
-//          printf("Event Offset: 0x%.8x\n", total_count);
+/*          printf("Event Offset: 0x%.8x\n", total_count); */
             if ((check_ret = check_midi_event(midi_data, midi_size, running_event, verbose, 0)) == -1) {
                 printf("Missing or Corrupt MIDI Data 0x%.8x\n",total_count);
                 return -1;
@@ -1793,7 +1793,7 @@ static int test_midi(unsigned char * midi_data, unsigned long int midi_size,
                 /* MIDI events 0x80 to 0xEF set running event */
                 if (*midi_data >= 0x80) {
                     running_event = *midi_data;
-//                  printf("Set running_event 0x%2x\n", running_event);
+/*                  printf("Set running_event 0x%2x\n", running_event); */
                 }
             }
 
@@ -1817,9 +1817,9 @@ static int test_midi(unsigned char * midi_data, unsigned long int midi_size,
             midi_size -= check_ret;
             total_count += check_ret;
 
-//          printf("Midi data remaining: %lu\n", midi_size);
+/*          printf("Midi data remaining: %lu\n", midi_size); */
 
-            // Check if we're at the end of the track/file
+            /* Check if we're at the end of the track/file */
             if (midi_type == 0) {
                 /*
                  * For this MIDI type we are going to assume that

--- a/src/f_hmi.c
+++ b/src/f_hmi.c
@@ -77,12 +77,12 @@ _WM_ParseNewHmi(uint8_t *hmi_data, uint32_t hmi_size) {
 
 
     if (hmi_size <= 370) {
-        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_CORUPT, "file too short", 0);
+        _WM_GLOBAL_ERROR(WM_ERR_CORUPT, "file too short", 0);
         return NULL;
     }
 
     if (memcmp(hmi_data, "HMI-MIDISONG061595", 18)) {
-        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_NOT_HMI, NULL, 0);
+        _WM_GLOBAL_ERROR(WM_ERR_NOT_HMI, NULL, 0);
         return NULL;
     }
 
@@ -94,16 +94,16 @@ _WM_ParseNewHmi(uint8_t *hmi_data, uint32_t hmi_size) {
     hmi_track_cnt = hmi_data[228];
 
     if (!hmi_track_cnt) {
-        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_CORUPT, "(no tracks)", 0);
+        _WM_GLOBAL_ERROR(WM_ERR_CORUPT, "(no tracks)", 0);
         return NULL;
     }
     if (!hmi_bpm) {
-        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_INVALID, "(bad bpm)", 0);
+        _WM_GLOBAL_ERROR(WM_ERR_INVALID, "(bad bpm)", 0);
         return NULL;
     }
 
     if (hmi_size < (370 + (hmi_track_cnt * 17))) {
-        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_CORUPT, "file too short", 0);
+        _WM_GLOBAL_ERROR(WM_ERR_CORUPT, "file too short", 0);
         return NULL;
     }
 
@@ -136,7 +136,7 @@ _WM_ParseNewHmi(uint8_t *hmi_data, uint32_t hmi_size) {
     for (i = 0; i < hmi_track_cnt; i++) {
         /* FIXME: better and/or more size checks??? */
         if (data_end - hmi_data < 4) {
-            _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_CORUPT, "file too short", 0);
+            _WM_GLOBAL_ERROR(WM_ERR_CORUPT, "file too short", 0);
             goto _hmi_end;
         }
 
@@ -146,14 +146,14 @@ _WM_ParseNewHmi(uint8_t *hmi_data, uint32_t hmi_size) {
         hmi_track_offset[i] += (*hmi_data++ << 24);
 
         if (hmi_size < (hmi_track_offset[i] + 0x5a + 4)) {
-            _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_NOT_HMI, "file too short", 0);
+            _WM_GLOBAL_ERROR(WM_ERR_NOT_HMI, "file too short", 0);
             goto _hmi_end;
         }
 
         hmi_addr = hmi_base + hmi_track_offset[i];
 
         if (memcmp(hmi_addr, "HMI-MIDITRACK", 13)) {
-            _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_NOT_HMI, NULL, 0);
+            _WM_GLOBAL_ERROR(WM_ERR_NOT_HMI, NULL, 0);
             goto _hmi_end;
         }
 
@@ -196,7 +196,7 @@ _WM_ParseNewHmi(uint8_t *hmi_data, uint32_t hmi_size) {
     if (smallest_delta >= 0x7fffffff) {
         //DEBUG
         //fprintf(stderr,"CRAZY SMALLEST DELTA %u\n", smallest_delta);
-        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_CORUPT, NULL, 0);
+        _WM_GLOBAL_ERROR(WM_ERR_CORUPT, NULL, 0);
         goto _hmi_end;
     }
 
@@ -204,7 +204,7 @@ _WM_ParseNewHmi(uint8_t *hmi_data, uint32_t hmi_size) {
         //DEBUG
         //fprintf(stderr,"INTEGER OVERFLOW (samples_per_delta: %f, smallest_delta: %u)\n",
         //        samples_per_delta_f, smallest_delta);
-        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_CORUPT, NULL, 0);
+        _WM_GLOBAL_ERROR(WM_ERR_CORUPT, NULL, 0);
         goto _hmi_end;
     }
 
@@ -251,7 +251,7 @@ _WM_ParseNewHmi(uint8_t *hmi_data, uint32_t hmi_size) {
                 hmi_data = hmi_base + hmi_track_offset[i];
                 hmi_delta[i] = 0;
                 if (hmi_track_offset[i] >= hmi_size) {
-                    _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_NOT_HMI, "file too short", 0);
+                    _WM_GLOBAL_ERROR(WM_ERR_NOT_HMI, "file too short", 0);
                     goto _hmi_end;
                 }
                 data_size = hmi_size - hmi_track_offset[i];
@@ -273,7 +273,7 @@ _WM_ParseNewHmi(uint8_t *hmi_data, uint32_t hmi_size) {
                     hmi_data += 4;
                     hmi_track_offset[i] += 4;
                     if (hmi_tmp > data_size) {
-                        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_NOT_HMI, "file too short", 0);
+                        _WM_GLOBAL_ERROR(WM_ERR_NOT_HMI, "file too short", 0);
                         goto _hmi_end;
                     }
                     data_size -= hmi_tmp;
@@ -330,7 +330,7 @@ _WM_ParseNewHmi(uint8_t *hmi_data, uint32_t hmi_size) {
                             } while (*hmi_data > 0x7F);
                         }
                         if (!data_size) {
-                            _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_NOT_HMI, "file too short", 0);
+                            _WM_GLOBAL_ERROR(WM_ERR_NOT_HMI, "file too short", 0);
                             goto _hmi_end;
                         }
                         note[hmi_tmp].length = (note[hmi_tmp].length << 7) | (*hmi_data & 0x7F);
@@ -365,7 +365,7 @@ _WM_ParseNewHmi(uint8_t *hmi_data, uint32_t hmi_size) {
                     } while (*hmi_data > 0x7F);
                 }
                 if (!data_size) {
-                    _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_NOT_HMI, "file too short", 0);
+                    _WM_GLOBAL_ERROR(WM_ERR_NOT_HMI, "file too short", 0);
                     goto _hmi_end;
                 }
                 hmi_delta[i] = (hmi_delta[i] << 7) | (*hmi_data & 0x7F);
@@ -387,7 +387,7 @@ _WM_ParseNewHmi(uint8_t *hmi_data, uint32_t hmi_size) {
             //DEBUG
             //fprintf(stderr,"INTEGER OVERFLOW (samples_per_delta: %f, smallest_delta: %u)\n",
             //        samples_per_delta_f, smallest_delta);
-            _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_CORUPT, NULL, 0);
+            _WM_GLOBAL_ERROR(WM_ERR_CORUPT, NULL, 0);
             goto _hmi_end;
         }
         subtract_delta = smallest_delta;
@@ -401,7 +401,7 @@ _WM_ParseNewHmi(uint8_t *hmi_data, uint32_t hmi_size) {
     }
 
     if ((hmi_mdi->reverb = _WM_init_reverb(_WM_SampleRate, _WM_reverb_room_width, _WM_reverb_room_length, _WM_reverb_listen_posx, _WM_reverb_listen_posy)) == NULL) {
-        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_MEM, NULL, 0);
+        _WM_GLOBAL_ERROR(WM_ERR_MEM, NULL, 0);
         goto _hmi_end;
     }
 

--- a/src/f_hmi.c
+++ b/src/f_hmi.c
@@ -39,10 +39,10 @@
  Turns hmp file data into an event stream
  */
 struct _mdi *
-_WM_ParseNewHmi(uint8_t *hmi_data, uint32_t hmi_size) {
+_WM_ParseNewHmi(const uint8_t *hmi_data, uint32_t hmi_size) {
     uint32_t hmi_tmp = 0;
-    uint8_t *hmi_base = hmi_data;
-    uint8_t *data_end = hmi_data + hmi_size;
+    const uint8_t *hmi_base = hmi_data;
+    const uint8_t *data_end = hmi_data + hmi_size;
     uint32_t data_size;
     uint16_t hmi_bpm = 0;
     uint16_t hmi_division = 0;
@@ -51,7 +51,7 @@ _WM_ParseNewHmi(uint8_t *hmi_data, uint32_t hmi_size) {
     uint32_t *hmi_track_offset = NULL;
     uint32_t i = 0;
     uint32_t j = 0;
-    uint8_t *hmi_addr = NULL;
+    const uint8_t *hmi_addr = NULL;
     uint32_t *hmi_track_header_length = NULL;
     struct _mdi *hmi_mdi = NULL;
     float tempo_f =  5000000.0f;

--- a/src/f_hmi.c
+++ b/src/f_hmi.c
@@ -86,7 +86,7 @@ _WM_ParseNewHmi(uint8_t *hmi_data, uint32_t hmi_size) {
         return NULL;
     }
 
-    //FIXME: Unsure if this is correct but it seems to be the only offset that plays the files at what appears to be the right speed.
+    /* FIXME: Unsure if this is correct but it seems to be the only offset that plays the files at what appears to be the right speed. */
     hmi_bpm = hmi_data[212];
 
     hmi_division = 60;
@@ -131,7 +131,7 @@ _WM_ParseNewHmi(uint8_t *hmi_data, uint32_t hmi_size) {
 
     smallest_delta = 0x7fffffff;
 
-    hmi_track_offset[0] = *hmi_data; // To keep Xcode happy
+    hmi_track_offset[0] = *hmi_data; /* To keep Xcode happy */
 
     for (i = 0; i < hmi_track_cnt; i++) {
         /* FIXME: better and/or more size checks??? */
@@ -165,7 +165,7 @@ _WM_ParseNewHmi(uint8_t *hmi_data, uint32_t hmi_size) {
         hmi_addr += hmi_track_header_length[i];
         hmi_track_offset[i] += hmi_track_header_length[i];
 
-        // Get tracks initial delta and set its samples_till_next;
+        /* Get tracks initial delta and set its samples_till_next; */
         hmi_delta[i] = 0;
         if (*hmi_addr > 0x7f) {
             do {
@@ -178,7 +178,7 @@ _WM_ParseNewHmi(uint8_t *hmi_data, uint32_t hmi_size) {
         hmi_track_offset[i]++;
         hmi_addr++;
 
-        // Find smallest delta to work with
+        /* Find smallest delta to work with */
         if (hmi_delta[i] < smallest_delta) {
             smallest_delta = hmi_delta[i];
         }
@@ -194,16 +194,16 @@ _WM_ParseNewHmi(uint8_t *hmi_data, uint32_t hmi_size) {
     }
 
     if (smallest_delta >= 0x7fffffff) {
-        //DEBUG
-        //fprintf(stderr,"CRAZY SMALLEST DELTA %u\n", smallest_delta);
+        /* DEBUG */
+        /* fprintf(stderr,"CRAZY SMALLEST DELTA %u\n", smallest_delta); */
         _WM_GLOBAL_ERROR(WM_ERR_CORUPT, NULL, 0);
         goto _hmi_end;
     }
 
     if ((float)smallest_delta >= 0x7fffffff / samples_per_delta_f) {
-        //DEBUG
-        //fprintf(stderr,"INTEGER OVERFLOW (samples_per_delta: %f, smallest_delta: %u)\n",
-        //        samples_per_delta_f, smallest_delta);
+        /* DEBUG */
+        /* fprintf(stderr,"INTEGER OVERFLOW (samples_per_delta: %f, smallest_delta: %u)\n", */
+        /*        samples_per_delta_f, smallest_delta); */
         _WM_GLOBAL_ERROR(WM_ERR_CORUPT, NULL, 0);
         goto _hmi_end;
     }
@@ -222,7 +222,7 @@ _WM_ParseNewHmi(uint8_t *hmi_data, uint32_t hmi_size) {
         for (i = 0; i < hmi_track_cnt; i++) {
             if (hmi_track_end[i]) continue;
 
-            // first check to see if any active notes need turning off.
+            /* first check to see if any active notes need turning off. */
             for (j = 0; j < 128; j++) {
                 hmi_tmp = (128 * i) + j;
                 if (note[hmi_tmp].length) {
@@ -257,7 +257,7 @@ _WM_ParseNewHmi(uint8_t *hmi_data, uint32_t hmi_size) {
                 data_size = hmi_size - hmi_track_offset[i];
 
                 if (hmi_data[0] == 0xfe) {
-                    // HMI only event of some sort.
+                    /* HMI only event of some sort. */
                     if (hmi_data[1] == 0x10) {
                         hmi_tmp = (hmi_data[4] + 5);
                         hmi_data += hmi_tmp;
@@ -293,19 +293,19 @@ _WM_ParseNewHmi(uint8_t *hmi_data, uint32_t hmi_size) {
                         }
                         goto _hmi_next_track;
                     }
-                    // Running event
-                    // 0xff does not alter running event
+                    /* Running event */
+                    /* 0xff does not alter running event */
                     if ((*hmi_data == 0xF0) || (*hmi_data == 0xF7)) {
-                        // Sysex resets running event data
+                        /* Sysex resets running event data */
                         hmi_running_event[i] = 0;
                     } else if (*hmi_data < 0xF0) {
-                        // MIDI events 0x80 to 0xEF set running event
+                        /* MIDI events 0x80 to 0xEF set running event */
                         if (*hmi_data >= 0x80) {
                             hmi_running_event[i] = *hmi_data;
                         }
                     }
                     if ((hmi_running_event[i] & 0xf0) == 0x90) {
-                        // note on has extra data to specify how long the note is.
+                        /* note on has extra data to specify how long the note is. */
                         if (*hmi_data > 127) {
                             hmi_tmp = hmi_data[1];
                         } else {
@@ -353,8 +353,8 @@ _WM_ParseNewHmi(uint8_t *hmi_data, uint32_t hmi_size) {
                     }
                 }
 
-                // get track delta
-                // hmi_delta[i] = 0; // set at start of loop
+                /* get track delta */
+                /* hmi_delta[i] = 0; */ /* set at start of loop */
                 if (data_size && *hmi_data > 0x7f) {
                     do {
                         if (!data_size) break;
@@ -382,11 +382,11 @@ _WM_ParseNewHmi(uint8_t *hmi_data, uint32_t hmi_size) {
             WMIDI_UNUSED(hmi_tmp);
         }
 
-        // convert smallest delta to samples till next
+        /* convert smallest delta to samples till next */
         if ((float)smallest_delta >= 0x7fffffff / samples_per_delta_f) {
-            //DEBUG
-            //fprintf(stderr,"INTEGER OVERFLOW (samples_per_delta: %f, smallest_delta: %u)\n",
-            //        samples_per_delta_f, smallest_delta);
+            /* DEBUG */
+            /* fprintf(stderr,"INTEGER OVERFLOW (samples_per_delta: %f, smallest_delta: %u)\n", */
+            /*        samples_per_delta_f, smallest_delta); */
             _WM_GLOBAL_ERROR(WM_ERR_CORUPT, NULL, 0);
             goto _hmi_end;
         }

--- a/src/f_hmp.c
+++ b/src/f_hmp.c
@@ -70,12 +70,12 @@ _WM_ParseNewHmp(uint8_t *hmp_data, uint32_t hmp_size) {
     float sample_remainder = 0;
 
     if (hmp_size < 776) {
-        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_CORUPT, "file too short", 0);
+        _WM_GLOBAL_ERROR(WM_ERR_CORUPT, "file too short", 0);
         return NULL;
     }
 
     if (memcmp(hmp_data, "HMIMIDIP", 8)) {
-        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_NOT_HMP, NULL, 0);
+        _WM_GLOBAL_ERROR(WM_ERR_NOT_HMP, NULL, 0);
         return NULL;
     }
     hmp_data += 8;
@@ -83,7 +83,7 @@ _WM_ParseNewHmp(uint8_t *hmp_data, uint32_t hmp_size) {
 
     if (!memcmp(hmp_data, "013195", 6)) {
         if (hmp_size < 896) {
-            _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_CORUPT, "file too short", 0);
+            _WM_GLOBAL_ERROR(WM_ERR_CORUPT, "file too short", 0);
             return NULL;
         }
         hmp_data += 6;
@@ -99,7 +99,7 @@ _WM_ParseNewHmp(uint8_t *hmp_data, uint32_t hmp_size) {
     }
     for (i = 0; i < zero_cnt; i++) {
         if (hmp_data[i] != 0) {
-            _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_NOT_HMP, NULL, 0);
+            _WM_GLOBAL_ERROR(WM_ERR_NOT_HMP, NULL, 0);
             return NULL;
         }
     }
@@ -125,7 +125,7 @@ _WM_ParseNewHmp(uint8_t *hmp_data, uint32_t hmp_size) {
     hmp_size -= 4;
 
     if (!hmp_chunks) {
-        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_CORUPT, "(no tracks)", 0);
+        _WM_GLOBAL_ERROR(WM_ERR_CORUPT, "(no tracks)", 0);
         return NULL;
     }
 
@@ -149,7 +149,7 @@ _WM_ParseNewHmp(uint8_t *hmp_data, uint32_t hmp_size) {
     hmp_size -= 4;
 
     if (!hmp_bpm) {
-        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_INVALID, "(bad bpm)", 0);
+        _WM_GLOBAL_ERROR(WM_ERR_INVALID, "(bad bpm)", 0);
         return NULL;
     }
 
@@ -218,7 +218,7 @@ _WM_ParseNewHmp(uint8_t *hmp_data, uint32_t hmp_size) {
         chunk_ofs[i] += 4;
 
         if (chunk_length[i] > hmp_size) {
-            _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_NOT_HMP, "file too short", 0);
+            _WM_GLOBAL_ERROR(WM_ERR_NOT_HMP, "file too short", 0);
             goto _hmp_end;
         }
         hmp_size -= chunk_length[i];
@@ -258,7 +258,7 @@ _WM_ParseNewHmp(uint8_t *hmp_data, uint32_t hmp_size) {
     if (smallest_delta >= 0x7fffffff) {
         //DEBUG
         //fprintf(stderr,"CRAZY SMALLEST DELTA %u\n", smallest_delta);
-        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_CORUPT, NULL, 0);
+        _WM_GLOBAL_ERROR(WM_ERR_CORUPT, NULL, 0);
         goto _hmp_end;
     }
 
@@ -266,7 +266,7 @@ _WM_ParseNewHmp(uint8_t *hmp_data, uint32_t hmp_size) {
         //DEBUG
         //fprintf(stderr,"INTEGER OVERFLOW (samples_per_delta: %f, smallest_delta: %u)\n",
         //        samples_per_delta_f, smallest_delta);
-        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_CORUPT, NULL, 0);
+        _WM_GLOBAL_ERROR(WM_ERR_CORUPT, NULL, 0);
         goto _hmp_end;
     }
 
@@ -343,7 +343,7 @@ _WM_ParseNewHmp(uint8_t *hmp_data, uint32_t hmp_size) {
                     } while (*hmp_chunk[i] < 0x80);
                 }
                 if (! chunk_length[i]) {
-                    _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_NOT_HMP, "file too short", 0);
+                    _WM_GLOBAL_ERROR(WM_ERR_NOT_HMP, "file too short", 0);
                     goto _hmp_end;
                 }
                 chunk_delta[i] = chunk_delta[i] + ((*hmp_chunk[i] & 0x7F) << var_len_shift);
@@ -361,7 +361,7 @@ _WM_ParseNewHmp(uint8_t *hmp_data, uint32_t hmp_size) {
             //DEBUG
             //fprintf(stderr,"INTEGER OVERFLOW (samples_per_delta: %f, smallest_delta: %u)\n",
             //        samples_per_delta_f, smallest_delta);
-            _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_CORUPT, NULL, 0);
+            _WM_GLOBAL_ERROR(WM_ERR_CORUPT, NULL, 0);
             goto _hmp_end;
         }
 
@@ -379,7 +379,7 @@ _WM_ParseNewHmp(uint8_t *hmp_data, uint32_t hmp_size) {
     }
 
     if ((hmp_mdi->reverb = _WM_init_reverb(_WM_SampleRate, _WM_reverb_room_width, _WM_reverb_room_length, _WM_reverb_listen_posx, _WM_reverb_listen_posy)) == NULL) {
-        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_MEM, NULL, 0);
+        _WM_GLOBAL_ERROR(WM_ERR_MEM, NULL, 0);
         goto _hmp_end;
     }
 

--- a/src/f_hmp.c
+++ b/src/f_hmp.c
@@ -39,7 +39,7 @@
  Turns hmp file data into an event stream
  */
 struct _mdi *
-_WM_ParseNewHmp(uint8_t *hmp_data, uint32_t hmp_size) {
+_WM_ParseNewHmp(const uint8_t *hmp_data, uint32_t hmp_size) {
     uint8_t is_hmp2 = 0;
     uint32_t zero_cnt = 0;
     uint32_t i = 0;
@@ -50,7 +50,7 @@ _WM_ParseNewHmp(uint8_t *hmp_data, uint32_t hmp_size) {
     uint32_t hmp_bpm = 0;
     uint32_t hmp_song_time = 0;
     struct _mdi *hmp_mdi;
-    uint8_t **hmp_chunk;
+    const uint8_t **hmp_chunk;
     uint32_t *chunk_length;
     uint32_t *chunk_ofs;
     uint32_t *chunk_delta;
@@ -190,7 +190,7 @@ _WM_ParseNewHmp(uint8_t *hmp_data, uint32_t hmp_size) {
     _WM_midi_setup_divisions(hmp_mdi, hmp_divisions);
     _WM_midi_setup_tempo(hmp_mdi, (uint32_t)tempo_f);
 
-    hmp_chunk = (uint8_t **) malloc(sizeof(uint8_t *) * hmp_chunks);
+    hmp_chunk = (const uint8_t **) malloc(sizeof(uint8_t *) * hmp_chunks);
     chunk_length = (uint32_t *) malloc(sizeof(uint32_t) * hmp_chunks);
     chunk_delta = (uint32_t *) malloc(sizeof(uint32_t) * hmp_chunks);
     chunk_ofs = (uint32_t *) malloc(sizeof(uint32_t) * hmp_chunks);

--- a/src/f_hmp.c
+++ b/src/f_hmp.c
@@ -91,7 +91,7 @@ _WM_ParseNewHmp(uint8_t *hmp_data, uint32_t hmp_size) {
         is_hmp2 = 1;
     }
 
-    // should be a bunch of \0's
+    /* should be a bunch of \0's */
     if (is_hmp2) {
         zero_cnt = 18;
     } else {
@@ -114,7 +114,7 @@ _WM_ParseNewHmp(uint8_t *hmp_data, uint32_t hmp_size) {
 
     WMIDI_UNUSED(hmp_file_length);
 
-    // Next 12 bytes are normally \0 so skipping over them
+    /* Next 12 bytes are normally \0 so skipping over them */
     hmp_data += 12;
     hmp_size -= 12;
 
@@ -129,7 +129,7 @@ _WM_ParseNewHmp(uint8_t *hmp_data, uint32_t hmp_size) {
         return NULL;
     }
 
-    // Still decyphering what this is
+    /* Still decyphering what this is */
     hmp_unknown = *hmp_data++;
     hmp_unknown += (*hmp_data++ << 8);
     hmp_unknown += (*hmp_data++ << 16);
@@ -138,10 +138,10 @@ _WM_ParseNewHmp(uint8_t *hmp_data, uint32_t hmp_size) {
 
     WMIDI_UNUSED(hmp_unknown);
 
-    // Defaulting: experimenting has found this to be the ideal value
+    /* Defaulting: experimenting has found this to be the ideal value */
     hmp_divisions = 60;
 
-    // Beats per minute
+    /* Beats per minute */
     hmp_bpm = *hmp_data++;
     hmp_bpm += (*hmp_data++ << 8);
     hmp_bpm += (*hmp_data++ << 16);
@@ -162,18 +162,18 @@ _WM_ParseNewHmp(uint8_t *hmp_data, uint32_t hmp_size) {
 
     samples_per_delta_f = _WM_GetSamplesPerTick(hmp_divisions, (uint32_t) tempo_f);
 
-    //DEBUG
-    //fprintf(stderr, "DEBUG: Samples Per Delta Tick: %f\r\n",samples_per_delta_f);
+    /* DEBUG */
+    /* fprintf(stderr, "DEBUG: Samples Per Delta Tick: %f\r\n",samples_per_delta_f); */
 
-    // FIXME: This value is incorrect
+    /* FIXME: This value is incorrect */
     hmp_song_time = *hmp_data++;
     hmp_song_time += (*hmp_data++ << 8);
     hmp_song_time += (*hmp_data++ << 16);
     hmp_song_time += (*hmp_data++ << 24);
     hmp_size -= 4;
 
-    // DEBUG
-    //fprintf(stderr,"DEBUG: ??DIVISIONS??: %u, BPM: %u, ??SONG TIME??: %u:%.2u\r\n",hmp_divisions, hmp_bpm, (hmp_song_time / 60), (hmp_song_time % 60));
+    /* DEBUG */
+    /* fprintf(stderr,"DEBUG: ??DIVISIONS??: %u, BPM: %u, ??SONG TIME??: %u:%.2u\r\n",hmp_divisions, hmp_bpm, (hmp_song_time / 60), (hmp_song_time % 60)); */
 
     WMIDI_UNUSED(hmp_song_time);
 
@@ -197,7 +197,7 @@ _WM_ParseNewHmp(uint8_t *hmp_data, uint32_t hmp_size) {
     chunk_end = (uint8_t *) malloc(sizeof(uint8_t) * hmp_chunks);
 
     smallest_delta = 0x7fffffff;
-    // store chunk info for use, and check chunk lengths
+    /* store chunk info for use, and check chunk lengths */
     for (i = 0; i < hmp_chunks; i++) {
         /* FIXME: add proper size checks!!! */
         hmp_chunk[i] = hmp_data;
@@ -231,7 +231,7 @@ _WM_ParseNewHmp(uint8_t *hmp_data, uint32_t hmp_size) {
 
         WMIDI_UNUSED(hmp_track);
 
-        // Start of Midi Data
+        /* Start of Midi Data */
         chunk_delta[i] = 0;
         var_len_shift = 0;
         if (*hmp_data < 0x80) {
@@ -248,7 +248,7 @@ _WM_ParseNewHmp(uint8_t *hmp_data, uint32_t hmp_size) {
             smallest_delta = chunk_delta[i];
         }
 
-        // goto start of next chunk
+        /* goto start of next chunk */
         hmp_data = hmp_chunk[i] + chunk_length[i];
         chunk_length[i] -= chunk_ofs[i];
         hmp_chunk[i] += chunk_ofs[i]++;
@@ -256,16 +256,16 @@ _WM_ParseNewHmp(uint8_t *hmp_data, uint32_t hmp_size) {
     }
 
     if (smallest_delta >= 0x7fffffff) {
-        //DEBUG
-        //fprintf(stderr,"CRAZY SMALLEST DELTA %u\n", smallest_delta);
+        /* DEBUG */
+        /* fprintf(stderr,"CRAZY SMALLEST DELTA %u\n", smallest_delta); */
         _WM_GLOBAL_ERROR(WM_ERR_CORUPT, NULL, 0);
         goto _hmp_end;
     }
 
     if ((float)smallest_delta >= 0x7fffffff / samples_per_delta_f) {
-        //DEBUG
-        //fprintf(stderr,"INTEGER OVERFLOW (samples_per_delta: %f, smallest_delta: %u)\n",
-        //        samples_per_delta_f, smallest_delta);
+        /* DEBUG */
+        /* fprintf(stderr,"INTEGER OVERFLOW (samples_per_delta: %f, smallest_delta: %u)\n", */
+        /*        samples_per_delta_f, smallest_delta); */
         _WM_GLOBAL_ERROR(WM_ERR_CORUPT, NULL, 0);
         goto _hmp_end;
     }
@@ -282,8 +282,8 @@ _WM_ParseNewHmp(uint8_t *hmp_data, uint32_t hmp_size) {
     while (end_of_chunks < hmp_chunks) {
         smallest_delta = 0;
 
-        // DEBUG
-        // fprintf(stderr,"DEBUG: Delta Ticks: %u\r\n",subtract_delta);
+        /* DEBUG */
+        /* fprintf(stderr,"DEBUG: Delta Ticks: %u\r\n",subtract_delta); */
 
         for (i = 0; i < hmp_chunks; i++) {
             if (chunk_end[i])
@@ -301,8 +301,8 @@ _WM_ParseNewHmp(uint8_t *hmp_data, uint32_t hmp_size) {
             }
             do {
                 if (((hmp_chunk[i][0] & 0xf0) == 0xb0 ) && ((hmp_chunk[i][1] == 110) || (hmp_chunk[i][1] == 111)) && (hmp_chunk[i][2] > 0x7f)) {
-                    // Reserved for loop markers
-                    // TODO: still deciding what to do about these
+                    /* Reserved for loop markers */
+                    /* TODO: still deciding what to do about these */
                     hmp_chunk[i] += 3;
                     chunk_length[i] -= 3;
                 } else {
@@ -325,8 +325,8 @@ _WM_ParseNewHmp(uint8_t *hmp_data, uint32_t hmp_size) {
                         if (tempo_f == 0.0f)
                             tempo_f = 500000.0f;
 
-                        // DEBUG
-                        // fprintf(stderr,"DEBUG: Tempo change %f\r\n", tempo_f);
+                        /* DEBUG */
+                        /* fprintf(stderr,"DEBUG: Tempo change %f\r\n", tempo_f); */
                     }
                     hmp_chunk[i] += setup_ret;
                     chunk_length[i] -= setup_ret;
@@ -358,9 +358,9 @@ _WM_ParseNewHmp(uint8_t *hmp_data, uint32_t hmp_size) {
         }
 
         if ((float)smallest_delta >= 0x7fffffff / samples_per_delta_f) {
-            //DEBUG
-            //fprintf(stderr,"INTEGER OVERFLOW (samples_per_delta: %f, smallest_delta: %u)\n",
-            //        samples_per_delta_f, smallest_delta);
+            /* DEBUG */
+            /* fprintf(stderr,"INTEGER OVERFLOW (samples_per_delta: %f, smallest_delta: %u)\n", */
+            /*        samples_per_delta_f, smallest_delta); */
             _WM_GLOBAL_ERROR(WM_ERR_CORUPT, NULL, 0);
             goto _hmp_end;
         }
@@ -374,8 +374,8 @@ _WM_ParseNewHmp(uint8_t *hmp_data, uint32_t hmp_size) {
         hmp_mdi->events[hmp_mdi->event_count - 1].samples_to_next += sample_count;
         hmp_mdi->extra_info.approx_total_samples += sample_count;
 
-        // DEBUG
-        // fprintf(stderr,"DEBUG: Sample Count %u\r\n",sample_count);
+        /* DEBUG */
+        /* fprintf(stderr,"DEBUG: Sample Count %u\r\n",sample_count); */
     }
 
     if ((hmp_mdi->reverb = _WM_init_reverb(_WM_SampleRate, _WM_reverb_room_width, _WM_reverb_room_length, _WM_reverb_listen_posx, _WM_reverb_listen_posy)) == NULL) {

--- a/src/f_midi.c
+++ b/src/f_midi.c
@@ -231,16 +231,16 @@ _WM_ParseNewMidi(uint8_t *midi_data, uint32_t midi_size) {
     }
 
     if (smallest_delta >= 0x7fffffff) {
-        //DEBUG
-        //fprintf(stderr,"CRAZY SMALLEST DELTA %u\n", smallest_delta);
+        /* DEBUG */
+        /* fprintf(stderr,"CRAZY SMALLEST DELTA %u\n", smallest_delta); */
         _WM_GLOBAL_ERROR(WM_ERR_CORUPT, NULL, 0);
         goto _end;
     }
 
     if ((float)smallest_delta >= 0x7fffffff / samples_per_delta_f) {
-        //DEBUG
-        //fprintf(stderr,"INTEGER OVERFLOW (samples_per_delta: %f, smallest_delta: %u)\n",
-        //        samples_per_delta_f, smallest_delta);
+        /* DEBUG */
+        /* fprintf(stderr,"INTEGER OVERFLOW (samples_per_delta: %f, smallest_delta: %u)\n", */
+        /*        samples_per_delta_f, smallest_delta); */
         _WM_GLOBAL_ERROR(WM_ERR_CORUPT, NULL, 0);
         goto _end;
     }
@@ -326,9 +326,9 @@ _WM_ParseNewMidi(uint8_t *midi_data, uint32_t midi_size) {
             }
 
             if ((float)smallest_delta >= 0x7fffffff / samples_per_delta_f) {
-                //DEBUG
-                //fprintf(stderr,"INTEGER OVERFLOW (samples_per_delta: %f, smallest_delta: %u)\n",
-                //        samples_per_delta_f, smallest_delta);
+                /* DEBUG */
+                /* fprintf(stderr,"INTEGER OVERFLOW (samples_per_delta: %f, smallest_delta: %u)\n", */
+                /*        samples_per_delta_f, smallest_delta); */
                 _WM_GLOBAL_ERROR(WM_ERR_CORUPT, NULL, 0);
                 goto _end;
             }
@@ -400,9 +400,9 @@ _WM_ParseNewMidi(uint8_t *midi_data, uint32_t midi_size) {
                 track_size[i]--;
 
                 if ((float)smallest_delta >= 0x7fffffff / samples_per_delta_f) {
-                    //DEBUG
-                    //fprintf(stderr,"INTEGER OVERFLOW (samples_per_delta: %f, smallest_delta: %u)\n",
-                    //        samples_per_delta_f, smallest_delta);
+                    /* DEBUG */
+                    /* fprintf(stderr,"INTEGER OVERFLOW (samples_per_delta: %f, smallest_delta: %u)\n", */
+                    /*        samples_per_delta_f, smallest_delta); */
                     _WM_GLOBAL_ERROR(WM_ERR_CORUPT, NULL, 0);
                     goto _end;
                 }
@@ -522,16 +522,16 @@ _WM_Event2Midi(struct _mdi *mdi, uint8_t **out, uint32_t *outsize) {
         /* TODO Is there a better way? */
         switch (event->evtype) {
         case ev_midi_divisions:
-            // DEBUG
-            // fprintf(stderr,"Division: %u\r\n",event->event_data.data);
+            /* DEBUG */
+            /* fprintf(stderr,"Division: %u\r\n",event->event_data.data); */
             divisions = event->event_data.data.value;
             (*out)[12] = (divisions >> 8) & 0xff;
             (*out)[13] = divisions & 0xff;
             samples_per_tick = _WM_GetSamplesPerTick(divisions, tempo);
             break;
         case ev_note_off:
-            // DEBUG
-            // fprintf(stderr,"Note Off: %u %.4x\r\n",event->event_data.channel, event->event_data.data);
+            /* DEBUG */
+            /* fprintf(stderr,"Note Off: %u %.4x\r\n",event->event_data.channel, event->event_data.data); */
             if (running_event != (0x80 | event->event_data.channel)) {
                 (*out)[out_ofs++] = 0x80 | event->event_data.channel;
                 running_event = (*out)[out_ofs - 1];
@@ -540,8 +540,8 @@ _WM_Event2Midi(struct _mdi *mdi, uint8_t **out, uint32_t *outsize) {
             (*out)[out_ofs++] = event->event_data.data.value & 0xff;
             break;
         case ev_note_on:
-            // DEBUG
-            // fprintf(stderr,"Note On: %u %.4x\r\n",event->event_data.channel, event->event_data.data);
+            /* DEBUG */
+            /* fprintf(stderr,"Note On: %u %.4x\r\n",event->event_data.channel, event->event_data.data); */
             if (running_event != (0x90 | event->event_data.channel)) {
                 (*out)[out_ofs++] = 0x90 | event->event_data.channel;
                 running_event = (*out)[out_ofs - 1];
@@ -550,8 +550,8 @@ _WM_Event2Midi(struct _mdi *mdi, uint8_t **out, uint32_t *outsize) {
             (*out)[out_ofs++] = event->event_data.data.value & 0xff;
             break;
         case ev_aftertouch:
-            // DEBUG
-            // fprintf(stderr,"Aftertouch: %u %.4x\r\n",event->event_data.channel, event->event_data.data);
+            /* DEBUG */
+            /* fprintf(stderr,"Aftertouch: %u %.4x\r\n",event->event_data.channel, event->event_data.data); */
             if (running_event != (0xa0 | event->event_data.channel)) {
                 (*out)[out_ofs++] = 0xa0 | event->event_data.channel;
                 running_event = (*out)[out_ofs - 1];
@@ -560,8 +560,8 @@ _WM_Event2Midi(struct _mdi *mdi, uint8_t **out, uint32_t *outsize) {
             (*out)[out_ofs++] = event->event_data.data.value & 0xff;
             break;
         case ev_control_bank_select:
-            // DEBUG
-            // fprintf(stderr,"Control Bank Select: %u %.4x\r\n",event->event_data.channel, event->event_data.data);
+            /* DEBUG */
+            /* fprintf(stderr,"Control Bank Select: %u %.4x\r\n",event->event_data.channel, event->event_data.data); */
             if (running_event != (0xb0 | event->event_data.channel)) {
                 (*out)[out_ofs++] = 0xb0 | event->event_data.channel;
                 running_event = (*out)[out_ofs - 1];
@@ -570,8 +570,8 @@ _WM_Event2Midi(struct _mdi *mdi, uint8_t **out, uint32_t *outsize) {
             (*out)[out_ofs++] = event->event_data.data.value & 0xff;
             break;
         case ev_control_data_entry_course:
-            // DEBUG
-            // fprintf(stderr,"Control Data Entry Course: %u %.4x\r\n",event->event_data.channel, event->event_data.data);
+            /* DEBUG */
+            /* fprintf(stderr,"Control Data Entry Course: %u %.4x\r\n",event->event_data.channel, event->event_data.data); */
             if (running_event != (0xb0 | event->event_data.channel)) {
                 (*out)[out_ofs++] = 0xb0 | event->event_data.channel;
                 running_event = (*out)[out_ofs - 1];
@@ -580,8 +580,8 @@ _WM_Event2Midi(struct _mdi *mdi, uint8_t **out, uint32_t *outsize) {
             (*out)[out_ofs++] = event->event_data.data.value & 0xff;
             break;
         case ev_control_channel_volume:
-            // DEBUG
-            // fprintf(stderr,"Control Channel Volume: %u %.4x\r\n",event->event_data.channel, event->event_data.data);
+            /* DEBUG */
+            /* fprintf(stderr,"Control Channel Volume: %u %.4x\r\n",event->event_data.channel, event->event_data.data); */
             if (running_event != (0xb0 | event->event_data.channel)) {
                 (*out)[out_ofs++] = 0xb0 | event->event_data.channel;
                 running_event = (*out)[out_ofs - 1];
@@ -590,8 +590,8 @@ _WM_Event2Midi(struct _mdi *mdi, uint8_t **out, uint32_t *outsize) {
             (*out)[out_ofs++] = event->event_data.data.value & 0xff;
             break;
         case ev_control_channel_balance:
-            // DEBUG
-            // fprintf(stderr,"Control Channel Balance: %u %.4x\r\n",event->event_data.channel, event->event_data.data);
+            /* DEBUG */
+            /* fprintf(stderr,"Control Channel Balance: %u %.4x\r\n",event->event_data.channel, event->event_data.data); */
             if (running_event != (0xb0 | event->event_data.channel)) {
                 (*out)[out_ofs++] = 0xb0 | event->event_data.channel;
                 running_event = (*out)[out_ofs - 1];
@@ -600,8 +600,8 @@ _WM_Event2Midi(struct _mdi *mdi, uint8_t **out, uint32_t *outsize) {
             (*out)[out_ofs++] = event->event_data.data.value & 0xff;
             break;
         case ev_control_channel_pan:
-            // DEBUG
-            // fprintf(stderr,"Control Channel Pan: %u %.4x\r\n",event->event_data.channel, event->event_data.data);
+            /* DEBUG */
+            /* fprintf(stderr,"Control Channel Pan: %u %.4x\r\n",event->event_data.channel, event->event_data.data); */
             if (running_event != (0xb0 | event->event_data.channel)) {
                 (*out)[out_ofs++] = 0xb0 | event->event_data.channel;
                 running_event = (*out)[out_ofs - 1];
@@ -610,8 +610,8 @@ _WM_Event2Midi(struct _mdi *mdi, uint8_t **out, uint32_t *outsize) {
             (*out)[out_ofs++] = event->event_data.data.value & 0xff;
             break;
         case ev_control_channel_expression:
-            // DEBUG
-            // fprintf(stderr,"Control Channel Expression: %u %.4x\r\n",event->event_data.channel, event->event_data.data);
+            /* DEBUG */
+            /* fprintf(stderr,"Control Channel Expression: %u %.4x\r\n",event->event_data.channel, event->event_data.data); */
             if (running_event != (0xb0 | event->event_data.channel)) {
                 (*out)[out_ofs++] = 0xb0 | event->event_data.channel;
                 running_event = (*out)[out_ofs - 1];
@@ -620,8 +620,8 @@ _WM_Event2Midi(struct _mdi *mdi, uint8_t **out, uint32_t *outsize) {
             (*out)[out_ofs++] = event->event_data.data.value & 0xff;
             break;
         case ev_control_data_entry_fine:
-            // DEBUG
-            // fprintf(stderr,"Control Data Entry Fine: %u %.4x\r\n",event->event_data.channel, event->event_data.data);
+            /* DEBUG */
+            /* fprintf(stderr,"Control Data Entry Fine: %u %.4x\r\n",event->event_data.channel, event->event_data.data); */
             if (running_event != (0xb0 | event->event_data.channel)) {
                 (*out)[out_ofs++] = 0xb0 | event->event_data.channel;
                 running_event = (*out)[out_ofs - 1];
@@ -630,8 +630,8 @@ _WM_Event2Midi(struct _mdi *mdi, uint8_t **out, uint32_t *outsize) {
             (*out)[out_ofs++] = event->event_data.data.value & 0xff;
             break;
         case ev_control_channel_hold:
-            // DEBUG
-            // fprintf(stderr,"Control Channel Hold: %u %.4x\r\n",event->event_data.channel, event->event_data.data);
+            /* DEBUG */
+            /* fprintf(stderr,"Control Channel Hold: %u %.4x\r\n",event->event_data.channel, event->event_data.data); */
             if (running_event != (0xb0 | event->event_data.channel)) {
                 (*out)[out_ofs++] = 0xb0 | event->event_data.channel;
                 running_event = (*out)[out_ofs - 1];
@@ -640,8 +640,8 @@ _WM_Event2Midi(struct _mdi *mdi, uint8_t **out, uint32_t *outsize) {
             (*out)[out_ofs++] = event->event_data.data.value & 0xff;
             break;
         case ev_control_data_increment:
-            // DEBUG
-            // fprintf(stderr,"Control Data Increment: %u %.4x\r\n",event->event_data.channel, event->event_data.data);
+            /* DEBUG */
+            /* fprintf(stderr,"Control Data Increment: %u %.4x\r\n",event->event_data.channel, event->event_data.data); */
             if (running_event != (0xb0 | event->event_data.channel)) {
                 (*out)[out_ofs++] = 0xb0 | event->event_data.channel;
                 running_event = (*out)[out_ofs - 1];
@@ -650,8 +650,8 @@ _WM_Event2Midi(struct _mdi *mdi, uint8_t **out, uint32_t *outsize) {
             (*out)[out_ofs++] = event->event_data.data.value & 0xff;
             break;
         case ev_control_data_decrement:
-            // DEBUG
-            //fprintf(stderr,"Control Data Decrement: %u %.4x\r\n",event->event_data.channel, event->event_data.data);
+            /* DEBUG */
+            /* fprintf(stderr,"Control Data Decrement: %u %.4x\r\n",event->event_data.channel, event->event_data.data); */
             if (running_event != (0xb0 | event->event_data.channel)) {
                 (*out)[out_ofs++] = 0xb0 | event->event_data.channel;
                 running_event = (*out)[out_ofs - 1];
@@ -660,8 +660,8 @@ _WM_Event2Midi(struct _mdi *mdi, uint8_t **out, uint32_t *outsize) {
             (*out)[out_ofs++] = event->event_data.data.value & 0xff;
             break;
         case ev_control_non_registered_param_fine:
-            // DEBUG
-            // fprintf(stderr,"Control Non Registered Param: %u %.4x\r\n",event->event_data.channel, event->event_data.data);
+            /* DEBUG */
+            /* fprintf(stderr,"Control Non Registered Param: %u %.4x\r\n",event->event_data.channel, event->event_data.data); */
             if (running_event != (0xb0 | event->event_data.channel)) {
                 (*out)[out_ofs++] = 0xb0 | event->event_data.channel;
                 running_event = (*out)[out_ofs - 1];
@@ -670,8 +670,8 @@ _WM_Event2Midi(struct _mdi *mdi, uint8_t **out, uint32_t *outsize) {
             (*out)[out_ofs++] = event->event_data.data.value & 0x7f;
             break;
         case ev_control_non_registered_param_course:
-            // DEBUG
-            // fprintf(stderr,"Control Non Registered Param: %u %.4x\r\n",event->event_data.channel, event->event_data.data);
+            /* DEBUG */
+            /* fprintf(stderr,"Control Non Registered Param: %u %.4x\r\n",event->event_data.channel, event->event_data.data); */
             if (running_event != (0xb0 | event->event_data.channel)) {
                 (*out)[out_ofs++] = 0xb0 | event->event_data.channel;
                 running_event = (*out)[out_ofs - 1];
@@ -680,8 +680,8 @@ _WM_Event2Midi(struct _mdi *mdi, uint8_t **out, uint32_t *outsize) {
             (*out)[out_ofs++] = (event->event_data.data.value >> 7) & 0x7f;
             break;
         case ev_control_registered_param_fine:
-            // DEBUG
-            // fprintf(stderr,"Control Registered Param Fine: %u %.4x\r\n",event->event_data.channel, event->event_data.data);
+            /* DEBUG */
+            /* fprintf(stderr,"Control Registered Param Fine: %u %.4x\r\n",event->event_data.channel, event->event_data.data); */
             if (running_event != (0xb0 | event->event_data.channel)) {
                 (*out)[out_ofs++] = 0xb0 | event->event_data.channel;
                 running_event = (*out)[out_ofs - 1];
@@ -690,8 +690,8 @@ _WM_Event2Midi(struct _mdi *mdi, uint8_t **out, uint32_t *outsize) {
             (*out)[out_ofs++] = event->event_data.data.value & 0x7f;
             break;
         case ev_control_registered_param_course:
-            // DEBUG
-            // fprintf(stderr,"Control Registered Param Course: %u %.4x\r\n",event->event_data.channel, event->event_data.data);
+            /* DEBUG */
+            /* fprintf(stderr,"Control Registered Param Course: %u %.4x\r\n",event->event_data.channel, event->event_data.data); */
             if (running_event != (0xb0 | event->event_data.channel)) {
                 (*out)[out_ofs++] = 0xb0 | event->event_data.channel;
                 running_event = (*out)[out_ofs - 1];
@@ -700,8 +700,8 @@ _WM_Event2Midi(struct _mdi *mdi, uint8_t **out, uint32_t *outsize) {
             (*out)[out_ofs++] = (event->event_data.data.value >> 7) & 0x7f;
             break;
         case ev_control_channel_sound_off:
-            // DEBUG
-            // fprintf(stderr,"Control Channel Sound Off: %u %.4x\r\n",event->event_data.channel, event->event_data.data);
+            /* DEBUG */
+            /* fprintf(stderr,"Control Channel Sound Off: %u %.4x\r\n",event->event_data.channel, event->event_data.data); */
             if (running_event != (0xb0 | event->event_data.channel)) {
                 (*out)[out_ofs++] = 0xb0 | event->event_data.channel;
                 running_event = (*out)[out_ofs - 1];
@@ -710,8 +710,8 @@ _WM_Event2Midi(struct _mdi *mdi, uint8_t **out, uint32_t *outsize) {
             (*out)[out_ofs++] = event->event_data.data.value & 0xff;
             break;
         case ev_control_channel_controllers_off:
-            // DEBUG
-            // fprintf(stderr,"Control Channel Controllers Off: %u %.4x\r\n",event->event_data.channel, event->event_data.data);
+            /* DEBUG */
+            /* fprintf(stderr,"Control Channel Controllers Off: %u %.4x\r\n",event->event_data.channel, event->event_data.data); */
             if (running_event != (0xb0 | event->event_data.channel)) {
                 (*out)[out_ofs++] = 0xb0 | event->event_data.channel;
                 running_event = (*out)[out_ofs - 1];
@@ -720,8 +720,8 @@ _WM_Event2Midi(struct _mdi *mdi, uint8_t **out, uint32_t *outsize) {
             (*out)[out_ofs++] = event->event_data.data.value & 0xff;
             break;
         case ev_control_channel_notes_off:
-            // DEBUG
-            // fprintf(stderr,"Control Channel Notes Off: %u %.4x\r\n",event->event_data.channel, event->event_data.data);
+            /* DEBUG */
+            /* fprintf(stderr,"Control Channel Notes Off: %u %.4x\r\n",event->event_data.channel, event->event_data.data); */
             if (running_event != (0xb0 | event->event_data.channel)) {
                 (*out)[out_ofs++] = 0xb0 | event->event_data.channel;
                 running_event = (*out)[out_ofs - 1];
@@ -730,8 +730,8 @@ _WM_Event2Midi(struct _mdi *mdi, uint8_t **out, uint32_t *outsize) {
             (*out)[out_ofs++] = event->event_data.data.value & 0xff;
             break;
         case ev_control_dummy:
-            // DEBUG
-            // fprintf(stderr,"Control Dummy Event: %u %.4x\r\n",event->event_data.channel, event->event_data.data);
+            /* DEBUG */
+            /* fprintf(stderr,"Control Dummy Event: %u %.4x\r\n",event->event_data.channel, event->event_data.data); */
             if (running_event != (0xb0 | event->event_data.channel)) {
                 (*out)[out_ofs++] = 0xb0 | event->event_data.channel;
                 running_event = (*out)[out_ofs - 1];
@@ -740,8 +740,8 @@ _WM_Event2Midi(struct _mdi *mdi, uint8_t **out, uint32_t *outsize) {
             (*out)[out_ofs++] = event->event_data.data.value & 0xff;
             break;
         case ev_patch:
-            // DEBUG
-            // fprintf(stderr,"Patch: %u %.4x\r\n",event->event_data.channel, event->event_data.data);
+            /* DEBUG */
+            /* fprintf(stderr,"Patch: %u %.4x\r\n",event->event_data.channel, event->event_data.data); */
             if (running_event != (0xc0 | event->event_data.channel)) {
                 (*out)[out_ofs++] = 0xc0 | event->event_data.channel;
                 running_event = (*out)[out_ofs - 1];
@@ -749,8 +749,8 @@ _WM_Event2Midi(struct _mdi *mdi, uint8_t **out, uint32_t *outsize) {
             (*out)[out_ofs++] = event->event_data.data.value & 0xff;
             break;
         case ev_channel_pressure:
-            // DEBUG
-            // fprintf(stderr,"Channel Pressure: %u %.4x\r\n",event->event_data.channel, event->event_data.data);
+            /* DEBUG */
+            /* fprintf(stderr,"Channel Pressure: %u %.4x\r\n",event->event_data.channel, event->event_data.data); */
             if (running_event != (0xd0 | event->event_data.channel)) {
                 (*out)[out_ofs++] = 0xd0 | event->event_data.channel;
                 running_event = (*out)[out_ofs - 1];
@@ -758,8 +758,8 @@ _WM_Event2Midi(struct _mdi *mdi, uint8_t **out, uint32_t *outsize) {
             (*out)[out_ofs++] = event->event_data.data.value & 0xff;
             break;
         case ev_pitch:
-            // DEBUG
-            // fprintf(stderr,"Pitch: %u %.4x\r\n",event->event_data.channel, event->event_data.data);
+            /* DEBUG */
+            /* fprintf(stderr,"Pitch: %u %.4x\r\n",event->event_data.channel, event->event_data.data); */
             if (running_event != (0xe0 | event->event_data.channel)) {
                 (*out)[out_ofs++] = 0xe0 | event->event_data.channel;
                 running_event = (*out)[out_ofs - 1];
@@ -768,8 +768,8 @@ _WM_Event2Midi(struct _mdi *mdi, uint8_t **out, uint32_t *outsize) {
             (*out)[out_ofs++] = (event->event_data.data.value >> 7) & 0x7f;
             break;
         case ev_sysex_roland_drum_track: {
-            // DEBUG
-            // fprintf(stderr,"Sysex Roland Drum Track: %u %.4x\r\n",event->event_data.channel, event->event_data.data);
+            /* DEBUG */
+            /* fprintf(stderr,"Sysex Roland Drum Track: %u %.4x\r\n",event->event_data.channel, event->event_data.data); */
             uint8_t foo[] = {0xf0, 0x09, 0x41, 0x10, 0x42, 0x12, 0x40, 0x00, 0x15, 0x00, 0xf7};
             uint8_t foo_ch = event->event_data.channel;
             if (foo_ch == 9) {
@@ -784,32 +784,32 @@ _WM_Event2Midi(struct _mdi *mdi, uint8_t **out, uint32_t *outsize) {
             running_event = 0;
           } break;
         case ev_sysex_gm_reset: {
-            // DEBUG
-            // fprintf(stderr,"Sysex GM Reset\r\n");
+            /* DEBUG */
+            /* fprintf(stderr,"Sysex GM Reset\r\n"); */
             uint8_t foo[] = {0xf0, 0x05, 0x7e, 0x7f, 0x09, 0x01, 0xf7};
             memcpy(&((*out)[out_ofs]),foo,7);
             out_ofs += 7;
             running_event = 0;
           } break;
         case ev_sysex_roland_reset: {
-            // DEBUG
-            // fprintf(stderr,"Sysex Roland Reset\r\n");
+            /* DEBUG */
+            /* fprintf(stderr,"Sysex Roland Reset\r\n"); */
             uint8_t foo[] = {0xf0, 0x0a, 0x41, 0x10, 0x42, 0x12, 0x40, 0x00, 0x7f, 0x00, 0x41, 0xf7};
             memcpy(&((*out)[out_ofs]),foo,12);
             out_ofs += 12;
             running_event = 0;
           } break;
         case ev_sysex_yamaha_reset: {
-            // DEBUG
-            // fprintf(stderr,"Sysex Yamaha Reset\r\n");
+            /* DEBUG */
+            /* fprintf(stderr,"Sysex Yamaha Reset\r\n"); */
             uint8_t foo[] = {0xf0, 0x08, 0x43, 0x10, 0x4c, 0x00, 0x00, 0x7e, 0x00, 0xf7};
             memcpy(&((*out)[out_ofs]),foo,10);
             out_ofs += 10;
             running_event = 0;
           } break;
         case ev_meta_endoftrack:
-            // DEBUG
-            // fprintf(stderr,"End Of Track\r\n");
+            /* DEBUG */
+            /* fprintf(stderr,"End Of Track\r\n"); */
             if ((!(_WM_MixerOptions & WM_MO_SAVEASTYPE0)) && (mdi->is_type2)) {
                 /* Write end of track marker */
                 (*out)[out_ofs++] = 0xff;
@@ -838,14 +838,14 @@ _WM_Event2Midi(struct _mdi *mdi, uint8_t **out, uint32_t *outsize) {
             }
             goto NEXT_EVENT;
         case ev_meta_tempo:
-            // DEBUG
-            // fprintf(stderr,"Tempo: %u\r\n",event->event_data.data);
+            /* DEBUG */
+            /* fprintf(stderr,"Tempo: %u\r\n",event->event_data.data); */
             tempo = event->event_data.data.value & 0xffffff;
 
             samples_per_tick = _WM_GetSamplesPerTick(divisions, tempo);
 
-            //DEBUG
-            //fprintf(stderr,"\rDEBUG: div %i, tempo %i, bpm %f, pps %f, spd %f\r\n", divisions, tempo, bpm_f, pulses_per_second_f, samples_per_delta_f);
+            /* DEBUG */
+            /* fprintf(stderr,"\rDEBUG: div %i, tempo %i, bpm %f, pps %f, spd %f\r\n", divisions, tempo, bpm_f, pulses_per_second_f, samples_per_delta_f); */
 
             (*out)[out_ofs++] = 0xff;
             (*out)[out_ofs++] = 0x51;
@@ -855,8 +855,8 @@ _WM_Event2Midi(struct _mdi *mdi, uint8_t **out, uint32_t *outsize) {
             (*out)[out_ofs++] = (tempo & 0xff);
             break;
         case ev_meta_timesignature:
-            // DEBUG
-            // fprintf(stderr,"Time Signature: %x\r\n",event->event_data.data);
+            /* DEBUG */
+            /* fprintf(stderr,"Time Signature: %x\r\n",event->event_data.data); */
             (*out)[out_ofs++] = 0xff;
             (*out)[out_ofs++] = 0x58;
             (*out)[out_ofs++] = 0x04;
@@ -866,8 +866,8 @@ _WM_Event2Midi(struct _mdi *mdi, uint8_t **out, uint32_t *outsize) {
             (*out)[out_ofs++] = (event->event_data.data.value & 0xff);
             break;
         case ev_meta_keysignature:
-            // DEBUG
-            // fprintf(stderr,"Key Signature: %x\r\n",event->event_data.data);
+            /* DEBUG */
+            /* fprintf(stderr,"Key Signature: %x\r\n",event->event_data.data); */
             (*out)[out_ofs++] = 0xff;
             (*out)[out_ofs++] = 0x59;
             (*out)[out_ofs++] = 0x02;
@@ -875,8 +875,8 @@ _WM_Event2Midi(struct _mdi *mdi, uint8_t **out, uint32_t *outsize) {
             (*out)[out_ofs++] = (event->event_data.data.value & 0xff);
             break;
         case ev_meta_sequenceno:
-            // DEBUG
-            // fprintf(stderr,"Sequence Number: %x\r\n",event->event_data.data);
+            /* DEBUG */
+            /* fprintf(stderr,"Sequence Number: %x\r\n",event->event_data.data); */
             (*out)[out_ofs++] = 0xff;
             (*out)[out_ofs++] = 0x00;
             (*out)[out_ofs++] = 0x02;
@@ -884,24 +884,24 @@ _WM_Event2Midi(struct _mdi *mdi, uint8_t **out, uint32_t *outsize) {
             (*out)[out_ofs++] = (event->event_data.data.value & 0xff);
             break;
         case ev_meta_channelprefix:
-            // DEBUG
-            // fprintf(stderr,"Channel Prefix: %x\r\n",event->event_data.data);
+            /* DEBUG */
+            /* fprintf(stderr,"Channel Prefix: %x\r\n",event->event_data.data); */
             (*out)[out_ofs++] = 0xff;
             (*out)[out_ofs++] = 0x20;
             (*out)[out_ofs++] = 0x01;
             (*out)[out_ofs++] = (event->event_data.data.value & 0xff);
             break;
         case ev_meta_portprefix:
-            // DEBUG
-            // fprintf(stderr,"Port Prefix: %x\r\n",event->event_data.data);
+            /* DEBUG */
+            /* fprintf(stderr,"Port Prefix: %x\r\n",event->event_data.data); */
             (*out)[out_ofs++] = 0xff;
             (*out)[out_ofs++] = 0x21;
             (*out)[out_ofs++] = 0x01;
             (*out)[out_ofs++] = (event->event_data.data.value & 0xff);
             break;
         case ev_meta_smpteoffset:
-            // DEBUG
-            // fprintf(stderr,"SMPTE Offset: %x\r\n",event->event_data.data);
+            /* DEBUG */
+            /* fprintf(stderr,"SMPTE Offset: %x\r\n",event->event_data.data); */
             (*out)[out_ofs++] = 0xff;
             (*out)[out_ofs++] = 0x54;
             (*out)[out_ofs++] = 0x05;
@@ -972,8 +972,8 @@ _WM_Event2Midi(struct _mdi *mdi, uint8_t **out, uint32_t *outsize) {
             break;
 
         default:
-            // DEBUG
-            // fprintf(stderr,"Unknown Event %.2x %.4x\n",event->event_data.channel, event->event_data.data.value);
+            /* DEBUG */
+            /* fprintf(stderr,"Unknown Event %.2x %.4x\n",event->event_data.channel, event->event_data.data.value); */
             event++;
             continue;
         }
@@ -981,8 +981,8 @@ _WM_Event2Midi(struct _mdi *mdi, uint8_t **out, uint32_t *outsize) {
         value_f = (float)event->samples_to_next / samples_per_tick;
         value = (uint32_t) (value_f + 0.5f);
 
-        //DEBUG
-        //fprintf(stderr,"\rDEBUG: STN %i, SPD %f, Delta %i\r\n", event->samples_to_next, samples_per_delta_f, value);
+        /* DEBUG */
+        /* fprintf(stderr,"\rDEBUG: STN %i, SPD %f, Delta %i\r\n", event->samples_to_next, samples_per_delta_f, value); */
 
         if (value > 0x0fffffff)
             (*out)[out_ofs++] = (((value >> 28) &0x7f) | 0x80);

--- a/src/f_midi.c
+++ b/src/f_midi.c
@@ -38,12 +38,12 @@
 
 
 struct _mdi *
-_WM_ParseNewMidi(uint8_t *midi_data, uint32_t midi_size) {
+_WM_ParseNewMidi(const uint8_t *midi_data, uint32_t midi_size) {
     struct _mdi *mdi;
 
     uint32_t tmp_val;
     uint32_t midi_type;
-    uint8_t **tracks;
+    const uint8_t **tracks;
     uint32_t *track_size;
     uint32_t end_of_tracks = 0;
     uint32_t no_tracks;
@@ -146,7 +146,7 @@ _WM_ParseNewMidi(uint8_t *midi_data, uint32_t midi_size) {
     mdi = _WM_initMDI();
     _WM_midi_setup_divisions(mdi,divisions);
 
-    tracks = (uint8_t **) malloc(sizeof(uint8_t *) * no_tracks);
+    tracks = (const uint8_t **) malloc(sizeof(uint8_t *) * no_tracks);
     track_size = (uint32_t *) malloc(sizeof(uint32_t) * no_tracks);
     track_delta = (uint32_t *) malloc(sizeof(uint32_t) * no_tracks);
     track_end = (uint8_t *) malloc(sizeof(uint8_t) * no_tracks);

--- a/src/f_midi.c
+++ b/src/f_midi.c
@@ -65,13 +65,13 @@ _WM_ParseNewMidi(uint8_t *midi_data, uint32_t midi_size) {
     uint32_t setup_ret = 0;
 
     if (midi_size < 14) {
-        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_CORUPT, "(too short)", 0);
+        _WM_GLOBAL_ERROR(WM_ERR_CORUPT, "(too short)", 0);
         return (NULL);
     }
 
     if (!memcmp(midi_data, "RIFF", 4)) {
         if (midi_size < 34) {
-            _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_CORUPT, "(too short)", 0);
+            _WM_GLOBAL_ERROR(WM_ERR_CORUPT, "(too short)", 0);
             return (NULL);
         }
         midi_data += 20;
@@ -79,7 +79,7 @@ _WM_ParseNewMidi(uint8_t *midi_data, uint32_t midi_size) {
     }
 
     if (memcmp(midi_data, "MThd", 4)) {
-        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_NOT_MIDI, NULL, 0);
+        _WM_GLOBAL_ERROR(WM_ERR_NOT_MIDI, NULL, 0);
         return (NULL);
     }
     midi_data += 4;
@@ -94,7 +94,7 @@ _WM_ParseNewMidi(uint8_t *midi_data, uint32_t midi_size) {
     tmp_val |= *midi_data++;
     midi_size -= 4;
     if (tmp_val != 6) {
-        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_CORUPT, NULL, 0);
+        _WM_GLOBAL_ERROR(WM_ERR_CORUPT, NULL, 0);
         return (NULL);
     }
 
@@ -105,7 +105,7 @@ _WM_ParseNewMidi(uint8_t *midi_data, uint32_t midi_size) {
     tmp_val |= *midi_data++;
     midi_size -= 2;
     if (tmp_val > 2) {
-        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_INVALID, NULL, 0);
+        _WM_GLOBAL_ERROR(WM_ERR_INVALID, NULL, 0);
         return (NULL);
     }
     midi_type = tmp_val;
@@ -117,7 +117,7 @@ _WM_ParseNewMidi(uint8_t *midi_data, uint32_t midi_size) {
     tmp_val |= *midi_data++;
     midi_size -= 2;
     if (tmp_val < 1) {
-        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_CORUPT, "(no tracks)", 0);
+        _WM_GLOBAL_ERROR(WM_ERR_CORUPT, "(no tracks)", 0);
         return (NULL);
     }
     no_tracks = tmp_val;
@@ -126,7 +126,7 @@ _WM_ParseNewMidi(uint8_t *midi_data, uint32_t midi_size) {
      * Check that type 0 midi file has only 1 track
      */
     if ((midi_type == 0) && (no_tracks > 1)) {
-        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_INVALID, "(expected 1 track for type 0 midi file, found more)", 0);
+        _WM_GLOBAL_ERROR(WM_ERR_INVALID, "(expected 1 track for type 0 midi file, found more)", 0);
         return (NULL);
     }
 
@@ -137,7 +137,7 @@ _WM_ParseNewMidi(uint8_t *midi_data, uint32_t midi_size) {
     divisions |= *midi_data++;
     midi_size -= 2;
     if (divisions & 0x00008000) {
-        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_INVALID, NULL, 0);
+        _WM_GLOBAL_ERROR(WM_ERR_INVALID, NULL, 0);
         return (NULL);
     }
 
@@ -155,11 +155,11 @@ _WM_ParseNewMidi(uint8_t *midi_data, uint32_t midi_size) {
     smallest_delta = 0x7fffffff;
     for (i = 0; i < no_tracks; i++) {
         if (midi_size < 8) {
-            _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_CORUPT, "(too short)", 0);
+            _WM_GLOBAL_ERROR(WM_ERR_CORUPT, "(too short)", 0);
             goto _end;
         }
         if (memcmp(midi_data, "MTrk", 4) != 0) {
-            _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_CORUPT, "(missing track header)", 0);
+            _WM_GLOBAL_ERROR(WM_ERR_CORUPT, "(missing track header)", 0);
             goto _end;
         }
         midi_data += 4;
@@ -172,11 +172,11 @@ _WM_ParseNewMidi(uint8_t *midi_data, uint32_t midi_size) {
         tmp_val |= *midi_data++;
         midi_size -= 4;
         if (midi_size < tmp_val) {
-            _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_CORUPT, "(too short)", 0);
+            _WM_GLOBAL_ERROR(WM_ERR_CORUPT, "(too short)", 0);
             goto _end;
         }
         if (tmp_val < 3) {
-            _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_CORUPT, "(bad track size)", 0);
+            _WM_GLOBAL_ERROR(WM_ERR_CORUPT, "(bad track size)", 0);
             goto _end;
         }
         if ((midi_data[tmp_val - 3] != 0xFF) ||
@@ -195,7 +195,7 @@ _WM_ParseNewMidi(uint8_t *midi_data, uint32_t midi_size) {
                     (midi_data[tmp_val - 4] != 0xFF) ||
                     (midi_data[tmp_val - 3] != 0x2F) ||
                     (midi_data[tmp_val - 2] != 0x00)) {
-                    _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_CORUPT, "(missing EOT)", 0);
+                    _WM_GLOBAL_ERROR(WM_ERR_CORUPT, "(missing EOT)", 0);
                     goto _end;
                 }
             }
@@ -233,7 +233,7 @@ _WM_ParseNewMidi(uint8_t *midi_data, uint32_t midi_size) {
     if (smallest_delta >= 0x7fffffff) {
         //DEBUG
         //fprintf(stderr,"CRAZY SMALLEST DELTA %u\n", smallest_delta);
-        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_CORUPT, NULL, 0);
+        _WM_GLOBAL_ERROR(WM_ERR_CORUPT, NULL, 0);
         goto _end;
     }
 
@@ -241,7 +241,7 @@ _WM_ParseNewMidi(uint8_t *midi_data, uint32_t midi_size) {
         //DEBUG
         //fprintf(stderr,"INTEGER OVERFLOW (samples_per_delta: %f, smallest_delta: %u)\n",
         //        samples_per_delta_f, smallest_delta);
-        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_CORUPT, NULL, 0);
+        _WM_GLOBAL_ERROR(WM_ERR_CORUPT, NULL, 0);
         goto _end;
     }
 
@@ -312,7 +312,7 @@ _WM_ParseNewMidi(uint8_t *midi_data, uint32_t midi_size) {
                         } while (*tracks[i] > 0x7f);
                     }
                     if (!track_size[i]) {
-                        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_CORUPT, "(too short)", 0);
+                        _WM_GLOBAL_ERROR(WM_ERR_CORUPT, "(too short)", 0);
                         goto _end;
                     }
                     track_delta[i] = (track_delta[i] << 7) + (*tracks[i] & 0x7F);
@@ -329,7 +329,7 @@ _WM_ParseNewMidi(uint8_t *midi_data, uint32_t midi_size) {
                 //DEBUG
                 //fprintf(stderr,"INTEGER OVERFLOW (samples_per_delta: %f, smallest_delta: %u)\n",
                 //        samples_per_delta_f, smallest_delta);
-                _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_CORUPT, NULL, 0);
+                _WM_GLOBAL_ERROR(WM_ERR_CORUPT, NULL, 0);
                 goto _end;
             }
             subtract_delta = smallest_delta;
@@ -388,7 +388,7 @@ _WM_ParseNewMidi(uint8_t *midi_data, uint32_t midi_size) {
                 }
                 if (!track_size[i]) {
                     if (midi_type != 0) {
-                        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_CORUPT, "(too short)", 0);
+                        _WM_GLOBAL_ERROR(WM_ERR_CORUPT, "(too short)", 0);
                         goto _end;
                     } else {
                         track_end[i] = 1;
@@ -403,7 +403,7 @@ _WM_ParseNewMidi(uint8_t *midi_data, uint32_t midi_size) {
                     //DEBUG
                     //fprintf(stderr,"INTEGER OVERFLOW (samples_per_delta: %f, smallest_delta: %u)\n",
                     //        samples_per_delta_f, smallest_delta);
-                    _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_CORUPT, NULL, 0);
+                    _WM_GLOBAL_ERROR(WM_ERR_CORUPT, NULL, 0);
                     goto _end;
                 }
                 sample_count_f = (((float) track_delta[i] * samples_per_delta_f)
@@ -422,7 +422,7 @@ _WM_ParseNewMidi(uint8_t *midi_data, uint32_t midi_size) {
     if ((mdi->reverb = _WM_init_reverb(_WM_SampleRate, _WM_reverb_room_width,
             _WM_reverb_room_length, _WM_reverb_listen_posx, _WM_reverb_listen_posy))
           == NULL) {
-        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_MEM, NULL, 0);
+        _WM_GLOBAL_ERROR(WM_ERR_MEM, NULL, 0);
         goto _end;
     }
 
@@ -476,7 +476,7 @@ _WM_Event2Midi(struct _mdi *mdi, uint8_t **out, uint32_t *outsize) {
     uint32_t track_count = 0;
 
     if (!mdi->event_count) {
-        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_CONVERT, "(No events to convert)", 0);
+        _WM_GLOBAL_ERROR(WM_ERR_CONVERT, "(No events to convert)", 0);
         return -1;
     }
 

--- a/src/f_mus.c
+++ b/src/f_mus.c
@@ -72,12 +72,12 @@ _WM_ParseNewMus(uint8_t *mus_data, uint32_t mus_size) {
     uint16_t pitchbend_tmp = 0;
 
     if (mus_size < 18) {
-        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_CORUPT, "file too short", 0);
+        _WM_GLOBAL_ERROR(WM_ERR_CORUPT, "file too short", 0);
         return NULL;
     }
 
     if (memcmp(mus_data, mus_hdr, 4)) {
-        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_NOT_MUS, NULL, 0);
+        _WM_GLOBAL_ERROR(WM_ERR_NOT_MUS, NULL, 0);
         return NULL;
     }
 
@@ -101,7 +101,7 @@ _WM_ParseNewMus(uint8_t *mus_data, uint32_t mus_size) {
 
     // Check that we have enough data to check the rest
     if (mus_size < (mus_data_ofs + (mus_no_instr << 1) + mus_song_len)) {
-        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_CORUPT, "file too short", 0);
+        _WM_GLOBAL_ERROR(WM_ERR_CORUPT, "file too short", 0);
         return NULL;
     }
 
@@ -351,7 +351,7 @@ _WM_ParseNewMus(uint8_t *mus_data, uint32_t mus_size) {
 _mus_end_of_song:
     // Finalise mdi structure
     if ((mus_mdi->reverb = _WM_init_reverb(_WM_SampleRate, _WM_reverb_room_width, _WM_reverb_room_length, _WM_reverb_listen_posx, _WM_reverb_listen_posy)) == NULL) {
-        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_MEM, NULL, 0);
+        _WM_GLOBAL_ERROR(WM_ERR_MEM, NULL, 0);
         goto _mus_end;
     }
     _WM_midi_setup_endoftrack(mus_mdi);

--- a/src/f_mus.c
+++ b/src/f_mus.c
@@ -81,41 +81,41 @@ _WM_ParseNewMus(uint8_t *mus_data, uint32_t mus_size) {
         return NULL;
     }
 
-    // Get Song Length
+    /* Get Song Length */
     mus_song_len = (mus_data[5] << 8) | mus_data[4];
-    // Get Song Offset
+    /* Get Song Offset */
     mus_song_ofs = (mus_data[7] << 8) | mus_data[6];
 
-    // Have yet to determine what this actually is.
+    /* Have yet to determine what this actually is. */
     mus_ch_cnt1 = (mus_data[9] << 8) | mus_data[8];
     mus_ch_cnt2 = (mus_data[11] << 8) | mus_data[10];
 
     WMIDI_UNUSED(mus_ch_cnt1);
     WMIDI_UNUSED(mus_ch_cnt2);
 
-    // Number of instruments defined
+    /* Number of instruments defined */
     mus_no_instr = (mus_data[13] << 8) | mus_data[12];
 
-    // Skip next 2 data bytes
+    /* Skip next 2 data bytes */
     mus_data_ofs = 16;
 
-    // Check that we have enough data to check the rest
+    /* Check that we have enough data to check the rest */
     if (mus_size < (mus_data_ofs + (mus_no_instr << 1) + mus_song_len)) {
         _WM_GLOBAL_ERROR(WM_ERR_CORUPT, "file too short", 0);
         return NULL;
     }
 
-    // Instrument definition
+    /* Instrument definition */
     mus_mid_instr = (uint16_t *) malloc(mus_no_instr * sizeof(uint16_t));
     for (mus_instr_cnt = 0; mus_instr_cnt < mus_no_instr; mus_instr_cnt++) {
         mus_mid_instr[mus_instr_cnt] = (mus_data[mus_data_ofs + 1] << 8) | mus_data[mus_data_ofs];
         mus_data_ofs += 2;
     }
 
-    // make sure we are at song offset
+    /* make sure we are at song offset */
     mus_data_ofs = mus_song_ofs;
 
-    // do some calculations so we know how many samples per mus tick
+    /* do some calculations so we know how many samples per mus tick */
     mus_freq = _cvt_get_option(WM_CO_FREQUENCY);
     if (mus_freq == 0) mus_freq = 140;
 
@@ -127,18 +127,18 @@ _WM_ParseNewMus(uint8_t *mus_data, uint32_t mus_size) {
 
     samples_per_tick_f = _WM_GetSamplesPerTick(mus_divisions, (uint32_t)tempo_f);
 
-    // initialise the mdi structure
+    /* initialise the mdi structure */
     mus_mdi = _WM_initMDI();
     _WM_midi_setup_divisions(mus_mdi, mus_divisions);
     _WM_midi_setup_tempo(mus_mdi, (uint32_t)tempo_f);
 
-    // lets do this
+    /* lets do this */
     do {
-     // Build the event
+     /* Build the event */
     _mus_build_event:
 #if 1
-        // Mus drums happen on channel 15, swap channel 9 & 15
-        // DEBUG
+        /* Mus drums happen on channel 15, swap channel 9 & 15 */
+        /* DEBUG */
         MUS_EVENT_DEBUG("Before", mus_data[mus_data_ofs], 0);
 
         if ((mus_data[mus_data_ofs] & 0x0f) == 0x0f) {
@@ -146,27 +146,27 @@ _WM_ParseNewMus(uint8_t *mus_data, uint32_t mus_size) {
         } else if ((mus_data[mus_data_ofs] & 0x0f) == 0x09) {
             mus_data[mus_data_ofs] = (mus_data[mus_data_ofs] & 0xf0) | 0x0f;
         }
-        // DEBUG
+        /* DEBUG */
         MUS_EVENT_DEBUG("After", mus_data[mus_data_ofs], 0);
 #endif
         switch ((mus_data[mus_data_ofs] >> 4) & 0x07) {
-            case 0: // Note Off
+            case 0: /* Note Off */
                 mus_event_size = 2;
                 mus_event[0] = 0x80 | (mus_data[mus_data_ofs] & 0x0f);
                 mus_event[1] = mus_data[mus_data_ofs + 1];
                 mus_event[2] = 0;
                 mus_event[3] = 0;
                 break;
-            case 1: // Note On
+            case 1: /* Note On */
                 if (mus_data[mus_data_ofs + 1] & 0x80) {
                     mus_event_size = 3;
                     mus_event[0] = 0x90 | (mus_data[mus_data_ofs] & 0x0f);
                     mus_event[1] = mus_data[mus_data_ofs + 1] & 0x7f;
                     mus_event[2] = mus_data[mus_data_ofs + 2];
-                    // The maximum volume is 127, but it is encoded as
-                    // a byte. Some songs erroneously use values higher
-                    // than 127, so we have to clamp them down.
-                    // https://github.com/Mindwerks/wildmidi/pull/226
+                    /* The maximum volume is 127, but it is encoded as
+                       a byte. Some songs erroneously use values higher
+                       than 127, so we have to clamp them down.
+                       https://github.com/Mindwerks/wildmidi/pull/226 */
                     if (mus_event[2] > 0x7f) mus_event[2] = 0x7f;
                     mus_event[3] = 0;
                     mus_prev_vol[mus_data[mus_data_ofs] & 0x0f] = mus_event[2];
@@ -178,7 +178,7 @@ _WM_ParseNewMus(uint8_t *mus_data, uint32_t mus_size) {
                     mus_event[3] = 0;
                 }
                 break;
-            case 2: // Pitch Bend
+            case 2: /* Pitch Bend */
                 mus_event_size = 2;
                 mus_event[0] = 0xe0 | (mus_data[mus_data_ofs] & 0x0f);
 
@@ -190,19 +190,19 @@ _WM_ParseNewMus(uint8_t *mus_data, uint32_t mus_size) {
             case 3:
                 mus_event_size = 2;
                 switch (mus_data[mus_data_ofs + 1]) {
-                    case 10: // All Sounds Off
+                    case 10: /* All Sounds Off */
                         mus_event[0] = 0xb0 | (mus_data[mus_data_ofs] & 0x0f);
                         mus_event[1] = 120;
                         mus_event[2] = 0;
                         mus_event[3] = 0;
                         break;
-                    case 11: // All Notes Off
+                    case 11: /* All Notes Off */
                         mus_event[0] = 0xb0 | (mus_data[mus_data_ofs] & 0x0f);
                         mus_event[1] = 123;
                         mus_event[2] = 0;
                         mus_event[3] = 0;
                         break;
-                    case 12: // Mono (Not supported by WildMIDI)
+                    case 12: /* Mono (Not supported by WildMIDI) */
                         /*
                          **************************
                          FIXME: Add dummy mdi event
@@ -213,7 +213,7 @@ _WM_ParseNewMus(uint8_t *mus_data, uint32_t mus_size) {
                         mus_event[2] = 0;
                         mus_event[3] = 0;
                         break;
-                    case 13: // Poly (Not supported by WildMIDI)
+                    case 13: /* Poly (Not supported by WildMIDI) */
                         /*
                          **************************
                          FIXME: Add dummy mdi event
@@ -224,20 +224,20 @@ _WM_ParseNewMus(uint8_t *mus_data, uint32_t mus_size) {
                         mus_event[2] = 0;
                         mus_event[3] = 0;
                         break;
-                    case 14: // Reset All Controllers
+                    case 14: /* Reset All Controllers */
                         mus_event[0] = 0xb0 | (mus_data[mus_data_ofs] & 0x0f);
                         mus_event[1] = 121;
                         mus_event[2] = 0;
                         mus_event[3] = 0;
                         break;
-                    default: // Unsupported
+                    default: /* Unsupported */
                         goto _mus_next_data;
                 }
                 break;
             case 4:
                 mus_event_size = 3;
                 switch (mus_data[mus_data_ofs + 1]) {
-                    case 0: // Patch
+                    case 0: /* Patch */
                         /*
                          *************************************************
                          FIXME: Check if setting is MIDI or MUS instrument
@@ -248,66 +248,66 @@ _WM_ParseNewMus(uint8_t *mus_data, uint32_t mus_size) {
                         mus_event[2] = 0;
                         mus_event[3] = 0;
                         break;
-                    case 1: // Bank Select
+                    case 1: /* Bank Select */
                         mus_event[0] = 0xb0 | (mus_data[mus_data_ofs] & 0x0f);
                         mus_event[1] = 0;
                         mus_event[2] = mus_data[mus_data_ofs + 2];
                         mus_event[3] = 0;
                         break;
-                    case 2: // Modulation (Not supported by WildMidi)
+                    case 2: /* Modulation (Not supported by WildMidi) */
                         mus_event[0] = 0xb0 | (mus_data[mus_data_ofs] & 0x0f);
                         mus_event[1] = 1;
                         mus_event[2] = mus_data[mus_data_ofs + 2];
                         mus_event[3] = 0;
                         break;
-                    case 3: // Volume
+                    case 3: /* Volume */
                         mus_event[0] = 0xb0 | (mus_data[mus_data_ofs] & 0x0f);
                         mus_event[1] = 7;
                         mus_event[2] = mus_data[mus_data_ofs + 2];
-                        // The maximum volume is 127, but it is encoded as
-                        // a byte. Some songs erroneously use values higher
-                        // than 127, so we have to clamp them down.
-                        // https://github.com/Mindwerks/wildmidi/pull/226
+                        /* The maximum volume is 127, but it is encoded as
+                           a byte. Some songs erroneously use values higher
+                           than 127, so we have to clamp them down.
+                           https://github.com/Mindwerks/wildmidi/pull/226 */
                         if (mus_event[2] > 0x7f) mus_event[2] = 0x7f;
                         mus_event[3] = 0;
                         break;
-                    case 4: // Pan
+                    case 4: /* Pan */
                         mus_event[0] = 0xb0 | (mus_data[mus_data_ofs] & 0x0f);
                         mus_event[1] = 10;
                         mus_event[2] = mus_data[mus_data_ofs + 2];
                         mus_event[3] = 0;
                         break;
-                    case 5: // Expression
+                    case 5: /* Expression */
                         mus_event[0] = 0xb0 | (mus_data[mus_data_ofs] & 0x0f);
                         mus_event[1] = 11;
                         mus_event[2] = mus_data[mus_data_ofs + 2];
                         mus_event[3] = 0;
                         break;
-                    case 6: // Reverb (Not supported by WildMidi)
+                    case 6: /* Reverb (Not supported by WildMidi) */
                         mus_event[0] = 0xb0 | (mus_data[mus_data_ofs] & 0x0f);
                         mus_event[1] = 91;
                         mus_event[2] = mus_data[mus_data_ofs + 2];
                         mus_event[3] = 0;
                         break;
-                    case 7: // Chorus (Not supported by WildMidi)
+                    case 7: /* Chorus (Not supported by WildMidi) */
                         mus_event[0] = 0xb0 | (mus_data[mus_data_ofs] & 0x0f);
                         mus_event[1] = 93;
                         mus_event[2] = mus_data[mus_data_ofs + 2];
                         mus_event[3] = 0;
                         break;
-                    case 8: // Sustain
+                    case 8: /* Sustain */
                         mus_event[0] = 0xb0 | (mus_data[mus_data_ofs] & 0x0f);
                         mus_event[1] = 64;
                         mus_event[2] = mus_data[mus_data_ofs + 2];
                         mus_event[3] = 0;
                         break;
-                    case 9: // Soft Peddle (Not supported by WildMidi)
+                    case 9: /* Soft Peddle (Not supported by WildMidi) */
                         mus_event[0] = 0xb0 | (mus_data[mus_data_ofs] & 0x0f);
                         mus_event[1] = 67;
                         mus_event[2] = mus_data[mus_data_ofs + 2];
                         mus_event[3] = 0;
                         break;
-                    default: // Unsupported
+                    default: /* Unsupported */
                         goto _mus_next_data;
                 }
                 break;
@@ -349,7 +349,7 @@ _WM_ParseNewMus(uint8_t *mus_data, uint32_t mus_size) {
     } while (mus_data_ofs < mus_size);
 
 _mus_end_of_song:
-    // Finalise mdi structure
+    /* Finalise mdi structure */
     if ((mus_mdi->reverb = _WM_init_reverb(_WM_SampleRate, _WM_reverb_room_width, _WM_reverb_room_length, _WM_reverb_listen_posx, _WM_reverb_listen_posy)) == NULL) {
         _WM_GLOBAL_ERROR(WM_ERR_MEM, NULL, 0);
         goto _mus_end;

--- a/src/f_xmidi.c
+++ b/src/f_xmidi.c
@@ -71,7 +71,7 @@ struct _mdi *_WM_ParseNewXmi(uint8_t *xmi_data, uint32_t xmi_size) {
     xmi_data += 4;
     xmi_size -= 4;
 
-    // bytes until next entry
+    /* bytes until next entry */
     xmi_tmpdata = *xmi_data++ << 24;
     xmi_tmpdata |= *xmi_data++ << 16;
     xmi_tmpdata |= *xmi_data++ << 8;
@@ -92,7 +92,7 @@ struct _mdi *_WM_ParseNewXmi(uint8_t *xmi_data, uint32_t xmi_size) {
     xmi_data += 4;
     xmi_size -= 4;
 
-    // number of forms contained after this point
+    /* number of forms contained after this point */
     xmi_formcnt = *xmi_data++;
     if (xmi_formcnt == 0) {
         _WM_GLOBAL_ERROR(WM_ERR_NOT_XMI, NULL, 0);
@@ -162,12 +162,12 @@ struct _mdi *_WM_ParseNewXmi(uint8_t *xmi_data, uint32_t xmi_size) {
         xmi_size -= 4;
         xmi_subformlen -= 4;
 
-        // Process Subform
+        /* Process Subform */
         do {
             if (!memcmp(xmi_data,"TIMB",4)) {
-                // Holds patch information
-                // FIXME: May not be needed for playback as EVNT seems to
-                //        hold patch events
+                /* Holds patch information */
+                /* FIXME: May not be needed for playback as EVNT seems to */
+                /*        hold patch events */
                 xmi_data += 4;
 
                 xmi_tmpdata = *xmi_data++ << 24;
@@ -179,8 +179,8 @@ struct _mdi *_WM_ParseNewXmi(uint8_t *xmi_data, uint32_t xmi_size) {
                 xmi_subformlen -= (8 + xmi_tmpdata);
 
             } else if (!memcmp(xmi_data,"RBRN",4)) {
-                // Unknown what this is
-                // FIXME: May not be needed for playback
+                /* Unknown what this is */
+                /* FIXME: May not be needed for playback */
                 xmi_data += 4;
 
                 xmi_tmpdata = *xmi_data++ << 24;
@@ -192,7 +192,7 @@ struct _mdi *_WM_ParseNewXmi(uint8_t *xmi_data, uint32_t xmi_size) {
                 xmi_subformlen -= (8 + xmi_tmpdata);
 
             } else if (!memcmp(xmi_data,"EVNT",4)) {
-                // EVNT is where all the MIDI music information is stored
+                /* EVNT is where all the MIDI music information is stored */
                 xmi_data += 4;
 
                 xmi_evnt_cnt++;
@@ -221,7 +221,7 @@ struct _mdi *_WM_ParseNewXmi(uint8_t *xmi_data, uint32_t xmi_size) {
                         xmi_subformlen--;
 
                         do {
-                            // determine delta till next event
+                            /* determine delta till next event */
                             if ((xmi_lowestdelta != 0) && (xmi_lowestdelta <= xmi_delta)) {
                                 xmi_tmpdata = xmi_lowestdelta;
                             } else {
@@ -229,9 +229,9 @@ struct _mdi *_WM_ParseNewXmi(uint8_t *xmi_data, uint32_t xmi_size) {
                             }
 
                             if ((float)xmi_tmpdata >= 0x7fffffff / xmi_samples_per_delta_f) {
-                                //DEBUG
-                                //fprintf(stderr,"INTEGER OVERFLOW (samples_per_delta: %f, smallest_delta: %u)\n",
-                                //        xmi_samples_per_delta_f, xmi_tmpdata);
+                                /* DEBUG */
+                                /* fprintf(stderr,"INTEGER OVERFLOW (samples_per_delta: %f, smallest_delta: %u)\n", */
+                                /*        xmi_samples_per_delta_f, xmi_tmpdata); */
                                 _WM_GLOBAL_ERROR(WM_ERR_CORUPT, NULL, 0);
                                 goto _xmi_end;
                             }
@@ -246,21 +246,21 @@ struct _mdi *_WM_ParseNewXmi(uint8_t *xmi_data, uint32_t xmi_size) {
 
                             xmi_lowestdelta = 0;
 
-                            // scan through on notes
+                            /* scan through on notes */
                             for (j = 0; j < (16*128); j++) {
-                                // only want notes that are on
+                                /* only want notes that are on */
                                 if (xmi_notelen[j] == 0) continue;
 
-                                // remove delta to next event from on notes
+                                /* remove delta to next event from on notes */
                                 xmi_notelen[j] -= xmi_tmpdata;
 
-                                // Check if we need to turn note off
+                                /* Check if we need to turn note off */
                                 if (xmi_notelen[j] == 0) {
                                     xmi_ch = j / 128;
                                     xmi_note = j - (xmi_ch * 128);
                                     _WM_midi_setup_noteoff(xmi_mdi, xmi_ch, xmi_note, 0);
                                 } else {
-                                    // otherwise work out new lowest delta
+                                    /* otherwise work out new lowest delta */
                                     if ((xmi_lowestdelta == 0) || (xmi_lowestdelta > xmi_notelen[j])) {
                                         xmi_lowestdelta = xmi_notelen[j];
                                     }
@@ -271,7 +271,7 @@ struct _mdi *_WM_ParseNewXmi(uint8_t *xmi_data, uint32_t xmi_size) {
 
                     } else {
                         if ((xmi_data[0] == 0xff) && (xmi_data[1] == 0x51) && (xmi_data[2] == 0x03)) {
-                            // Ignore tempo events
+                            /* Ignore tempo events */
                             setup_ret = 6;
                             goto _XMI_Next_Event;
                         }
@@ -280,7 +280,7 @@ struct _mdi *_WM_ParseNewXmi(uint8_t *xmi_data, uint32_t xmi_size) {
                         }
 
                         if ((*xmi_data & 0xf0) == 0x90) {
-                            // Note on has extra data stating note length
+                            /* Note on has extra data stating note length */
                             xmi_ch = *xmi_data & 0x0f;
                             xmi_note = xmi_data[1];
                             xmi_data += setup_ret;
@@ -303,7 +303,7 @@ struct _mdi *_WM_ParseNewXmi(uint8_t *xmi_data, uint32_t xmi_size) {
                             xmi_evntlen--;
                             xmi_subformlen--;
 
-                            // store length
+                            /* store length */
                             xmi_notelen[128 * xmi_ch + xmi_note] = xmi_tmpdata;
                             if ((xmi_tmpdata > 0) && ((xmi_lowestdelta == 0) || (xmi_tmpdata < xmi_lowestdelta))) {
                                 xmi_lowestdelta = xmi_tmpdata;
@@ -328,7 +328,7 @@ struct _mdi *_WM_ParseNewXmi(uint8_t *xmi_data, uint32_t xmi_size) {
         } while (xmi_subformlen);
     }
 
-    // Finalise mdi structure
+    /* Finalise mdi structure */
     if ((xmi_mdi->reverb = _WM_init_reverb(_WM_SampleRate, _WM_reverb_room_width, _WM_reverb_room_length, _WM_reverb_listen_posx, _WM_reverb_listen_posy)) == NULL) {
         _WM_GLOBAL_ERROR(WM_ERR_MEM, NULL, 0);
         goto _xmi_end;

--- a/src/f_xmidi.c
+++ b/src/f_xmidi.c
@@ -36,7 +36,7 @@
 #include "f_xmidi.h"
 
 
-struct _mdi *_WM_ParseNewXmi(uint8_t *xmi_data, uint32_t xmi_size) {
+struct _mdi *_WM_ParseNewXmi(const uint8_t *xmi_data, uint32_t xmi_size) {
     struct _mdi *xmi_mdi = NULL;
     uint32_t xmi_tmpdata = 0;
     uint8_t xmi_formcnt = 0;

--- a/src/f_xmidi.c
+++ b/src/f_xmidi.c
@@ -64,7 +64,7 @@ struct _mdi *_WM_ParseNewXmi(uint8_t *xmi_data, uint32_t xmi_size) {
 
 
     if (memcmp(xmi_data,"FORM",4)) {
-        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_NOT_XMI, NULL, 0);
+        _WM_GLOBAL_ERROR(WM_ERR_NOT_XMI, NULL, 0);
         return NULL;
     }
 
@@ -79,7 +79,7 @@ struct _mdi *_WM_ParseNewXmi(uint8_t *xmi_data, uint32_t xmi_size) {
     xmi_size -= 4;
 
     if (memcmp(xmi_data,"XDIRINFO",8)) {
-        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_NOT_XMI, NULL, 0);
+        _WM_GLOBAL_ERROR(WM_ERR_NOT_XMI, NULL, 0);
         return NULL;
     }
     xmi_data += 8;
@@ -95,7 +95,7 @@ struct _mdi *_WM_ParseNewXmi(uint8_t *xmi_data, uint32_t xmi_size) {
     // number of forms contained after this point
     xmi_formcnt = *xmi_data++;
     if (xmi_formcnt == 0) {
-        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_NOT_XMI, NULL, 0);
+        _WM_GLOBAL_ERROR(WM_ERR_NOT_XMI, NULL, 0);
         return NULL;
     }
     xmi_size--;
@@ -110,7 +110,7 @@ struct _mdi *_WM_ParseNewXmi(uint8_t *xmi_data, uint32_t xmi_size) {
 
     /* FIXME: Check: may not even need to process CAT information */
     if (memcmp(xmi_data,"CAT ",4)) {
-        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_NOT_XMI, NULL, 0);
+        _WM_GLOBAL_ERROR(WM_ERR_NOT_XMI, NULL, 0);
         return NULL;
     }
     xmi_data += 4;
@@ -125,7 +125,7 @@ struct _mdi *_WM_ParseNewXmi(uint8_t *xmi_data, uint32_t xmi_size) {
     WMIDI_UNUSED(xmi_catlen);
 
     if (memcmp(xmi_data,"XMID",4)) {
-        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_NOT_XMI, NULL, 0);
+        _WM_GLOBAL_ERROR(WM_ERR_NOT_XMI, NULL, 0);
         return NULL;
     }
     xmi_data += 4;
@@ -142,7 +142,7 @@ struct _mdi *_WM_ParseNewXmi(uint8_t *xmi_data, uint32_t xmi_size) {
 
     for (i = 0; i < xmi_formcnt; i++) {
         if (memcmp(xmi_data,"FORM",4)) {
-            _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_NOT_XMI, NULL, 0);
+            _WM_GLOBAL_ERROR(WM_ERR_NOT_XMI, NULL, 0);
             goto _xmi_end;
         }
         xmi_data += 4;
@@ -155,7 +155,7 @@ struct _mdi *_WM_ParseNewXmi(uint8_t *xmi_data, uint32_t xmi_size) {
         xmi_size -= 4;
 
         if (memcmp(xmi_data,"XMID",4)) {
-            _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_NOT_XMI, NULL, 0);
+            _WM_GLOBAL_ERROR(WM_ERR_NOT_XMI, NULL, 0);
             goto _xmi_end;
         }
         xmi_data += 4;
@@ -232,7 +232,7 @@ struct _mdi *_WM_ParseNewXmi(uint8_t *xmi_data, uint32_t xmi_size) {
                                 //DEBUG
                                 //fprintf(stderr,"INTEGER OVERFLOW (samples_per_delta: %f, smallest_delta: %u)\n",
                                 //        xmi_samples_per_delta_f, xmi_tmpdata);
-                                _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_CORUPT, NULL, 0);
+                                _WM_GLOBAL_ERROR(WM_ERR_CORUPT, NULL, 0);
                                 goto _xmi_end;
                             }
 
@@ -321,7 +321,7 @@ struct _mdi *_WM_ParseNewXmi(uint8_t *xmi_data, uint32_t xmi_size) {
                 } while (xmi_evntlen);
 
             } else {
-                _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_NOT_XMI, NULL, 0);
+                _WM_GLOBAL_ERROR(WM_ERR_NOT_XMI, NULL, 0);
                 goto _xmi_end;
             }
 
@@ -330,7 +330,7 @@ struct _mdi *_WM_ParseNewXmi(uint8_t *xmi_data, uint32_t xmi_size) {
 
     // Finalise mdi structure
     if ((xmi_mdi->reverb = _WM_init_reverb(_WM_SampleRate, _WM_reverb_room_width, _WM_reverb_room_length, _WM_reverb_listen_posx, _WM_reverb_listen_posy)) == NULL) {
-        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_MEM, NULL, 0);
+        _WM_GLOBAL_ERROR(WM_ERR_MEM, NULL, 0);
         goto _xmi_end;
     }
     xmi_mdi->extra_info.current_sample = 0;

--- a/src/file_io.c
+++ b/src/file_io.c
@@ -151,7 +151,7 @@ void *_WM_BufferFileImpl(const char *filename, uint32_t *size) {
         if (home) {
             buffer_file = (char *) malloc(strlen(filename) + strlen(home) + 1);
             if (buffer_file == NULL) {
-                _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_MEM, NULL, errno);
+                _WM_GLOBAL_ERROR(WM_ERR_MEM, NULL, errno);
                 return NULL;
             }
             strcpy(buffer_file, home);
@@ -162,7 +162,7 @@ void *_WM_BufferFileImpl(const char *filename, uint32_t *size) {
         if (cwdresult != NULL)
             buffer_file = (char *) malloc(strlen(filename) + strlen(buffer_dir) + 2);
         if (buffer_file == NULL || cwdresult == NULL) {
-            _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_MEM, NULL, errno);
+            _WM_GLOBAL_ERROR(WM_ERR_MEM, NULL, errno);
             return NULL;
         }
         strcpy(buffer_file, buffer_dir);
@@ -175,7 +175,7 @@ void *_WM_BufferFileImpl(const char *filename, uint32_t *size) {
     if (buffer_file == NULL) {
         buffer_file = (char *) malloc(strlen(filename) + 1);
         if (buffer_file == NULL) {
-            _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_MEM, NULL, errno);
+            _WM_GLOBAL_ERROR(WM_ERR_MEM, NULL, errno);
             return NULL;
         }
         strcpy(buffer_file, filename);
@@ -183,14 +183,14 @@ void *_WM_BufferFileImpl(const char *filename, uint32_t *size) {
 
 #ifdef __DJGPP__
     if (findfirst(buffer_file, &f, FA_ARCH | FA_RDONLY) != 0) {
-        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_STAT, filename, errno);
+        _WM_GLOBAL_ERROR(WM_ERR_STAT, filename, errno);
         free(buffer_file);
         return NULL;
     }
     *size = f.ff_fsize;
 #elif defined(_WIN32)
     if ((h = FindFirstFileA(buffer_file, &wfd)) == INVALID_HANDLE_VALUE) {
-        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_STAT, filename, ENOENT);
+        _WM_GLOBAL_ERROR(WM_ERR_STAT, filename, ENOENT);
         free(buffer_file);
         return NULL;
     }
@@ -200,7 +200,7 @@ void *_WM_BufferFileImpl(const char *filename, uint32_t *size) {
     else *size = wfd.nFileSizeLow;
 #elif defined(__OS2__) || defined(__EMX__)
     if (DosFindFirst(buffer_file, &h, FILE_NORMAL, &fb, sizeof(fb), &cnt, FIL_STANDARD) != NO_ERROR) {
-        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_STAT, filename, ENOENT);
+        _WM_GLOBAL_ERROR(WM_ERR_STAT, filename, ENOENT);
         free(buffer_file);
         return NULL;
     }
@@ -208,14 +208,14 @@ void *_WM_BufferFileImpl(const char *filename, uint32_t *size) {
     *size = fb.cbFile;
 #elif defined(WILDMIDI_AMIGA)
     if ((filsize = AMIGA_filesize(buffer_file)) < 0) {
-        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_STAT, filename, ENOENT /* do better!! */);
+        _WM_GLOBAL_ERROR(WM_ERR_STAT, filename, ENOENT /* do better!! */);
         free(buffer_file);
         return NULL;
     }
     *size = filsize;
 #else
     if (stat(buffer_file, &buffer_stat)) {
-        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_STAT, filename, errno);
+        _WM_GLOBAL_ERROR(WM_ERR_STAT, filename, errno);
         free(buffer_file);
         return NULL;
     }
@@ -227,7 +227,7 @@ void *_WM_BufferFileImpl(const char *filename, uint32_t *size) {
 
     if (__builtin_expect((*size > WM_MAXFILESIZE), 0)) {
         /* don't bother loading suspiciously long files */
-        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_LONGFIL, filename, 0);
+        _WM_GLOBAL_ERROR(WM_ERR_LONGFIL, filename, 0);
         free(buffer_file);
         return NULL;
     }
@@ -235,20 +235,20 @@ void *_WM_BufferFileImpl(const char *filename, uint32_t *size) {
     /* +1 needed for parsing text files without a newline at the end */
     data = (uint8_t *) malloc(*size + 1);
     if (data == NULL) {
-        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_MEM, NULL, errno);
+        _WM_GLOBAL_ERROR(WM_ERR_MEM, NULL, errno);
         free(buffer_file);
         return NULL;
     }
 
 #if defined(WILDMIDI_AMIGA)
     if (!(buffer_fd = AMIGA_open(buffer_file))) {
-        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_OPEN, filename, ENOENT /* do better!! */);
+        _WM_GLOBAL_ERROR(WM_ERR_OPEN, filename, ENOENT /* do better!! */);
         free(buffer_file);
         free(data);
         return NULL;
     }
     if (AMIGA_read(buffer_fd, data, filsize) != filsize) {
-        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_READ, filename, EIO /* do better!! */);
+        _WM_GLOBAL_ERROR(WM_ERR_READ, filename, EIO /* do better!! */);
         free(buffer_file);
         free(data);
         AMIGA_close(buffer_fd);
@@ -258,13 +258,13 @@ void *_WM_BufferFileImpl(const char *filename, uint32_t *size) {
     free(buffer_file);
 #else
     if ((buffer_fd = open(buffer_file,(O_RDONLY | O_BINARY))) == -1) {
-        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_OPEN, filename, errno);
+        _WM_GLOBAL_ERROR(WM_ERR_OPEN, filename, errno);
         free(buffer_file);
         free(data);
         return NULL;
     }
     if (read(buffer_fd, data, *size) != (long) *size) {
-        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_READ, filename, errno);
+        _WM_GLOBAL_ERROR(WM_ERR_READ, filename, errno);
         free(buffer_file);
         free(data);
         close(buffer_fd);

--- a/src/file_io.c
+++ b/src/file_io.c
@@ -129,13 +129,11 @@ void *_WM_BufferFileImpl(const char *filename, uint32_t *size) {
 #elif defined(WILDMIDI_AMIGA)
     BPTR buffer_fd;
     long filsize;
-#elif defined(_3DS) || defined(GEKKO) || defined(__vita__) || defined(__SWITCH__) || defined(__riscos__)
-    int buffer_fd;
-    struct stat buffer_stat;
-#else /* unix builds */
+#elif defined(_3DS) || defined(GEKKO) || defined(__vita__) || defined(__SWITCH__) || defined(__riscos__) || defined(unix) || defined(__unix) || defined(__unix__) || (defined(__APPLE__) && defined(__MACH__))
     int buffer_fd;
     struct stat buffer_stat;
 
+#if defined(unix) || defined(__unix) || defined(__unix__) || (defined(__APPLE__) && defined(__MACH__))
 /* for basedir of filename: */
     const char *home = NULL;
     struct passwd *pwd_ent;
@@ -170,7 +168,13 @@ void *_WM_BufferFileImpl(const char *filename, uint32_t *size) {
             strcat(buffer_file, "/");
         strcat(buffer_file, filename);
     }
-#endif /* unix builds */
+#endif
+
+#else
+    /* Standard C fallback */
+    FILE *file;
+    long ftell_result;
+#endif
 
     if (buffer_file == NULL) {
         buffer_file = (char *) malloc(strlen(filename) + 1);
@@ -213,7 +217,7 @@ void *_WM_BufferFileImpl(const char *filename, uint32_t *size) {
         return NULL;
     }
     *size = filsize;
-#else
+#elif defined(_3DS) || defined(GEKKO) || defined(__vita__) || defined(__SWITCH__) || defined(__riscos__) || defined(unix) || defined(__unix) || defined(__unix__) || (defined(__APPLE__) && defined(__MACH__))
     if (stat(buffer_file, &buffer_stat)) {
         _WM_GLOBAL_ERROR(WM_ERR_STAT, filename, errno);
         free(buffer_file);
@@ -223,6 +227,37 @@ void *_WM_BufferFileImpl(const char *filename, uint32_t *size) {
     if (buffer_stat.st_size > WM_MAXFILESIZE) /* too big */
         *size = 0xffffffff;
     else *size = buffer_stat.st_size;
+#else
+    /* Standard C fallback */
+    file = fopen(buffer_file, "rb");
+
+    if (file == NULL) {
+        _WM_GLOBAL_ERROR(WM_ERR_STAT, filename, errno);
+        free(buffer_file);
+        return NULL;
+    }
+
+    /* Technically undefined behaviour, but any sane implementation will allow this without issue. Besides, what choice do we have? */
+    if (fseek(file, 0, SEEK_END) != 0) {
+        _WM_GLOBAL_ERROR(WM_ERR_READ, filename, EIO);
+        free(buffer_file);
+        fclose(file);
+        return NULL;
+    }
+
+    ftell_result = ftell(file);
+
+    if (ftell_result == -1L) {
+        _WM_GLOBAL_ERROR(WM_ERR_READ, filename, EIO);
+        free(buffer_file);
+        fclose(file);
+        return NULL;
+    }
+
+    rewind(file);
+
+    /* 'long' can be a lot bigger than a 'uint32_t', so cap it. */
+    *size = ftell_result > WM_MAXFILESIZE ? 0xffffffff : ftell_result;
 #endif
 
     if (__builtin_expect((*size > WM_MAXFILESIZE), 0)) {
@@ -255,8 +290,7 @@ void *_WM_BufferFileImpl(const char *filename, uint32_t *size) {
         return NULL;
     }
     AMIGA_close(buffer_fd);
-    free(buffer_file);
-#else
+#elif defined(__DJGPP__) || defined(_WIN32) || defined(__OS2__) || defined(__EMX__) || defined(_3DS) || defined(GEKKO) || defined(__vita__) || defined(__SWITCH__) || defined(__riscos__) || defined(unix) || defined(__unix) || defined(__unix__) || (defined(__APPLE__) && defined(__MACH__))
     if ((buffer_fd = open(buffer_file,(O_RDONLY | O_BINARY))) == -1) {
         _WM_GLOBAL_ERROR(WM_ERR_OPEN, filename, errno);
         free(buffer_file);
@@ -271,8 +305,19 @@ void *_WM_BufferFileImpl(const char *filename, uint32_t *size) {
         return NULL;
     }
     close(buffer_fd);
-    free(buffer_file);
+#else
+    if (fread(data, 1, (size_t)*size, file) != (size_t)*size) {
+        _WM_GLOBAL_ERROR(WM_ERR_READ, filename, EIO);
+        free(buffer_file);
+        fclose(file);
+        free(data);
+        return NULL;
+    }
+
+    fclose(file);
 #endif
+
+    free(buffer_file);
 
     data[*size] = '\0';
     return data;

--- a/src/gus_pat.c
+++ b/src/gus_pat.c
@@ -73,7 +73,7 @@ static int convert_8s(uint8_t *data, struct _sample *gus_sample) {
         return 0;
     }
 
-    _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_MEM, NULL, errno);
+    _WM_GLOBAL_ERROR(WM_ERR_MEM, NULL, errno);
 
     return -1;
 }
@@ -124,7 +124,7 @@ static int convert_8sp(uint8_t *data, struct _sample *gus_sample) {
         return 0;
     }
 
-    _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_MEM, NULL, errno);
+    _WM_GLOBAL_ERROR(WM_ERR_MEM, NULL, errno);
     return -1;
 }
 
@@ -150,7 +150,7 @@ static int convert_8sr(uint8_t *data, struct _sample *gus_sample) {
         gus_sample->modes ^= SAMPLE_REVERSE;
         return 0;
     }
-    _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_MEM, NULL, errno);
+    _WM_GLOBAL_ERROR(WM_ERR_MEM, NULL, errno);
     return -1;
 }
 
@@ -201,7 +201,7 @@ static int convert_8srp(uint8_t *data, struct _sample *gus_sample) {
         return 0;
     }
 
-    _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_MEM, NULL, errno);
+    _WM_GLOBAL_ERROR(WM_ERR_MEM, NULL, errno);
     return -1;
 }
 
@@ -221,7 +221,7 @@ static int convert_8u(uint8_t *data, struct _sample *gus_sample) {
         gus_sample->modes ^= SAMPLE_UNSIGNED;
         return 0;
     }
-    _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_MEM, NULL, errno);
+    _WM_GLOBAL_ERROR(WM_ERR_MEM, NULL, errno);
     return -1;
 }
 
@@ -272,7 +272,7 @@ static int convert_8up(uint8_t *data, struct _sample *gus_sample) {
         return 0;
     }
 
-    _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_MEM, NULL, errno);
+    _WM_GLOBAL_ERROR(WM_ERR_MEM, NULL, errno);
     return -1;
 }
 
@@ -298,7 +298,7 @@ static int convert_8ur(uint8_t *data, struct _sample *gus_sample) {
         gus_sample->modes ^= SAMPLE_REVERSE | SAMPLE_UNSIGNED;
         return 0;
     }
-    _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_MEM, NULL, errno);
+    _WM_GLOBAL_ERROR(WM_ERR_MEM, NULL, errno);
     return -1;
 }
 
@@ -348,7 +348,7 @@ static int convert_8urp(uint8_t *data, struct _sample *gus_sample) {
         return 0;
     }
 
-    _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_MEM, NULL, errno);
+    _WM_GLOBAL_ERROR(WM_ERR_MEM, NULL, errno);
     return -1;
 }
 
@@ -372,7 +372,7 @@ static int convert_16s(uint8_t *data, struct _sample *gus_sample) {
         gus_sample->data_length >>= 1;
         return 0;
     }
-    _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_MEM, NULL, errno);
+    _WM_GLOBAL_ERROR(WM_ERR_MEM, NULL, errno);
     return -1;
 }
 
@@ -432,7 +432,7 @@ static int convert_16sp(uint8_t *data, struct _sample *gus_sample) {
         return 0;
     }
 
-    _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_MEM, NULL, errno);
+    _WM_GLOBAL_ERROR(WM_ERR_MEM, NULL, errno);
     return -1;
 }
 
@@ -462,7 +462,7 @@ static int convert_16sr(uint8_t *data, struct _sample *gus_sample) {
         gus_sample->modes ^= SAMPLE_REVERSE;
         return 0;
     }
-    _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_MEM, NULL, errno);
+    _WM_GLOBAL_ERROR(WM_ERR_MEM, NULL, errno);
     return -1;
 }
 
@@ -517,7 +517,7 @@ static int convert_16srp(uint8_t *data, struct _sample *gus_sample) {
         return 0;
     }
 
-    _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_MEM, NULL, errno);
+    _WM_GLOBAL_ERROR(WM_ERR_MEM, NULL, errno);
     return -1;
 }
 
@@ -541,7 +541,7 @@ static int convert_16u(uint8_t *data, struct _sample *gus_sample) {
         gus_sample->modes ^= SAMPLE_UNSIGNED;
         return 0;
     }
-    _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_MEM, NULL, errno);
+    _WM_GLOBAL_ERROR(WM_ERR_MEM, NULL, errno);
     return -1;
 }
 
@@ -601,7 +601,7 @@ static int convert_16up(uint8_t *data, struct _sample *gus_sample) {
         return 0;
     }
 
-    _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_MEM, NULL, errno);
+    _WM_GLOBAL_ERROR(WM_ERR_MEM, NULL, errno);
     return -1;
 }
 
@@ -631,7 +631,7 @@ static int convert_16ur(uint8_t *data, struct _sample *gus_sample) {
         gus_sample->modes ^= SAMPLE_REVERSE | SAMPLE_UNSIGNED;
         return 0;
     }
-    _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_MEM, NULL, errno);
+    _WM_GLOBAL_ERROR(WM_ERR_MEM, NULL, errno);
     return -1;
 }
 
@@ -686,7 +686,7 @@ static int convert_16urp(uint8_t *data, struct _sample *gus_sample) {
         return 0;
     }
 
-    _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_MEM, NULL, errno);
+    _WM_GLOBAL_ERROR(WM_ERR_MEM, NULL, errno);
     return -1;
 }
 
@@ -730,23 +730,23 @@ struct _sample * _WM_load_gus_pat(const char *filename, int fix_release) {
         return NULL;
     }
     if (gus_size < 239) {
-        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_CORUPT, filename, 0);
+        _WM_GLOBAL_ERROR(WM_ERR_CORUPT, filename, 0);
         _WM_FreeBufferFile(gus_patch);
         return NULL;
     }
     if (memcmp(gus_patch, "GF1PATCH110\0ID#000002", 22)
             && memcmp(gus_patch, "GF1PATCH100\0ID#000002", 22)) {
-        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_INVALID, filename, 0);
+        _WM_GLOBAL_ERROR(WM_ERR_INVALID, filename, 0);
         _WM_FreeBufferFile(gus_patch);
         return NULL;
     }
     if (gus_patch[82] > 1) {
-        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_INVALID, filename, 0);
+        _WM_GLOBAL_ERROR(WM_ERR_INVALID, filename, 0);
         _WM_FreeBufferFile(gus_patch);
         return NULL;
     }
     if (gus_patch[151] > 1) {
-        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_INVALID, filename, 0);
+        _WM_GLOBAL_ERROR(WM_ERR_INVALID, filename, 0);
         _WM_FreeBufferFile(gus_patch);
         return NULL;
     }
@@ -766,7 +766,7 @@ struct _sample * _WM_load_gus_pat(const char *filename, int fix_release) {
             gus_sample = gus_sample->next;
         }
         if (gus_sample == NULL) {
-            _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_MEM, NULL, 0);
+            _WM_GLOBAL_ERROR(WM_ERR_MEM, NULL, 0);
             _WM_FreeBufferFile(gus_patch);
             return NULL;
         }

--- a/src/gus_pat.c
+++ b/src/gus_pat.c
@@ -63,7 +63,7 @@ static int convert_8s(uint8_t *data, struct _sample *gus_sample) {
     uint8_t *read_end = data + gus_sample->data_length;
     int16_t *write_data = NULL;
 
-    SAMPLE_CONVERT_DEBUG(__FUNCTION__);
+    SAMPLE_CONVERT_DEBUG(__func__);
     gus_sample->data = (int16_t *) calloc((gus_sample->data_length + 2), sizeof(int16_t));
     if (__builtin_expect((gus_sample->data != NULL), 1)) {
         write_data = gus_sample->data;
@@ -90,7 +90,7 @@ static int convert_8sp(uint8_t *data, struct _sample *gus_sample) {
     int16_t *write_data_a = NULL;
     int16_t *write_data_b = NULL;
 
-    SAMPLE_CONVERT_DEBUG(__FUNCTION__);
+    SAMPLE_CONVERT_DEBUG(__func__);
     gus_sample->data = (int16_t *) calloc((new_length + 2), sizeof(int16_t));
     if (__builtin_expect((gus_sample->data != NULL), 1)) {
         write_data = gus_sample->data;
@@ -135,7 +135,7 @@ static int convert_8sr(uint8_t *data, struct _sample *gus_sample) {
     int16_t *write_data = NULL;
     uint32_t tmp_loop = 0;
 
-    SAMPLE_CONVERT_DEBUG(__FUNCTION__);
+    SAMPLE_CONVERT_DEBUG(__func__);
     gus_sample->data = (int16_t *) calloc((gus_sample->data_length + 2), sizeof(int16_t));
     if (__builtin_expect((gus_sample->data != NULL), 1)) {
         write_data = gus_sample->data + gus_sample->data_length - 1;
@@ -166,7 +166,7 @@ static int convert_8srp(uint8_t *data, struct _sample *gus_sample) {
     int16_t *write_data_a = NULL;
     int16_t *write_data_b = NULL;
 
-    SAMPLE_CONVERT_DEBUG(__FUNCTION__);
+    SAMPLE_CONVERT_DEBUG(__func__);
     gus_sample->data = (int16_t *) calloc((new_length + 2), sizeof(int16_t));
     if (__builtin_expect((gus_sample->data != NULL), 1)) {
         write_data = gus_sample->data;
@@ -211,7 +211,7 @@ static int convert_8u(uint8_t *data, struct _sample *gus_sample) {
     uint8_t *read_end = data + gus_sample->data_length;
     int16_t *write_data = NULL;
 
-    SAMPLE_CONVERT_DEBUG(__FUNCTION__);
+    SAMPLE_CONVERT_DEBUG(__func__);
     gus_sample->data = (int16_t *) calloc((gus_sample->data_length + 2), sizeof(int16_t));
     if (__builtin_expect((gus_sample->data != NULL), 1)) {
         write_data = gus_sample->data;
@@ -237,7 +237,7 @@ static int convert_8up(uint8_t *data, struct _sample *gus_sample) {
     int16_t *write_data_a = NULL;
     int16_t *write_data_b = NULL;
 
-    SAMPLE_CONVERT_DEBUG(__FUNCTION__);
+    SAMPLE_CONVERT_DEBUG(__func__);
     gus_sample->data = (int16_t *) calloc((new_length + 2), sizeof(int16_t));
     if (__builtin_expect((gus_sample->data != NULL), 1)) {
         write_data = gus_sample->data;
@@ -283,7 +283,7 @@ static int convert_8ur(uint8_t *data, struct _sample *gus_sample) {
     int16_t *write_data = NULL;
     uint32_t tmp_loop = 0;
 
-    SAMPLE_CONVERT_DEBUG(__FUNCTION__);
+    SAMPLE_CONVERT_DEBUG(__func__);
     gus_sample->data = (int16_t *) calloc((gus_sample->data_length + 2), sizeof(int16_t));
     if (__builtin_expect((gus_sample->data != NULL), 1)) {
         write_data = gus_sample->data + gus_sample->data_length - 1;
@@ -314,7 +314,7 @@ static int convert_8urp(uint8_t *data, struct _sample *gus_sample) {
     int16_t *write_data_a = NULL;
     int16_t *write_data_b = NULL;
 
-    SAMPLE_CONVERT_DEBUG(__FUNCTION__);
+    SAMPLE_CONVERT_DEBUG(__func__);
     gus_sample->data = (int16_t *) calloc((new_length + 2), sizeof(int16_t));
     if (__builtin_expect((gus_sample->data != NULL), 1)) {
         write_data = gus_sample->data;
@@ -358,7 +358,7 @@ static int convert_16s(uint8_t *data, struct _sample *gus_sample) {
     uint8_t *read_end = data + gus_sample->data_length;
     int16_t *write_data = NULL;
 
-    SAMPLE_CONVERT_DEBUG(__FUNCTION__);
+    SAMPLE_CONVERT_DEBUG(__func__);
     gus_sample->data = (int16_t *) calloc(((gus_sample->data_length >> 1) + 2), sizeof(int16_t));
     if (__builtin_expect((gus_sample->data != NULL), 1)) {
         write_data = gus_sample->data;
@@ -388,7 +388,7 @@ static int convert_16sp(uint8_t *data, struct _sample *gus_sample) {
     int16_t *write_data_a = NULL;
     int16_t *write_data_b = NULL;
 
-    SAMPLE_CONVERT_DEBUG(__FUNCTION__);
+    SAMPLE_CONVERT_DEBUG(__func__);
     gus_sample->data = (int16_t *) calloc(((new_length >> 1) + 2), sizeof(int16_t));
     if (__builtin_expect((gus_sample->data != NULL), 1)) {
         write_data = gus_sample->data;
@@ -443,7 +443,7 @@ static int convert_16sr(uint8_t *data, struct _sample *gus_sample) {
     int16_t *write_data = NULL;
     uint32_t tmp_loop = 0;
 
-    SAMPLE_CONVERT_DEBUG(__FUNCTION__);
+    SAMPLE_CONVERT_DEBUG(__func__);
     gus_sample->data = (int16_t *) calloc(((gus_sample->data_length >> 1) + 2), sizeof(int16_t));
     if (__builtin_expect((gus_sample->data != NULL), 1)) {
         write_data = gus_sample->data + (gus_sample->data_length >> 1) - 1;
@@ -478,7 +478,7 @@ static int convert_16srp(uint8_t *data, struct _sample *gus_sample) {
     int16_t *write_data_a = NULL;
     int16_t *write_data_b = NULL;
 
-    SAMPLE_CONVERT_DEBUG(__FUNCTION__);
+    SAMPLE_CONVERT_DEBUG(__func__);
     gus_sample->data = (int16_t *) calloc(((new_length >> 1) + 2), sizeof(int16_t));
     if (__builtin_expect((gus_sample->data != NULL), 1)) {
         write_data = gus_sample->data;
@@ -527,7 +527,7 @@ static int convert_16u(uint8_t *data, struct _sample *gus_sample) {
     uint8_t *read_end = data + gus_sample->data_length;
     int16_t *write_data = NULL;
 
-    SAMPLE_CONVERT_DEBUG(__FUNCTION__);
+    SAMPLE_CONVERT_DEBUG(__func__);
     gus_sample->data = (int16_t *) calloc(((gus_sample->data_length >> 1) + 2), sizeof(int16_t));
     if (__builtin_expect((gus_sample->data != NULL), 1)) {
         write_data = gus_sample->data;
@@ -557,7 +557,7 @@ static int convert_16up(uint8_t *data, struct _sample *gus_sample) {
     int16_t *write_data_a = NULL;
     int16_t *write_data_b = NULL;
 
-    SAMPLE_CONVERT_DEBUG(__FUNCTION__);
+    SAMPLE_CONVERT_DEBUG(__func__);
     gus_sample->data = (int16_t *) calloc(((new_length >> 1) + 2), sizeof(int16_t));
     if (__builtin_expect((gus_sample->data != NULL), 1)) {
         write_data = gus_sample->data;
@@ -612,7 +612,7 @@ static int convert_16ur(uint8_t *data, struct _sample *gus_sample) {
     int16_t *write_data = NULL;
     uint32_t tmp_loop = 0;
 
-    SAMPLE_CONVERT_DEBUG(__FUNCTION__);
+    SAMPLE_CONVERT_DEBUG(__func__);
     gus_sample->data = (int16_t *) calloc(((gus_sample->data_length >> 1) + 2), sizeof(int16_t));
     if (__builtin_expect((gus_sample->data != NULL), 1)) {
         write_data = gus_sample->data + (gus_sample->data_length >> 1) - 1;
@@ -647,7 +647,7 @@ static int convert_16urp(uint8_t *data, struct _sample *gus_sample) {
     int16_t *write_data_a = NULL;
     int16_t *write_data_b = NULL;
 
-    SAMPLE_CONVERT_DEBUG(__FUNCTION__);
+    SAMPLE_CONVERT_DEBUG(__func__);
     gus_sample->data = (int16_t *) calloc(((new_length >> 1) + 2), sizeof(int16_t));
     if (__builtin_expect((gus_sample->data != NULL), 1)) {
         write_data = gus_sample->data;
@@ -724,7 +724,7 @@ struct _sample * _WM_load_gus_pat(const char *filename, int fix_release) {
 
     WMIDI_UNUSED(fix_release);
 
-    SAMPLE_CONVERT_DEBUG(__FUNCTION__); SAMPLE_CONVERT_DEBUG(filename);
+    SAMPLE_CONVERT_DEBUG(__func__); SAMPLE_CONVERT_DEBUG(filename);
 
     if ((gus_patch = (uint8_t *) _WM_BufferFile(filename, &gus_size)) == NULL) {
         return NULL;
@@ -852,7 +852,7 @@ struct _sample * _WM_load_gus_pat(const char *filename, int fix_release) {
                 GUSPAT_INT_DEBUG("Envelope Rate",gus_sample->env_rate[i]); GUSPAT_INT_DEBUG("GUSPAT Rate",env_rate);
                 if (gus_sample->env_rate[i] == 0) {
                     _WM_DEBUG_MSG("%s: Warning: found invalid envelope(%u) rate setting in %s. Using %f instead.",
-                                  __FUNCTION__, i, filename, env_time_table[63]);
+                                  __func__, i, filename, env_time_table[63]);
                     gus_sample->env_rate[i] = (int32_t) (4194303.0f
                             / ((float) _WM_SampleRate * env_time_table[63]));
                     GUSPAT_FLOAT_DEBUG("Envelope Time",env_time_table[63]);

--- a/src/gus_pat.c
+++ b/src/gus_pat.c
@@ -35,7 +35,7 @@
 #include "file_io.h"
 #include "sample.h"
 
-//#define DEBUG_GUSPAT
+/* #define DEBUG_GUSPAT */
 #ifdef DEBUG_GUSPAT
 #define GUSPAT_FILENAME_DEBUG(dx) fprintf(stderr,"\r%s\n",dx)
 
@@ -823,15 +823,15 @@ struct _sample * _WM_load_gus_pat(const char *filename, int fix_release) {
                             | ((gus_sample->loop_fraction & 0xf0) >> 4);
         }
 
-        // All sorts of annoying things happen with pat files.
-        // One of them is that the sustained release time and
-        // normal release time gets mixed up because software got muddled
+        /* All sorts of annoying things happen with pat files.
+           One of them is that the sustained release time and
+           normal release time gets mixed up because software got muddled */
         envsusreltime = env_time_table[gus_patch[gus_ptr + 40]];
         envreltime = env_time_table[gus_patch[gus_ptr + 41]];
         if (envsusreltime < envreltime) {
-            // EXPERIMENTAL
+            /* EXPERIMENTAL */
             gus_patch[gus_ptr + 40] = gus_patch[gus_ptr + 41];
-            // timidity does this:
+            /* timidity does this: */
             gus_patch[gus_ptr + 41] = 0x3f;
             gus_patch[gus_ptr + 42] = 0x3f;
 
@@ -840,7 +840,7 @@ struct _sample * _WM_load_gus_pat(const char *filename, int fix_release) {
             gus_patch[gus_ptr + 48] = 0;
         }
 
-        // lets set up the envelope data
+        /* lets set up the envelope data */
         for (i = 0; i < 6; i++) {
             GUSPAT_INT_DEBUG("Envelope #",i);
             if (gus_sample->modes & SAMPLE_ENVELOPE) {

--- a/src/gus_pat.c
+++ b/src/gus_pat.c
@@ -63,7 +63,7 @@ static int convert_8s(uint8_t *data, struct _sample *gus_sample) {
     uint8_t *read_end = data + gus_sample->data_length;
     int16_t *write_data = NULL;
 
-    SAMPLE_CONVERT_DEBUG(__func__);
+    SAMPLE_CONVERT_DEBUG("convert_8s");
     gus_sample->data = (int16_t *) calloc((gus_sample->data_length + 2), sizeof(int16_t));
     if (__builtin_expect((gus_sample->data != NULL), 1)) {
         write_data = gus_sample->data;
@@ -90,7 +90,7 @@ static int convert_8sp(uint8_t *data, struct _sample *gus_sample) {
     int16_t *write_data_a = NULL;
     int16_t *write_data_b = NULL;
 
-    SAMPLE_CONVERT_DEBUG(__func__);
+    SAMPLE_CONVERT_DEBUG("convert_8sp");
     gus_sample->data = (int16_t *) calloc((new_length + 2), sizeof(int16_t));
     if (__builtin_expect((gus_sample->data != NULL), 1)) {
         write_data = gus_sample->data;
@@ -135,7 +135,7 @@ static int convert_8sr(uint8_t *data, struct _sample *gus_sample) {
     int16_t *write_data = NULL;
     uint32_t tmp_loop = 0;
 
-    SAMPLE_CONVERT_DEBUG(__func__);
+    SAMPLE_CONVERT_DEBUG("convert_8sr");
     gus_sample->data = (int16_t *) calloc((gus_sample->data_length + 2), sizeof(int16_t));
     if (__builtin_expect((gus_sample->data != NULL), 1)) {
         write_data = gus_sample->data + gus_sample->data_length - 1;
@@ -166,7 +166,7 @@ static int convert_8srp(uint8_t *data, struct _sample *gus_sample) {
     int16_t *write_data_a = NULL;
     int16_t *write_data_b = NULL;
 
-    SAMPLE_CONVERT_DEBUG(__func__);
+    SAMPLE_CONVERT_DEBUG("convert_8srp");
     gus_sample->data = (int16_t *) calloc((new_length + 2), sizeof(int16_t));
     if (__builtin_expect((gus_sample->data != NULL), 1)) {
         write_data = gus_sample->data;
@@ -211,7 +211,7 @@ static int convert_8u(uint8_t *data, struct _sample *gus_sample) {
     uint8_t *read_end = data + gus_sample->data_length;
     int16_t *write_data = NULL;
 
-    SAMPLE_CONVERT_DEBUG(__func__);
+    SAMPLE_CONVERT_DEBUG("convert_8u");
     gus_sample->data = (int16_t *) calloc((gus_sample->data_length + 2), sizeof(int16_t));
     if (__builtin_expect((gus_sample->data != NULL), 1)) {
         write_data = gus_sample->data;
@@ -237,7 +237,7 @@ static int convert_8up(uint8_t *data, struct _sample *gus_sample) {
     int16_t *write_data_a = NULL;
     int16_t *write_data_b = NULL;
 
-    SAMPLE_CONVERT_DEBUG(__func__);
+    SAMPLE_CONVERT_DEBUG("convert_8up");
     gus_sample->data = (int16_t *) calloc((new_length + 2), sizeof(int16_t));
     if (__builtin_expect((gus_sample->data != NULL), 1)) {
         write_data = gus_sample->data;
@@ -283,7 +283,7 @@ static int convert_8ur(uint8_t *data, struct _sample *gus_sample) {
     int16_t *write_data = NULL;
     uint32_t tmp_loop = 0;
 
-    SAMPLE_CONVERT_DEBUG(__func__);
+    SAMPLE_CONVERT_DEBUG("convert_8ur");
     gus_sample->data = (int16_t *) calloc((gus_sample->data_length + 2), sizeof(int16_t));
     if (__builtin_expect((gus_sample->data != NULL), 1)) {
         write_data = gus_sample->data + gus_sample->data_length - 1;
@@ -314,7 +314,7 @@ static int convert_8urp(uint8_t *data, struct _sample *gus_sample) {
     int16_t *write_data_a = NULL;
     int16_t *write_data_b = NULL;
 
-    SAMPLE_CONVERT_DEBUG(__func__);
+    SAMPLE_CONVERT_DEBUG("convert_8urp");
     gus_sample->data = (int16_t *) calloc((new_length + 2), sizeof(int16_t));
     if (__builtin_expect((gus_sample->data != NULL), 1)) {
         write_data = gus_sample->data;
@@ -358,7 +358,7 @@ static int convert_16s(uint8_t *data, struct _sample *gus_sample) {
     uint8_t *read_end = data + gus_sample->data_length;
     int16_t *write_data = NULL;
 
-    SAMPLE_CONVERT_DEBUG(__func__);
+    SAMPLE_CONVERT_DEBUG("convert_16s");
     gus_sample->data = (int16_t *) calloc(((gus_sample->data_length >> 1) + 2), sizeof(int16_t));
     if (__builtin_expect((gus_sample->data != NULL), 1)) {
         write_data = gus_sample->data;
@@ -388,7 +388,7 @@ static int convert_16sp(uint8_t *data, struct _sample *gus_sample) {
     int16_t *write_data_a = NULL;
     int16_t *write_data_b = NULL;
 
-    SAMPLE_CONVERT_DEBUG(__func__);
+    SAMPLE_CONVERT_DEBUG("convert_16sp");
     gus_sample->data = (int16_t *) calloc(((new_length >> 1) + 2), sizeof(int16_t));
     if (__builtin_expect((gus_sample->data != NULL), 1)) {
         write_data = gus_sample->data;
@@ -443,7 +443,7 @@ static int convert_16sr(uint8_t *data, struct _sample *gus_sample) {
     int16_t *write_data = NULL;
     uint32_t tmp_loop = 0;
 
-    SAMPLE_CONVERT_DEBUG(__func__);
+    SAMPLE_CONVERT_DEBUG("convert_16sr");
     gus_sample->data = (int16_t *) calloc(((gus_sample->data_length >> 1) + 2), sizeof(int16_t));
     if (__builtin_expect((gus_sample->data != NULL), 1)) {
         write_data = gus_sample->data + (gus_sample->data_length >> 1) - 1;
@@ -478,7 +478,7 @@ static int convert_16srp(uint8_t *data, struct _sample *gus_sample) {
     int16_t *write_data_a = NULL;
     int16_t *write_data_b = NULL;
 
-    SAMPLE_CONVERT_DEBUG(__func__);
+    SAMPLE_CONVERT_DEBUG("convert_16srp");
     gus_sample->data = (int16_t *) calloc(((new_length >> 1) + 2), sizeof(int16_t));
     if (__builtin_expect((gus_sample->data != NULL), 1)) {
         write_data = gus_sample->data;
@@ -527,7 +527,7 @@ static int convert_16u(uint8_t *data, struct _sample *gus_sample) {
     uint8_t *read_end = data + gus_sample->data_length;
     int16_t *write_data = NULL;
 
-    SAMPLE_CONVERT_DEBUG(__func__);
+    SAMPLE_CONVERT_DEBUG("convert_16u");
     gus_sample->data = (int16_t *) calloc(((gus_sample->data_length >> 1) + 2), sizeof(int16_t));
     if (__builtin_expect((gus_sample->data != NULL), 1)) {
         write_data = gus_sample->data;
@@ -557,7 +557,7 @@ static int convert_16up(uint8_t *data, struct _sample *gus_sample) {
     int16_t *write_data_a = NULL;
     int16_t *write_data_b = NULL;
 
-    SAMPLE_CONVERT_DEBUG(__func__);
+    SAMPLE_CONVERT_DEBUG("convert_16up");
     gus_sample->data = (int16_t *) calloc(((new_length >> 1) + 2), sizeof(int16_t));
     if (__builtin_expect((gus_sample->data != NULL), 1)) {
         write_data = gus_sample->data;
@@ -612,7 +612,7 @@ static int convert_16ur(uint8_t *data, struct _sample *gus_sample) {
     int16_t *write_data = NULL;
     uint32_t tmp_loop = 0;
 
-    SAMPLE_CONVERT_DEBUG(__func__);
+    SAMPLE_CONVERT_DEBUG("convert_16ur");
     gus_sample->data = (int16_t *) calloc(((gus_sample->data_length >> 1) + 2), sizeof(int16_t));
     if (__builtin_expect((gus_sample->data != NULL), 1)) {
         write_data = gus_sample->data + (gus_sample->data_length >> 1) - 1;
@@ -647,7 +647,7 @@ static int convert_16urp(uint8_t *data, struct _sample *gus_sample) {
     int16_t *write_data_a = NULL;
     int16_t *write_data_b = NULL;
 
-    SAMPLE_CONVERT_DEBUG(__func__);
+    SAMPLE_CONVERT_DEBUG("convert_16urp");
     gus_sample->data = (int16_t *) calloc(((new_length >> 1) + 2), sizeof(int16_t));
     if (__builtin_expect((gus_sample->data != NULL), 1)) {
         write_data = gus_sample->data;
@@ -724,7 +724,7 @@ struct _sample * _WM_load_gus_pat(const char *filename, int fix_release) {
 
     WMIDI_UNUSED(fix_release);
 
-    SAMPLE_CONVERT_DEBUG(__func__); SAMPLE_CONVERT_DEBUG(filename);
+    SAMPLE_CONVERT_DEBUG("_WM_load_gus_pat"); SAMPLE_CONVERT_DEBUG(filename);
 
     if ((gus_patch = (uint8_t *) _WM_BufferFile(filename, &gus_size)) == NULL) {
         return NULL;
@@ -851,8 +851,8 @@ struct _sample * _WM_load_gus_pat(const char *filename, int fix_release) {
                         / ((float) _WM_SampleRate * env_time_table[env_rate]));
                 GUSPAT_INT_DEBUG("Envelope Rate",gus_sample->env_rate[i]); GUSPAT_INT_DEBUG("GUSPAT Rate",env_rate);
                 if (gus_sample->env_rate[i] == 0) {
-                    _WM_DEBUG_MSG("%s: Warning: found invalid envelope(%u) rate setting in %s. Using %f instead.",
-                                  __func__, i, filename, env_time_table[63]);
+                    _WM_DEBUG_MSG("_WM_load_gus_pat: Warning: found invalid envelope(%u) rate setting in %s. Using %f instead.",
+                                  i, filename, env_time_table[63]);
                     gus_sample->env_rate[i] = (int32_t) (4194303.0f
                             / ((float) _WM_SampleRate * env_time_table[63]));
                     GUSPAT_FLOAT_DEBUG("Envelope Time",env_time_table[63]);

--- a/src/internal_midi.c
+++ b/src/internal_midi.c
@@ -43,11 +43,11 @@
 /* #define DEBUG_MIDI */
 
 #ifdef DEBUG_MIDI
-#define MIDI_EVENT_DEBUG(dy,dz) fprintf(stderr,"\r%s, 0x%.2x, 0x%.8x\n",__func__,dy,dz)
-#define MIDI_EVENT_SDEBUG(dy,dz) fprintf(stderr,"\r%s, 0x%.2x, %s\n",__func__,dy,dz)
+#define MIDI_EVENT_DEBUG(dx,dy,dz) fprintf(stderr,"\r%s, 0x%.2x, 0x%.8x\n",dx,dy,dz)
+#define MIDI_EVENT_SDEBUG(dx,dy,dz) fprintf(stderr,"\r%s, 0x%.2x, %s\n",dx,dy,dz)
 #else
-#define MIDI_EVENT_DEBUG(dy,dz)
-#define MIDI_EVENT_SDEBUG(dy,dz)
+#define MIDI_EVENT_DEBUG(dx,dy,dz)
+#define MIDI_EVENT_SDEBUG(dx,dy,dz)
 #endif
 
 /* f: ( VOLUME / 127.0 ) * 1024.0 */
@@ -486,7 +486,7 @@ void _WM_AdjustNoteVolumes(struct _mdi *mdi, uint8_t ch, struct _note *nte) {
 #define VOL_DIVISOR 4.0
     volume_adj = ((double)_WM_MasterVolume / 1024.0) / VOL_DIVISOR;
 
-    MIDI_EVENT_DEBUG(ch, 0);
+    MIDI_EVENT_DEBUG("_WM_AdjustNoteVolumes", ch, 0);
 
     if (pan_ofs > 127) pan_ofs = 127;
     premix_dBm_left = dBm_pan_volume[(127-pan_ofs)];
@@ -555,7 +555,7 @@ static void _WM_CheckEventMemoryPool(struct _mdi *mdi) {
 
 void _WM_do_note_off_extra(struct _note *nte) {
 
-    MIDI_EVENT_DEBUG(0, 0);
+    MIDI_EVENT_DEBUG("_WM_do_note_off_extra", 0, 0);
     nte->is_off = 0;
 
     if (!(nte->modes & SAMPLE_ENVELOPE)) {
@@ -609,7 +609,7 @@ void _WM_do_note_off(struct _mdi *mdi, struct _event_data *data) {
     struct _note *nte;
     uint8_t ch = data->channel;
 
-    MIDI_EVENT_DEBUG(ch, data->data.value);
+    MIDI_EVENT_DEBUG("_WM_do_note_off", ch, data->data.value);
 
     nte = &mdi->note_table[0][ch][(data->data.value >> 8)];
     if (!nte->active) {
@@ -670,7 +670,7 @@ void _WM_do_note_on(struct _mdi *mdi, struct _event_data *data) {
         return;
     }
 
-    MIDI_EVENT_DEBUG(ch, data->data.value);
+    MIDI_EVENT_DEBUG("_WM_do_note_on", ch, data->data.value);
 
     if (!mdi->channel[ch].isdrum) {
         patch = mdi->channel[ch].patch;
@@ -752,7 +752,7 @@ void _WM_do_aftertouch(struct _mdi *mdi, struct _event_data *data) {
     struct _note *nte;
     uint8_t ch = data->channel;
 
-    MIDI_EVENT_DEBUG(ch, data->data.value);
+    MIDI_EVENT_DEBUG("_WM_do_aftertouch", ch, data->data.value);
 
     nte = &mdi->note_table[0][ch][(data->data.value >> 8)];
     if (!nte->active) {
@@ -772,7 +772,7 @@ void _WM_do_aftertouch(struct _mdi *mdi, struct _event_data *data) {
 
 void _WM_do_control_bank_select(struct _mdi *mdi, struct _event_data *data) {
     uint8_t ch = data->channel;
-    MIDI_EVENT_DEBUG(ch, data->data.value);
+    MIDI_EVENT_DEBUG("_WM_do_control_bank_select", ch, data->data.value);
     mdi->channel[ch].bank = data->data.value;
 }
 
@@ -780,7 +780,7 @@ void _WM_do_control_data_entry_course(struct _mdi *mdi,
                                          struct _event_data *data) {
     uint8_t ch = data->channel;
     int data_tmp;
-    MIDI_EVENT_DEBUG(ch, data->data.value);
+    MIDI_EVENT_DEBUG("_WM_do_control_data_entry_course", ch, data->data.value);
 
     if ((mdi->channel[ch].reg_non == 0)
         && (mdi->channel[ch].reg_data == 0x0000)) { /* Pitch Bend Range */
@@ -794,7 +794,7 @@ void _WM_do_control_data_entry_course(struct _mdi *mdi,
 void _WM_do_control_channel_volume(struct _mdi *mdi,
                                       struct _event_data *data) {
     uint8_t ch = data->channel;
-    MIDI_EVENT_DEBUG(ch, data->data.value);
+    MIDI_EVENT_DEBUG("_WM_do_control_channel_volume", ch, data->data.value);
 
     mdi->channel[ch].volume = data->data.value;
     _WM_AdjustChannelVolumes(mdi, ch);
@@ -803,7 +803,7 @@ void _WM_do_control_channel_volume(struct _mdi *mdi,
 void _WM_do_control_channel_balance(struct _mdi *mdi,
                                        struct _event_data *data) {
     uint8_t ch = data->channel;
-    MIDI_EVENT_DEBUG(ch, data->data.value);
+    MIDI_EVENT_DEBUG("_WM_do_control_channel_balance", ch, data->data.value);
 
     mdi->channel[ch].balance = data->data.value;
     _WM_AdjustChannelVolumes(mdi, ch);
@@ -811,7 +811,7 @@ void _WM_do_control_channel_balance(struct _mdi *mdi,
 
 void _WM_do_control_channel_pan(struct _mdi *mdi, struct _event_data *data) {
     uint8_t ch = data->channel;
-    MIDI_EVENT_DEBUG(ch, data->data.value);
+    MIDI_EVENT_DEBUG("_WM_do_control_channel_pan", ch, data->data.value);
 
     mdi->channel[ch].pan = data->data.value;
     _WM_AdjustChannelVolumes(mdi, ch);
@@ -820,7 +820,7 @@ void _WM_do_control_channel_pan(struct _mdi *mdi, struct _event_data *data) {
 void _WM_do_control_channel_expression(struct _mdi *mdi,
                                           struct _event_data *data) {
     uint8_t ch = data->channel;
-    MIDI_EVENT_DEBUG(ch, data->data.value);
+    MIDI_EVENT_DEBUG("_WM_do_control_channel_expression", ch, data->data.value);
 
     mdi->channel[ch].expression = data->data.value;
     _WM_AdjustChannelVolumes(mdi, ch);
@@ -830,7 +830,7 @@ void _WM_do_control_data_entry_fine(struct _mdi *mdi,
                                        struct _event_data *data) {
     uint8_t ch = data->channel;
     int data_tmp;
-    MIDI_EVENT_DEBUG(ch, data->data.value);
+    MIDI_EVENT_DEBUG("_WM_do_control_data_entry_fine", ch, data->data.value);
 
     if ((mdi->channel[ch].reg_non == 0)
       && (mdi->channel[ch].reg_data == 0x0000)) { /* Pitch Bend Range */
@@ -844,7 +844,7 @@ void _WM_do_control_data_entry_fine(struct _mdi *mdi,
 void _WM_do_control_channel_hold(struct _mdi *mdi, struct _event_data *data) {
     struct _note *note_data = mdi->note;
     uint8_t ch = data->channel;
-    MIDI_EVENT_DEBUG(ch, data->data.value);
+    MIDI_EVENT_DEBUG("_WM_do_control_channel_hold", ch, data->data.value);
 
     if (data->data.value > 63) {
         mdi->channel[ch].hold = 1;
@@ -910,7 +910,7 @@ void _WM_do_control_channel_hold(struct _mdi *mdi, struct _event_data *data) {
 void _WM_do_control_data_increment(struct _mdi *mdi,
                                       struct _event_data *data) {
     uint8_t ch = data->channel;
-    MIDI_EVENT_DEBUG(ch, data->data.value);
+    MIDI_EVENT_DEBUG("_WM_do_control_data_increment", ch, data->data.value);
 
     if ((mdi->channel[ch].reg_non == 0)
         && (mdi->channel[ch].reg_data == 0x0000)) { /* Pitch Bend Range */
@@ -922,7 +922,7 @@ void _WM_do_control_data_increment(struct _mdi *mdi,
 void _WM_do_control_data_decrement(struct _mdi *mdi,
                                       struct _event_data *data) {
     uint8_t ch = data->channel;
-    MIDI_EVENT_DEBUG(ch, data->data.value);
+    MIDI_EVENT_DEBUG("_WM_do_control_data_decrement", ch, data->data.value);
 
     if ((mdi->channel[ch].reg_non == 0)
         && (mdi->channel[ch].reg_data == 0x0000)) { /* Pitch Bend Range */
@@ -933,7 +933,7 @@ void _WM_do_control_data_decrement(struct _mdi *mdi,
 void _WM_do_control_non_registered_param_fine(struct _mdi *mdi,
                                             struct _event_data *data) {
     uint8_t ch = data->channel;
-    MIDI_EVENT_DEBUG(ch, data->data.value);
+    MIDI_EVENT_DEBUG("_WM_do_control_non_registered_param_fine", ch, data->data.value);
     mdi->channel[ch].reg_data = (mdi->channel[ch].reg_data & 0x3F80)
                                 | data->data.value;
     mdi->channel[ch].reg_non = 1;
@@ -942,7 +942,7 @@ void _WM_do_control_non_registered_param_fine(struct _mdi *mdi,
 void _WM_do_control_non_registered_param_course(struct _mdi *mdi,
                                      struct _event_data *data) {
     uint8_t ch = data->channel;
-    MIDI_EVENT_DEBUG(ch, data->data.value);
+    MIDI_EVENT_DEBUG("_WM_do_control_non_registered_param_course", ch, data->data.value);
     mdi->channel[ch].reg_data = (mdi->channel[ch].reg_data & 0x7F)
                                 | (data->data.value << 7);
     mdi->channel[ch].reg_non = 1;
@@ -951,7 +951,7 @@ void _WM_do_control_non_registered_param_course(struct _mdi *mdi,
 void _WM_do_control_registered_param_fine(struct _mdi *mdi,
                                           struct _event_data *data) {
     uint8_t ch = data->channel;
-    MIDI_EVENT_DEBUG(ch, data->data.value);
+    MIDI_EVENT_DEBUG("_WM_do_control_registered_param_fine", ch, data->data.value);
     mdi->channel[ch].reg_data = (mdi->channel[ch].reg_data & 0x3F80)
                                 | data->data.value;
     mdi->channel[ch].reg_non = 0;
@@ -960,7 +960,7 @@ void _WM_do_control_registered_param_fine(struct _mdi *mdi,
 void _WM_do_control_registered_param_course(struct _mdi *mdi,
                                             struct _event_data *data) {
     uint8_t ch = data->channel;
-    MIDI_EVENT_DEBUG(ch, data->data.value);
+    MIDI_EVENT_DEBUG("_WM_do_control_registered_param_course", ch, data->data.value);
     mdi->channel[ch].reg_data = (mdi->channel[ch].reg_data & 0x7F)
                                 | (data->data.value << 7);
     mdi->channel[ch].reg_non = 0;
@@ -970,7 +970,7 @@ void _WM_do_control_channel_sound_off(struct _mdi *mdi,
                                       struct _event_data *data) {
     struct _note *note_data = mdi->note;
     uint8_t ch = data->channel;
-    MIDI_EVENT_DEBUG(ch, data->data.value);
+    MIDI_EVENT_DEBUG("_WM_do_control_channel_sound_off", ch, data->data.value);
 
     if (note_data) {
         do {
@@ -988,7 +988,7 @@ void _WM_do_control_channel_sound_off(struct _mdi *mdi,
 void _WM_do_control_channel_controllers_off(struct _mdi *mdi,
                                             struct _event_data *data) {
     uint8_t ch = data->channel;
-    MIDI_EVENT_DEBUG(ch, data->data.value);
+    MIDI_EVENT_DEBUG("_WM_do_control_channel_controllers_off", ch, data->data.value);
 
     mdi->channel[ch].expression = 127;
     mdi->channel[ch].pressure = 127;
@@ -1005,7 +1005,7 @@ void _WM_do_control_channel_notes_off(struct _mdi *mdi,
                                       struct _event_data *data) {
     struct _note *note_data = mdi->note;
     uint8_t ch = data->channel;
-    MIDI_EVENT_DEBUG(ch, data->data.value);
+    MIDI_EVENT_DEBUG("_WM_do_control_channel_notes_off", ch, data->data.value);
 
     if (mdi->channel[ch].isdrum)
         return;
@@ -1038,7 +1038,7 @@ void _WM_do_control_channel_notes_off(struct _mdi *mdi,
 void _WM_do_control_dummy(struct _mdi *mdi, struct _event_data *data) {
 #ifdef DEBUG_MIDI
     uint8_t ch = data->channel;
-    MIDI_EVENT_DEBUG(ch, data->data.value);
+    MIDI_EVENT_DEBUG("_WM_do_control_dummy", ch, data->data.value);
 #else
     WMIDI_UNUSED(data);
 #endif
@@ -1047,7 +1047,7 @@ void _WM_do_control_dummy(struct _mdi *mdi, struct _event_data *data) {
 
 void _WM_do_patch(struct _mdi *mdi, struct _event_data *data) {
     uint8_t ch = data->channel;
-    MIDI_EVENT_DEBUG(ch, data->data.value);
+    MIDI_EVENT_DEBUG("_WM_do_patch", ch, data->data.value);
     if (!mdi->channel[ch].isdrum) {
         mdi->channel[ch].patch = _WM_get_patch_data(mdi,
                                                 ((mdi->channel[ch].bank << 8) | data->data.value));
@@ -1059,7 +1059,7 @@ void _WM_do_patch(struct _mdi *mdi, struct _event_data *data) {
 void _WM_do_channel_pressure(struct _mdi *mdi, struct _event_data *data) {
     uint8_t ch = data->channel;
     struct _note *note_data = mdi->note;
-    MIDI_EVENT_DEBUG(ch, data->data.value);
+    MIDI_EVENT_DEBUG("_WM_do_channel_pressure", ch, data->data.value);
 
     mdi->channel[ch].pressure = data->data.value;
 
@@ -1082,7 +1082,7 @@ void _WM_do_pitch(struct _mdi *mdi, struct _event_data *data) {
     struct _note *note_data = mdi->note;
     uint8_t ch = data->channel;
 
-    MIDI_EVENT_DEBUG(ch, data->data.value);
+    MIDI_EVENT_DEBUG("_WM_do_pitch", ch, data->data.value);
     mdi->channel[ch].pitch = data->data.value - 0x2000;
 
     if (mdi->channel[ch].pitch < 0) {
@@ -1106,7 +1106,7 @@ void _WM_do_pitch(struct _mdi *mdi, struct _event_data *data) {
 void _WM_do_sysex_roland_drum_track(struct _mdi *mdi, struct _event_data *data) {
     uint8_t ch = data->channel;
 
-    MIDI_EVENT_DEBUG(ch, data->data.value);
+    MIDI_EVENT_DEBUG("_WM_do_sysex_roland_drum_track", ch, data->data.value);
 
     if (data->data.value > 0) {
         mdi->channel[ch].isdrum = 1;
@@ -1121,9 +1121,9 @@ void _WM_do_sysex_gm_reset(struct _mdi *mdi, struct _event_data *data) {
     int i;
 
     if (data != NULL) {
-        MIDI_EVENT_DEBUG(data->channel, data->data.value);
+        MIDI_EVENT_DEBUG("_WM_do_sysex_gm_reset", data->channel, data->data.value);
     } else {
-        MIDI_EVENT_DEBUG(0, 0);
+        MIDI_EVENT_DEBUG("_WM_do_sysex_gm_reset", 0, 0);
     }
 
     for (i = 0; i < 16; i++) {
@@ -1154,7 +1154,7 @@ void _WM_do_sysex_gm_reset(struct _mdi *mdi, struct _event_data *data) {
 void _WM_do_sysex_roland_reset(struct _mdi *mdi, struct _event_data *data) {
 #ifdef DEBUG_MIDI
     uint8_t ch = data->channel;
-    MIDI_EVENT_DEBUG(ch, data->data.value);
+    MIDI_EVENT_DEBUG("_WM_do_sysex_roland_reset", ch, data->data.value);
 #else
     WMIDI_UNUSED(data);
 #endif
@@ -1164,7 +1164,7 @@ void _WM_do_sysex_roland_reset(struct _mdi *mdi, struct _event_data *data) {
 void _WM_do_sysex_yamaha_reset(struct _mdi *mdi, struct _event_data *data) {
 #ifdef DEBUG_MIDI
     uint8_t ch = data->channel;
-    MIDI_EVENT_DEBUG(ch, data->data.value);
+    MIDI_EVENT_DEBUG("_WM_do_sysex_yamaha_reset", ch, data->data.value);
 #else
     WMIDI_UNUSED(data);
 #endif
@@ -1212,7 +1212,7 @@ void _WM_do_meta_endoftrack(struct _mdi *mdi, struct _event_data *data) {
  * for conversion function _WM_Event2Midi */
 #ifdef DEBUG_MIDI
     uint8_t ch = data->channel;
-    MIDI_EVENT_DEBUG(ch, data->data.value);
+    MIDI_EVENT_DEBUG("_WM_do_meta_endoftrack", ch, data->data.value);
 #else
     WMIDI_UNUSED(data);
 #endif
@@ -1226,7 +1226,7 @@ void _WM_do_meta_tempo(struct _mdi *mdi, struct _event_data *data) {
  * for conversion function _WM_Event2Midi */
 #ifdef DEBUG_MIDI
     uint8_t ch = data->channel;
-    MIDI_EVENT_DEBUG(ch, data->data.value);
+    MIDI_EVENT_DEBUG("_WM_do_meta_tempo", ch, data->data.value);
 #else
     WMIDI_UNUSED(data);
 #endif
@@ -1239,7 +1239,7 @@ void _WM_do_meta_timesignature(struct _mdi *mdi, struct _event_data *data) {
  * for conversion function _WM_Event2Midi */
 #ifdef DEBUG_MIDI
     uint8_t ch = data->channel;
-    MIDI_EVENT_DEBUG(ch, data->data.value);
+    MIDI_EVENT_DEBUG("_WM_do_meta_timesignature", ch, data->data.value);
 #else
     WMIDI_UNUSED(data);
 #endif
@@ -1252,7 +1252,7 @@ void _WM_do_meta_keysignature(struct _mdi *mdi, struct _event_data *data) {
  * for conversion function _WM_Event2Midi */
 #ifdef DEBUG_MIDI
     uint8_t ch = data->channel;
-    MIDI_EVENT_DEBUG(ch, data->data.value);
+    MIDI_EVENT_DEBUG("_WM_do_meta_keysignature", ch, data->data.value);
 #else
     WMIDI_UNUSED(data);
 #endif
@@ -1265,7 +1265,7 @@ void _WM_do_meta_sequenceno(struct _mdi *mdi, struct _event_data *data) {
  * for conversion function _WM_Event2Midi */
 #ifdef DEBUG_MIDI
     uint8_t ch = data->channel;
-    MIDI_EVENT_DEBUG(ch, data->data.value);
+    MIDI_EVENT_DEBUG("_WM_do_meta_sequenceno", ch, data->data.value);
 #else
     WMIDI_UNUSED(data);
 #endif
@@ -1278,7 +1278,7 @@ void _WM_do_meta_channelprefix(struct _mdi *mdi, struct _event_data *data) {
  * for conversion function _WM_Event2Midi */
 #ifdef DEBUG_MIDI
     uint8_t ch = data->channel;
-    MIDI_EVENT_DEBUG(ch, data->data.value);
+    MIDI_EVENT_DEBUG("_WM_do_meta_channelprefix", ch, data->data.value);
 #else
     WMIDI_UNUSED(data);
 #endif
@@ -1291,7 +1291,7 @@ void _WM_do_meta_portprefix(struct _mdi *mdi, struct _event_data *data) {
  * for conversion function _WM_Event2Midi */
 #ifdef DEBUG_MIDI
     uint8_t ch = data->channel;
-    MIDI_EVENT_DEBUG(ch, data->data.value);
+    MIDI_EVENT_DEBUG("_WM_do_meta_portprefix", ch, data->data.value);
 #else
     WMIDI_UNUSED(data);
 #endif
@@ -1304,7 +1304,7 @@ void _WM_do_meta_smpteoffset(struct _mdi *mdi, struct _event_data *data) {
  * for conversion function _WM_Event2Midi */
 #ifdef DEBUG_MIDI
     uint8_t ch = data->channel;
-    MIDI_EVENT_DEBUG(ch, data->data.value);
+    MIDI_EVENT_DEBUG("_WM_do_meta_smpteoffset", ch, data->data.value);
 #else
     WMIDI_UNUSED(data);
 #endif
@@ -1317,7 +1317,7 @@ void _WM_do_meta_text(struct _mdi *mdi, struct _event_data *data) {
  * for conversion function _WM_Event2Midi */
 #ifdef DEBUG_MIDI
     uint8_t ch = data->channel;
-    MIDI_EVENT_SDEBUG(ch, data->data.string);
+    MIDI_EVENT_SDEBUG("_WM_do_meta_text", ch, data->data.string);
 #endif
     if (mdi->extra_info.mixer_options & WM_MO_TEXTASLYRIC) {
         mdi->lyric = data->data.string;
@@ -1331,7 +1331,7 @@ void _WM_do_meta_copyright(struct _mdi *mdi, struct _event_data *data) {
  * for conversion function _WM_Event2Midi */
 #ifdef DEBUG_MIDI
     uint8_t ch = data->channel;
-    MIDI_EVENT_SDEBUG(ch, data->data.string);
+    MIDI_EVENT_SDEBUG("_WM_do_meta_copyright", ch, data->data.string);
 #else
     WMIDI_UNUSED(data);
 #endif
@@ -1344,7 +1344,7 @@ void _WM_do_meta_trackname(struct _mdi *mdi, struct _event_data *data) {
  * for conversion function _WM_Event2Midi */
 #ifdef DEBUG_MIDI
     uint8_t ch = data->channel;
-    MIDI_EVENT_SDEBUG(ch, data->data.string);
+    MIDI_EVENT_SDEBUG("_WM_do_meta_trackname", ch, data->data.string);
 #else
     WMIDI_UNUSED(data);
 #endif
@@ -1357,7 +1357,7 @@ void _WM_do_meta_instrumentname(struct _mdi *mdi, struct _event_data *data) {
  * for conversion function _WM_Event2Midi */
 #ifdef DEBUG_MIDI
     uint8_t ch = data->channel;
-    MIDI_EVENT_SDEBUG(ch, data->data.string);
+    MIDI_EVENT_SDEBUG("_WM_do_meta_instrumentname", ch, data->data.string);
 #else
     WMIDI_UNUSED(data);
 #endif
@@ -1370,7 +1370,7 @@ void _WM_do_meta_lyric(struct _mdi *mdi, struct _event_data *data) {
  * for conversion function _WM_Event2Midi */
 #ifdef DEBUG_MIDI
     uint8_t ch = data->channel;
-    MIDI_EVENT_SDEBUG(ch, data->data.string);
+    MIDI_EVENT_SDEBUG("_WM_do_meta_lyric", ch, data->data.string);
 #endif
     if (!(mdi->extra_info.mixer_options & WM_MO_TEXTASLYRIC)) {
         mdi->lyric = data->data.string;
@@ -1383,7 +1383,7 @@ void _WM_do_meta_marker(struct _mdi *mdi, struct _event_data *data) {
  * for conversion function _WM_Event2Midi */
 #ifdef DEBUG_MIDI
     uint8_t ch = data->channel;
-    MIDI_EVENT_SDEBUG(ch, data->data.string);
+    MIDI_EVENT_SDEBUG("_WM_do_meta_marker", ch, data->data.string);
 #else
     WMIDI_UNUSED(data);
 #endif
@@ -1396,7 +1396,7 @@ void _WM_do_meta_cuepoint(struct _mdi *mdi, struct _event_data *data) {
  * for conversion function _WM_Event2Midi */
 #ifdef DEBUG_MIDI
     uint8_t ch = data->channel;
-    MIDI_EVENT_SDEBUG(ch, data->data.string);
+    MIDI_EVENT_SDEBUG("_WM_do_meta_cuepoint", ch, data->data.string);
 #else
     WMIDI_UNUSED(data);
 #endif
@@ -1451,7 +1451,7 @@ void _WM_ResetToStart(struct _mdi *mdi) {
 }
 
 int _WM_midi_setup_divisions(struct _mdi *mdi, uint32_t divisions) {
-    MIDI_EVENT_DEBUG(0,0);
+    MIDI_EVENT_DEBUG("_WM_midi_setup_divisions", 0,0);
     _WM_CheckEventMemoryPool(mdi);
     mdi->events[mdi->event_count].evtype = ev_midi_divisions;
     mdi->events[mdi->event_count].do_event = _WM_do_midi_divisions;
@@ -1464,7 +1464,7 @@ int _WM_midi_setup_divisions(struct _mdi *mdi, uint32_t divisions) {
 
 int _WM_midi_setup_noteoff(struct _mdi *mdi, uint8_t channel,
                            uint8_t note, uint8_t velocity) {
-    MIDI_EVENT_DEBUG(channel, note);
+    MIDI_EVENT_DEBUG("_WM_midi_setup_noteoff", channel, note);
     _WM_CheckEventMemoryPool(mdi);
     note &= 0x7f; /* silently bound note to 0..127 (github bug #180) */
     mdi->events[mdi->event_count].evtype = ev_note_off;
@@ -1478,7 +1478,7 @@ int _WM_midi_setup_noteoff(struct _mdi *mdi, uint8_t channel,
 
 static int midi_setup_noteon(struct _mdi *mdi, uint8_t channel,
                              uint8_t note, uint8_t velocity) {
-    MIDI_EVENT_DEBUG(channel, note);
+    MIDI_EVENT_DEBUG("midi_setup_noteon", channel, note);
     _WM_CheckEventMemoryPool(mdi);
     note &= 0x7f; /* silently bound note to 0..127 (github bug #180) */
     mdi->events[mdi->event_count].evtype = ev_note_on;
@@ -1495,7 +1495,7 @@ static int midi_setup_noteon(struct _mdi *mdi, uint8_t channel,
 
 static int midi_setup_aftertouch(struct _mdi *mdi, uint8_t channel,
                                  uint8_t note, uint8_t pressure) {
-    MIDI_EVENT_DEBUG(channel, note);
+    MIDI_EVENT_DEBUG("midi_setup_aftertouch", channel, note);
     _WM_CheckEventMemoryPool(mdi);
     note &= 0x7f; /* silently bound note to 0..127 (github bug #180) */
     mdi->events[mdi->event_count].evtype = ev_aftertouch;
@@ -1512,7 +1512,7 @@ static int midi_setup_control(struct _mdi *mdi, uint8_t channel,
     void (*tmp_event)(struct _mdi *mdi, struct _event_data *data);
     enum _event_type ev;
 
-    MIDI_EVENT_DEBUG(channel, controller);
+    MIDI_EVENT_DEBUG("midi_setup_control", channel, controller);
 
     switch (controller) {
         /*
@@ -1613,7 +1613,7 @@ static int midi_setup_control(struct _mdi *mdi, uint8_t channel,
 }
 
 static int midi_setup_patch(struct _mdi *mdi, uint8_t channel, uint8_t patch) {
-    MIDI_EVENT_DEBUG(channel, patch);
+    MIDI_EVENT_DEBUG("midi_setup_patch", channel, patch);
     _WM_CheckEventMemoryPool(mdi);
     mdi->events[mdi->event_count].evtype = ev_patch;
     mdi->events[mdi->event_count].do_event = _WM_do_patch;
@@ -1634,7 +1634,7 @@ static int midi_setup_patch(struct _mdi *mdi, uint8_t channel, uint8_t patch) {
 
 static int midi_setup_channel_pressure(struct _mdi *mdi, uint8_t channel,
                                        uint8_t pressure) {
-    MIDI_EVENT_DEBUG(channel, pressure);
+    MIDI_EVENT_DEBUG("midi_setup_channel_pressure", channel, pressure);
     _WM_CheckEventMemoryPool(mdi);
     mdi->events[mdi->event_count].evtype = ev_channel_pressure;
     mdi->events[mdi->event_count].do_event = _WM_do_channel_pressure;
@@ -1646,7 +1646,7 @@ static int midi_setup_channel_pressure(struct _mdi *mdi, uint8_t channel,
 }
 
 static int midi_setup_pitch(struct _mdi *mdi, uint8_t channel, uint16_t pitch) {
-    MIDI_EVENT_DEBUG(channel, pitch);
+    MIDI_EVENT_DEBUG("midi_setup_pitch", channel, pitch);
     _WM_CheckEventMemoryPool(mdi);
     mdi->events[mdi->event_count].evtype = ev_pitch;
     mdi->events[mdi->event_count].do_event = _WM_do_pitch;
@@ -1659,7 +1659,7 @@ static int midi_setup_pitch(struct _mdi *mdi, uint8_t channel, uint16_t pitch) {
 
 static int midi_setup_sysex_roland_drum_track(struct _mdi *mdi,
                                               uint8_t channel, uint16_t setting) {
-    MIDI_EVENT_DEBUG(channel, setting);
+    MIDI_EVENT_DEBUG("midi_setup_sysex_roland_drum_track", channel, setting);
     _WM_CheckEventMemoryPool(mdi);
     mdi->events[mdi->event_count].evtype = ev_sysex_roland_drum_track;
     mdi->events[mdi->event_count].do_event = _WM_do_sysex_roland_drum_track;
@@ -1677,7 +1677,7 @@ static int midi_setup_sysex_roland_drum_track(struct _mdi *mdi,
 }
 
 static int midi_setup_sysex_gm_reset(struct _mdi *mdi) {
-    MIDI_EVENT_DEBUG(0,0);
+    MIDI_EVENT_DEBUG("midi_setup_sysex_gm_reset", 0, 0);
 
     _WM_CheckEventMemoryPool(mdi);
     mdi->events[mdi->event_count].evtype = ev_sysex_roland_reset;
@@ -1690,7 +1690,7 @@ static int midi_setup_sysex_gm_reset(struct _mdi *mdi) {
 }
 
 static int midi_setup_sysex_roland_reset(struct _mdi *mdi) {
-    MIDI_EVENT_DEBUG(0,0);
+    MIDI_EVENT_DEBUG("midi_setup_sysex_roland_reset", 0, 0);
     _WM_CheckEventMemoryPool(mdi);
     mdi->events[mdi->event_count].evtype = ev_sysex_roland_reset;
     mdi->events[mdi->event_count].do_event = _WM_do_sysex_roland_reset;
@@ -1702,7 +1702,7 @@ static int midi_setup_sysex_roland_reset(struct _mdi *mdi) {
 }
 
 static int midi_setup_sysex_yamaha_reset(struct _mdi *mdi) {
-    MIDI_EVENT_DEBUG(0,0);
+    MIDI_EVENT_DEBUG("midi_setup_sysex_yamaha_reset", 0, 0);
     _WM_CheckEventMemoryPool(mdi);
     mdi->events[mdi->event_count].evtype = ev_sysex_roland_reset;
     mdi->events[mdi->event_count].do_event = _WM_do_sysex_roland_reset;
@@ -1714,7 +1714,7 @@ static int midi_setup_sysex_yamaha_reset(struct _mdi *mdi) {
 }
 
 int _WM_midi_setup_endoftrack(struct _mdi *mdi) {
-    MIDI_EVENT_DEBUG(0,0);
+    MIDI_EVENT_DEBUG("_WM_midi_setup_endoftrack", 0, 0);
     _WM_CheckEventMemoryPool(mdi);
     mdi->events[mdi->event_count].evtype = ev_meta_endoftrack;
     mdi->events[mdi->event_count].do_event = _WM_do_meta_endoftrack;
@@ -1726,7 +1726,7 @@ int _WM_midi_setup_endoftrack(struct _mdi *mdi) {
 }
 
 int _WM_midi_setup_tempo(struct _mdi *mdi, uint32_t setting) {
-    MIDI_EVENT_DEBUG(0,setting);
+    MIDI_EVENT_DEBUG("_WM_midi_setup_tempo", 0, setting);
     _WM_CheckEventMemoryPool(mdi);
     mdi->events[mdi->event_count].evtype = ev_meta_tempo;
     mdi->events[mdi->event_count].do_event = _WM_do_meta_tempo;
@@ -1738,7 +1738,7 @@ int _WM_midi_setup_tempo(struct _mdi *mdi, uint32_t setting) {
 }
 
 static int midi_setup_timesignature(struct _mdi *mdi, uint32_t setting) {
-    MIDI_EVENT_DEBUG(0, setting);
+    MIDI_EVENT_DEBUG("midi_setup_timesignature", 0, setting);
     _WM_CheckEventMemoryPool(mdi);
     mdi->events[mdi->event_count].evtype = ev_meta_timesignature;
     mdi->events[mdi->event_count].do_event = _WM_do_meta_timesignature;
@@ -1750,7 +1750,7 @@ static int midi_setup_timesignature(struct _mdi *mdi, uint32_t setting) {
 }
 
 static int midi_setup_keysignature(struct _mdi *mdi, uint32_t setting) {
-    MIDI_EVENT_DEBUG(0, setting);
+    MIDI_EVENT_DEBUG("midi_setup_keysignature", 0, setting);
     _WM_CheckEventMemoryPool(mdi);
     mdi->events[mdi->event_count].evtype = ev_meta_keysignature;
     mdi->events[mdi->event_count].do_event = _WM_do_meta_keysignature;
@@ -1762,7 +1762,7 @@ static int midi_setup_keysignature(struct _mdi *mdi, uint32_t setting) {
 }
 
 static int midi_setup_sequenceno(struct _mdi *mdi, uint32_t setting) {
-    MIDI_EVENT_DEBUG(0, setting);
+    MIDI_EVENT_DEBUG("midi_setup_sequenceno", 0, setting);
     _WM_CheckEventMemoryPool(mdi);
     mdi->events[mdi->event_count].evtype = ev_meta_sequenceno;
     mdi->events[mdi->event_count].do_event = _WM_do_meta_sequenceno;
@@ -1774,7 +1774,7 @@ static int midi_setup_sequenceno(struct _mdi *mdi, uint32_t setting) {
 }
 
 static int midi_setup_channelprefix(struct _mdi *mdi, uint32_t setting) {
-    MIDI_EVENT_DEBUG(0, setting);
+    MIDI_EVENT_DEBUG("midi_setup_channelprefix", 0, setting);
     _WM_CheckEventMemoryPool(mdi);
     mdi->events[mdi->event_count].evtype = ev_meta_channelprefix;
     mdi->events[mdi->event_count].do_event = _WM_do_meta_channelprefix;
@@ -1786,7 +1786,7 @@ static int midi_setup_channelprefix(struct _mdi *mdi, uint32_t setting) {
 }
 
 static int midi_setup_portprefix(struct _mdi *mdi, uint32_t setting) {
-    MIDI_EVENT_DEBUG(0, setting);
+    MIDI_EVENT_DEBUG("midi_setup_portprefix", 0, setting);
     _WM_CheckEventMemoryPool(mdi);
     mdi->events[mdi->event_count].evtype = ev_meta_portprefix;
     mdi->events[mdi->event_count].do_event = _WM_do_meta_portprefix;
@@ -1798,7 +1798,7 @@ static int midi_setup_portprefix(struct _mdi *mdi, uint32_t setting) {
 }
 
 static int midi_setup_smpteoffset(struct _mdi *mdi, uint32_t setting) {
-    MIDI_EVENT_DEBUG(0, setting);
+    MIDI_EVENT_DEBUG("midi_setup_smpteoffset", 0, setting);
     _WM_CheckEventMemoryPool(mdi);
     mdi->events[mdi->event_count].evtype = ev_meta_smpteoffset;
     mdi->events[mdi->event_count].do_event = _WM_do_meta_smpteoffset;
@@ -1825,7 +1825,7 @@ static void strip_text(char * text) {
 }
 
 static int midi_setup_text(struct _mdi *mdi, char * text) {
-    MIDI_EVENT_SDEBUG(0, text);
+    MIDI_EVENT_SDEBUG("midi_setup_text", 0, text);
     strip_text(text);
     _WM_CheckEventMemoryPool(mdi);
     mdi->events[mdi->event_count].evtype = ev_meta_text;
@@ -1838,7 +1838,7 @@ static int midi_setup_text(struct _mdi *mdi, char * text) {
 }
 
 static int midi_setup_copyright(struct _mdi *mdi, char * text) {
-    MIDI_EVENT_SDEBUG(0, text);
+    MIDI_EVENT_SDEBUG("midi_setup_copyright", 0, text);
     strip_text(text);
     _WM_CheckEventMemoryPool(mdi);
     mdi->events[mdi->event_count].evtype = ev_meta_copyright;
@@ -1851,7 +1851,7 @@ static int midi_setup_copyright(struct _mdi *mdi, char * text) {
 }
 
 static int midi_setup_trackname(struct _mdi *mdi, char * text) {
-    MIDI_EVENT_SDEBUG(0, text);
+    MIDI_EVENT_SDEBUG("midi_setup_trackname", 0, text);
     strip_text(text);
     _WM_CheckEventMemoryPool(mdi);
     mdi->events[mdi->event_count].evtype = ev_meta_trackname;
@@ -1864,7 +1864,7 @@ static int midi_setup_trackname(struct _mdi *mdi, char * text) {
 }
 
 static int midi_setup_instrumentname(struct _mdi *mdi, char * text) {
-    MIDI_EVENT_SDEBUG(0, text);
+    MIDI_EVENT_SDEBUG("midi_setup_instrumentname", 0, text);
     strip_text(text);
     _WM_CheckEventMemoryPool(mdi);
     mdi->events[mdi->event_count].evtype = ev_meta_instrumentname;
@@ -1877,7 +1877,7 @@ static int midi_setup_instrumentname(struct _mdi *mdi, char * text) {
 }
 
 static int midi_setup_lyric(struct _mdi *mdi, char * text) {
-    MIDI_EVENT_SDEBUG(0, text);
+    MIDI_EVENT_SDEBUG("midi_setup_lyric", 0, text);
     strip_text(text);
     _WM_CheckEventMemoryPool(mdi);
     mdi->events[mdi->event_count].evtype = ev_meta_lyric;
@@ -1890,7 +1890,7 @@ static int midi_setup_lyric(struct _mdi *mdi, char * text) {
 }
 
 static int midi_setup_marker(struct _mdi *mdi, char * text) {
-    MIDI_EVENT_SDEBUG(0, text);
+    MIDI_EVENT_SDEBUG("midi_setup_marker", 0, text);
     strip_text(text);
     _WM_CheckEventMemoryPool(mdi);
     mdi->events[mdi->event_count].evtype = ev_meta_marker;
@@ -1903,7 +1903,7 @@ static int midi_setup_marker(struct _mdi *mdi, char * text) {
 }
 
 static int midi_setup_cuepoint(struct _mdi *mdi, char * text) {
-    MIDI_EVENT_SDEBUG(0, text);
+    MIDI_EVENT_SDEBUG("midi_setup_cuepoint", 0, text);
     strip_text(text);
     _WM_CheckEventMemoryPool(mdi);
     mdi->events[mdi->event_count].evtype = ev_meta_cuepoint;

--- a/src/internal_midi.c
+++ b/src/internal_midi.c
@@ -2003,7 +2003,7 @@ void _WM_freeMDI(struct _mdi *mdi) {
     free(mdi);
 }
 
-uint32_t _WM_SetupMidiEvent(struct _mdi *mdi, uint8_t * event_data, uint32_t input_length, uint8_t running_event) {
+uint32_t _WM_SetupMidiEvent(struct _mdi *mdi, const uint8_t * event_data, uint32_t input_length, uint8_t running_event) {
     /*
      Only add standard MIDI and Sysex events in here.
      Non-standard events need to be handled by calling function

--- a/src/internal_midi.c
+++ b/src/internal_midi.c
@@ -486,7 +486,7 @@ void _WM_AdjustNoteVolumes(struct _mdi *mdi, uint8_t ch, struct _note *nte) {
 #define VOL_DIVISOR 4.0
     volume_adj = ((double)_WM_MasterVolume / 1024.0) / VOL_DIVISOR;
 
-    MIDI_EVENT_DEBUG(__FUNCTION__,ch, 0);
+    MIDI_EVENT_DEBUG(__func__,ch, 0);
 
     if (pan_ofs > 127) pan_ofs = 127;
     premix_dBm_left = dBm_pan_volume[(127-pan_ofs)];
@@ -555,7 +555,7 @@ static void _WM_CheckEventMemoryPool(struct _mdi *mdi) {
 
 void _WM_do_note_off_extra(struct _note *nte) {
 
-    MIDI_EVENT_DEBUG(__FUNCTION__,0, 0);
+    MIDI_EVENT_DEBUG(__func__,0, 0);
     nte->is_off = 0;
 
     if (!(nte->modes & SAMPLE_ENVELOPE)) {
@@ -609,7 +609,7 @@ void _WM_do_note_off(struct _mdi *mdi, struct _event_data *data) {
     struct _note *nte;
     uint8_t ch = data->channel;
 
-    MIDI_EVENT_DEBUG(__FUNCTION__,ch, data->data.value);
+    MIDI_EVENT_DEBUG(__func__,ch, data->data.value);
 
     nte = &mdi->note_table[0][ch][(data->data.value >> 8)];
     if (!nte->active) {
@@ -670,7 +670,7 @@ void _WM_do_note_on(struct _mdi *mdi, struct _event_data *data) {
         return;
     }
 
-    MIDI_EVENT_DEBUG(__FUNCTION__,ch, data->data.value);
+    MIDI_EVENT_DEBUG(__func__,ch, data->data.value);
 
     if (!mdi->channel[ch].isdrum) {
         patch = mdi->channel[ch].patch;
@@ -752,7 +752,7 @@ void _WM_do_aftertouch(struct _mdi *mdi, struct _event_data *data) {
     struct _note *nte;
     uint8_t ch = data->channel;
 
-    MIDI_EVENT_DEBUG(__FUNCTION__,ch, data->data.value);
+    MIDI_EVENT_DEBUG(__func__,ch, data->data.value);
 
     nte = &mdi->note_table[0][ch][(data->data.value >> 8)];
     if (!nte->active) {
@@ -772,7 +772,7 @@ void _WM_do_aftertouch(struct _mdi *mdi, struct _event_data *data) {
 
 void _WM_do_control_bank_select(struct _mdi *mdi, struct _event_data *data) {
     uint8_t ch = data->channel;
-    MIDI_EVENT_DEBUG(__FUNCTION__,ch, data->data.value);
+    MIDI_EVENT_DEBUG(__func__,ch, data->data.value);
     mdi->channel[ch].bank = data->data.value;
 }
 
@@ -780,7 +780,7 @@ void _WM_do_control_data_entry_course(struct _mdi *mdi,
                                          struct _event_data *data) {
     uint8_t ch = data->channel;
     int data_tmp;
-    MIDI_EVENT_DEBUG(__FUNCTION__,ch, data->data.value);
+    MIDI_EVENT_DEBUG(__func__,ch, data->data.value);
 
     if ((mdi->channel[ch].reg_non == 0)
         && (mdi->channel[ch].reg_data == 0x0000)) { /* Pitch Bend Range */
@@ -794,7 +794,7 @@ void _WM_do_control_data_entry_course(struct _mdi *mdi,
 void _WM_do_control_channel_volume(struct _mdi *mdi,
                                       struct _event_data *data) {
     uint8_t ch = data->channel;
-    MIDI_EVENT_DEBUG(__FUNCTION__,ch, data->data.value);
+    MIDI_EVENT_DEBUG(__func__,ch, data->data.value);
 
     mdi->channel[ch].volume = data->data.value;
     _WM_AdjustChannelVolumes(mdi, ch);
@@ -803,7 +803,7 @@ void _WM_do_control_channel_volume(struct _mdi *mdi,
 void _WM_do_control_channel_balance(struct _mdi *mdi,
                                        struct _event_data *data) {
     uint8_t ch = data->channel;
-    MIDI_EVENT_DEBUG(__FUNCTION__,ch, data->data.value);
+    MIDI_EVENT_DEBUG(__func__,ch, data->data.value);
 
     mdi->channel[ch].balance = data->data.value;
     _WM_AdjustChannelVolumes(mdi, ch);
@@ -811,7 +811,7 @@ void _WM_do_control_channel_balance(struct _mdi *mdi,
 
 void _WM_do_control_channel_pan(struct _mdi *mdi, struct _event_data *data) {
     uint8_t ch = data->channel;
-    MIDI_EVENT_DEBUG(__FUNCTION__,ch, data->data.value);
+    MIDI_EVENT_DEBUG(__func__,ch, data->data.value);
 
     mdi->channel[ch].pan = data->data.value;
     _WM_AdjustChannelVolumes(mdi, ch);
@@ -820,7 +820,7 @@ void _WM_do_control_channel_pan(struct _mdi *mdi, struct _event_data *data) {
 void _WM_do_control_channel_expression(struct _mdi *mdi,
                                           struct _event_data *data) {
     uint8_t ch = data->channel;
-    MIDI_EVENT_DEBUG(__FUNCTION__,ch, data->data.value);
+    MIDI_EVENT_DEBUG(__func__,ch, data->data.value);
 
     mdi->channel[ch].expression = data->data.value;
     _WM_AdjustChannelVolumes(mdi, ch);
@@ -830,7 +830,7 @@ void _WM_do_control_data_entry_fine(struct _mdi *mdi,
                                        struct _event_data *data) {
     uint8_t ch = data->channel;
     int data_tmp;
-    MIDI_EVENT_DEBUG(__FUNCTION__,ch, data->data.value);
+    MIDI_EVENT_DEBUG(__func__,ch, data->data.value);
 
     if ((mdi->channel[ch].reg_non == 0)
       && (mdi->channel[ch].reg_data == 0x0000)) { /* Pitch Bend Range */
@@ -844,7 +844,7 @@ void _WM_do_control_data_entry_fine(struct _mdi *mdi,
 void _WM_do_control_channel_hold(struct _mdi *mdi, struct _event_data *data) {
     struct _note *note_data = mdi->note;
     uint8_t ch = data->channel;
-    MIDI_EVENT_DEBUG(__FUNCTION__,ch, data->data.value);
+    MIDI_EVENT_DEBUG(__func__,ch, data->data.value);
 
     if (data->data.value > 63) {
         mdi->channel[ch].hold = 1;
@@ -910,7 +910,7 @@ void _WM_do_control_channel_hold(struct _mdi *mdi, struct _event_data *data) {
 void _WM_do_control_data_increment(struct _mdi *mdi,
                                       struct _event_data *data) {
     uint8_t ch = data->channel;
-    MIDI_EVENT_DEBUG(__FUNCTION__,ch, data->data.value);
+    MIDI_EVENT_DEBUG(__func__,ch, data->data.value);
 
     if ((mdi->channel[ch].reg_non == 0)
         && (mdi->channel[ch].reg_data == 0x0000)) { /* Pitch Bend Range */
@@ -922,7 +922,7 @@ void _WM_do_control_data_increment(struct _mdi *mdi,
 void _WM_do_control_data_decrement(struct _mdi *mdi,
                                       struct _event_data *data) {
     uint8_t ch = data->channel;
-    MIDI_EVENT_DEBUG(__FUNCTION__,ch, data->data.value);
+    MIDI_EVENT_DEBUG(__func__,ch, data->data.value);
 
     if ((mdi->channel[ch].reg_non == 0)
         && (mdi->channel[ch].reg_data == 0x0000)) { /* Pitch Bend Range */
@@ -933,7 +933,7 @@ void _WM_do_control_data_decrement(struct _mdi *mdi,
 void _WM_do_control_non_registered_param_fine(struct _mdi *mdi,
                                             struct _event_data *data) {
     uint8_t ch = data->channel;
-    MIDI_EVENT_DEBUG(__FUNCTION__,ch, data->data.value);
+    MIDI_EVENT_DEBUG(__func__,ch, data->data.value);
     mdi->channel[ch].reg_data = (mdi->channel[ch].reg_data & 0x3F80)
                                 | data->data.value;
     mdi->channel[ch].reg_non = 1;
@@ -942,7 +942,7 @@ void _WM_do_control_non_registered_param_fine(struct _mdi *mdi,
 void _WM_do_control_non_registered_param_course(struct _mdi *mdi,
                                      struct _event_data *data) {
     uint8_t ch = data->channel;
-    MIDI_EVENT_DEBUG(__FUNCTION__,ch, data->data.value);
+    MIDI_EVENT_DEBUG(__func__,ch, data->data.value);
     mdi->channel[ch].reg_data = (mdi->channel[ch].reg_data & 0x7F)
                                 | (data->data.value << 7);
     mdi->channel[ch].reg_non = 1;
@@ -951,7 +951,7 @@ void _WM_do_control_non_registered_param_course(struct _mdi *mdi,
 void _WM_do_control_registered_param_fine(struct _mdi *mdi,
                                           struct _event_data *data) {
     uint8_t ch = data->channel;
-    MIDI_EVENT_DEBUG(__FUNCTION__,ch, data->data.value);
+    MIDI_EVENT_DEBUG(__func__,ch, data->data.value);
     mdi->channel[ch].reg_data = (mdi->channel[ch].reg_data & 0x3F80)
                                 | data->data.value;
     mdi->channel[ch].reg_non = 0;
@@ -960,7 +960,7 @@ void _WM_do_control_registered_param_fine(struct _mdi *mdi,
 void _WM_do_control_registered_param_course(struct _mdi *mdi,
                                             struct _event_data *data) {
     uint8_t ch = data->channel;
-    MIDI_EVENT_DEBUG(__FUNCTION__,ch, data->data.value);
+    MIDI_EVENT_DEBUG(__func__,ch, data->data.value);
     mdi->channel[ch].reg_data = (mdi->channel[ch].reg_data & 0x7F)
                                 | (data->data.value << 7);
     mdi->channel[ch].reg_non = 0;
@@ -970,7 +970,7 @@ void _WM_do_control_channel_sound_off(struct _mdi *mdi,
                                       struct _event_data *data) {
     struct _note *note_data = mdi->note;
     uint8_t ch = data->channel;
-    MIDI_EVENT_DEBUG(__FUNCTION__,ch, data->data.value);
+    MIDI_EVENT_DEBUG(__func__,ch, data->data.value);
 
     if (note_data) {
         do {
@@ -988,7 +988,7 @@ void _WM_do_control_channel_sound_off(struct _mdi *mdi,
 void _WM_do_control_channel_controllers_off(struct _mdi *mdi,
                                             struct _event_data *data) {
     uint8_t ch = data->channel;
-    MIDI_EVENT_DEBUG(__FUNCTION__,ch, data->data.value);
+    MIDI_EVENT_DEBUG(__func__,ch, data->data.value);
 
     mdi->channel[ch].expression = 127;
     mdi->channel[ch].pressure = 127;
@@ -1005,7 +1005,7 @@ void _WM_do_control_channel_notes_off(struct _mdi *mdi,
                                       struct _event_data *data) {
     struct _note *note_data = mdi->note;
     uint8_t ch = data->channel;
-    MIDI_EVENT_DEBUG(__FUNCTION__,ch, data->data.value);
+    MIDI_EVENT_DEBUG(__func__,ch, data->data.value);
 
     if (mdi->channel[ch].isdrum)
         return;
@@ -1038,7 +1038,7 @@ void _WM_do_control_channel_notes_off(struct _mdi *mdi,
 void _WM_do_control_dummy(struct _mdi *mdi, struct _event_data *data) {
 #ifdef DEBUG_MIDI
     uint8_t ch = data->channel;
-    MIDI_EVENT_DEBUG(__FUNCTION__, ch, data->data.value);
+    MIDI_EVENT_DEBUG(__func__, ch, data->data.value);
 #else
     WMIDI_UNUSED(data);
 #endif
@@ -1047,7 +1047,7 @@ void _WM_do_control_dummy(struct _mdi *mdi, struct _event_data *data) {
 
 void _WM_do_patch(struct _mdi *mdi, struct _event_data *data) {
     uint8_t ch = data->channel;
-    MIDI_EVENT_DEBUG(__FUNCTION__,ch, data->data.value);
+    MIDI_EVENT_DEBUG(__func__,ch, data->data.value);
     if (!mdi->channel[ch].isdrum) {
         mdi->channel[ch].patch = _WM_get_patch_data(mdi,
                                                 ((mdi->channel[ch].bank << 8) | data->data.value));
@@ -1059,7 +1059,7 @@ void _WM_do_patch(struct _mdi *mdi, struct _event_data *data) {
 void _WM_do_channel_pressure(struct _mdi *mdi, struct _event_data *data) {
     uint8_t ch = data->channel;
     struct _note *note_data = mdi->note;
-    MIDI_EVENT_DEBUG(__FUNCTION__,ch, data->data.value);
+    MIDI_EVENT_DEBUG(__func__,ch, data->data.value);
 
     mdi->channel[ch].pressure = data->data.value;
 
@@ -1082,7 +1082,7 @@ void _WM_do_pitch(struct _mdi *mdi, struct _event_data *data) {
     struct _note *note_data = mdi->note;
     uint8_t ch = data->channel;
 
-    MIDI_EVENT_DEBUG(__FUNCTION__,ch, data->data.value);
+    MIDI_EVENT_DEBUG(__func__,ch, data->data.value);
     mdi->channel[ch].pitch = data->data.value - 0x2000;
 
     if (mdi->channel[ch].pitch < 0) {
@@ -1106,7 +1106,7 @@ void _WM_do_pitch(struct _mdi *mdi, struct _event_data *data) {
 void _WM_do_sysex_roland_drum_track(struct _mdi *mdi, struct _event_data *data) {
     uint8_t ch = data->channel;
 
-    MIDI_EVENT_DEBUG(__FUNCTION__,ch, data->data.value);
+    MIDI_EVENT_DEBUG(__func__,ch, data->data.value);
 
     if (data->data.value > 0) {
         mdi->channel[ch].isdrum = 1;
@@ -1121,9 +1121,9 @@ void _WM_do_sysex_gm_reset(struct _mdi *mdi, struct _event_data *data) {
     int i;
 
     if (data != NULL) {
-        MIDI_EVENT_DEBUG(__FUNCTION__,data->channel, data->data.value);
+        MIDI_EVENT_DEBUG(__func__,data->channel, data->data.value);
     } else {
-        MIDI_EVENT_DEBUG(__FUNCTION__,0, 0);
+        MIDI_EVENT_DEBUG(__func__,0, 0);
     }
 
     for (i = 0; i < 16; i++) {
@@ -1154,7 +1154,7 @@ void _WM_do_sysex_gm_reset(struct _mdi *mdi, struct _event_data *data) {
 void _WM_do_sysex_roland_reset(struct _mdi *mdi, struct _event_data *data) {
 #ifdef DEBUG_MIDI
     uint8_t ch = data->channel;
-    MIDI_EVENT_DEBUG(__FUNCTION__, ch, data->data.value);
+    MIDI_EVENT_DEBUG(__func__, ch, data->data.value);
 #else
     WMIDI_UNUSED(data);
 #endif
@@ -1164,7 +1164,7 @@ void _WM_do_sysex_roland_reset(struct _mdi *mdi, struct _event_data *data) {
 void _WM_do_sysex_yamaha_reset(struct _mdi *mdi, struct _event_data *data) {
 #ifdef DEBUG_MIDI
     uint8_t ch = data->channel;
-    MIDI_EVENT_DEBUG(__FUNCTION__, ch, data->data.value);
+    MIDI_EVENT_DEBUG(__func__, ch, data->data.value);
 #else
     WMIDI_UNUSED(data);
 #endif
@@ -1212,7 +1212,7 @@ void _WM_do_meta_endoftrack(struct _mdi *mdi, struct _event_data *data) {
  * for conversion function _WM_Event2Midi */
 #ifdef DEBUG_MIDI
     uint8_t ch = data->channel;
-    MIDI_EVENT_DEBUG(__FUNCTION__, ch, data->data.value);
+    MIDI_EVENT_DEBUG(__func__, ch, data->data.value);
 #else
     WMIDI_UNUSED(data);
 #endif
@@ -1226,7 +1226,7 @@ void _WM_do_meta_tempo(struct _mdi *mdi, struct _event_data *data) {
  * for conversion function _WM_Event2Midi */
 #ifdef DEBUG_MIDI
     uint8_t ch = data->channel;
-    MIDI_EVENT_DEBUG(__FUNCTION__, ch, data->data.value);
+    MIDI_EVENT_DEBUG(__func__, ch, data->data.value);
 #else
     WMIDI_UNUSED(data);
 #endif
@@ -1239,7 +1239,7 @@ void _WM_do_meta_timesignature(struct _mdi *mdi, struct _event_data *data) {
  * for conversion function _WM_Event2Midi */
 #ifdef DEBUG_MIDI
     uint8_t ch = data->channel;
-    MIDI_EVENT_DEBUG(__FUNCTION__, ch, data->data.value);
+    MIDI_EVENT_DEBUG(__func__, ch, data->data.value);
 #else
     WMIDI_UNUSED(data);
 #endif
@@ -1252,7 +1252,7 @@ void _WM_do_meta_keysignature(struct _mdi *mdi, struct _event_data *data) {
  * for conversion function _WM_Event2Midi */
 #ifdef DEBUG_MIDI
     uint8_t ch = data->channel;
-    MIDI_EVENT_DEBUG(__FUNCTION__, ch, data->data.value);
+    MIDI_EVENT_DEBUG(__func__, ch, data->data.value);
 #else
     WMIDI_UNUSED(data);
 #endif
@@ -1265,7 +1265,7 @@ void _WM_do_meta_sequenceno(struct _mdi *mdi, struct _event_data *data) {
  * for conversion function _WM_Event2Midi */
 #ifdef DEBUG_MIDI
     uint8_t ch = data->channel;
-    MIDI_EVENT_DEBUG(__FUNCTION__, ch, data->data.value);
+    MIDI_EVENT_DEBUG(__func__, ch, data->data.value);
 #else
     WMIDI_UNUSED(data);
 #endif
@@ -1278,7 +1278,7 @@ void _WM_do_meta_channelprefix(struct _mdi *mdi, struct _event_data *data) {
  * for conversion function _WM_Event2Midi */
 #ifdef DEBUG_MIDI
     uint8_t ch = data->channel;
-    MIDI_EVENT_DEBUG(__FUNCTION__, ch, data->data.value);
+    MIDI_EVENT_DEBUG(__func__, ch, data->data.value);
 #else
     WMIDI_UNUSED(data);
 #endif
@@ -1291,7 +1291,7 @@ void _WM_do_meta_portprefix(struct _mdi *mdi, struct _event_data *data) {
  * for conversion function _WM_Event2Midi */
 #ifdef DEBUG_MIDI
     uint8_t ch = data->channel;
-    MIDI_EVENT_DEBUG(__FUNCTION__, ch, data->data.value);
+    MIDI_EVENT_DEBUG(__func__, ch, data->data.value);
 #else
     WMIDI_UNUSED(data);
 #endif
@@ -1304,7 +1304,7 @@ void _WM_do_meta_smpteoffset(struct _mdi *mdi, struct _event_data *data) {
  * for conversion function _WM_Event2Midi */
 #ifdef DEBUG_MIDI
     uint8_t ch = data->channel;
-    MIDI_EVENT_DEBUG(__FUNCTION__, ch, data->data.value);
+    MIDI_EVENT_DEBUG(__func__, ch, data->data.value);
 #else
     WMIDI_UNUSED(data);
 #endif
@@ -1317,7 +1317,7 @@ void _WM_do_meta_text(struct _mdi *mdi, struct _event_data *data) {
  * for conversion function _WM_Event2Midi */
 #ifdef DEBUG_MIDI
     uint8_t ch = data->channel;
-    MIDI_EVENT_SDEBUG(__FUNCTION__, ch, data->data.string);
+    MIDI_EVENT_SDEBUG(__func__, ch, data->data.string);
 #endif
     if (mdi->extra_info.mixer_options & WM_MO_TEXTASLYRIC) {
         mdi->lyric = data->data.string;
@@ -1331,7 +1331,7 @@ void _WM_do_meta_copyright(struct _mdi *mdi, struct _event_data *data) {
  * for conversion function _WM_Event2Midi */
 #ifdef DEBUG_MIDI
     uint8_t ch = data->channel;
-    MIDI_EVENT_SDEBUG(__FUNCTION__, ch, data->data.string);
+    MIDI_EVENT_SDEBUG(__func__, ch, data->data.string);
 #else
     WMIDI_UNUSED(data);
 #endif
@@ -1344,7 +1344,7 @@ void _WM_do_meta_trackname(struct _mdi *mdi, struct _event_data *data) {
  * for conversion function _WM_Event2Midi */
 #ifdef DEBUG_MIDI
     uint8_t ch = data->channel;
-    MIDI_EVENT_SDEBUG(__FUNCTION__, ch, data->data.string);
+    MIDI_EVENT_SDEBUG(__func__, ch, data->data.string);
 #else
     WMIDI_UNUSED(data);
 #endif
@@ -1357,7 +1357,7 @@ void _WM_do_meta_instrumentname(struct _mdi *mdi, struct _event_data *data) {
  * for conversion function _WM_Event2Midi */
 #ifdef DEBUG_MIDI
     uint8_t ch = data->channel;
-    MIDI_EVENT_SDEBUG(__FUNCTION__, ch, data->data.string);
+    MIDI_EVENT_SDEBUG(__func__, ch, data->data.string);
 #else
     WMIDI_UNUSED(data);
 #endif
@@ -1370,7 +1370,7 @@ void _WM_do_meta_lyric(struct _mdi *mdi, struct _event_data *data) {
  * for conversion function _WM_Event2Midi */
 #ifdef DEBUG_MIDI
     uint8_t ch = data->channel;
-    MIDI_EVENT_SDEBUG(__FUNCTION__, ch, data->data.string);
+    MIDI_EVENT_SDEBUG(__func__, ch, data->data.string);
 #endif
     if (!(mdi->extra_info.mixer_options & WM_MO_TEXTASLYRIC)) {
         mdi->lyric = data->data.string;
@@ -1383,7 +1383,7 @@ void _WM_do_meta_marker(struct _mdi *mdi, struct _event_data *data) {
  * for conversion function _WM_Event2Midi */
 #ifdef DEBUG_MIDI
     uint8_t ch = data->channel;
-    MIDI_EVENT_SDEBUG(__FUNCTION__, ch, data->data.string);
+    MIDI_EVENT_SDEBUG(__func__, ch, data->data.string);
 #else
     WMIDI_UNUSED(data);
 #endif
@@ -1396,7 +1396,7 @@ void _WM_do_meta_cuepoint(struct _mdi *mdi, struct _event_data *data) {
  * for conversion function _WM_Event2Midi */
 #ifdef DEBUG_MIDI
     uint8_t ch = data->channel;
-    MIDI_EVENT_SDEBUG(__FUNCTION__, ch, data->data.string);
+    MIDI_EVENT_SDEBUG(__func__, ch, data->data.string);
 #else
     WMIDI_UNUSED(data);
 #endif
@@ -1451,7 +1451,7 @@ void _WM_ResetToStart(struct _mdi *mdi) {
 }
 
 int _WM_midi_setup_divisions(struct _mdi *mdi, uint32_t divisions) {
-    MIDI_EVENT_DEBUG(__FUNCTION__,0,0);
+    MIDI_EVENT_DEBUG(__func__,0,0);
     _WM_CheckEventMemoryPool(mdi);
     mdi->events[mdi->event_count].evtype = ev_midi_divisions;
     mdi->events[mdi->event_count].do_event = _WM_do_midi_divisions;
@@ -1464,7 +1464,7 @@ int _WM_midi_setup_divisions(struct _mdi *mdi, uint32_t divisions) {
 
 int _WM_midi_setup_noteoff(struct _mdi *mdi, uint8_t channel,
                            uint8_t note, uint8_t velocity) {
-    MIDI_EVENT_DEBUG(__FUNCTION__,channel, note);
+    MIDI_EVENT_DEBUG(__func__,channel, note);
     _WM_CheckEventMemoryPool(mdi);
     note &= 0x7f; /* silently bound note to 0..127 (github bug #180) */
     mdi->events[mdi->event_count].evtype = ev_note_off;
@@ -1478,7 +1478,7 @@ int _WM_midi_setup_noteoff(struct _mdi *mdi, uint8_t channel,
 
 static int midi_setup_noteon(struct _mdi *mdi, uint8_t channel,
                              uint8_t note, uint8_t velocity) {
-    MIDI_EVENT_DEBUG(__FUNCTION__,channel, note);
+    MIDI_EVENT_DEBUG(__func__,channel, note);
     _WM_CheckEventMemoryPool(mdi);
     note &= 0x7f; /* silently bound note to 0..127 (github bug #180) */
     mdi->events[mdi->event_count].evtype = ev_note_on;
@@ -1495,7 +1495,7 @@ static int midi_setup_noteon(struct _mdi *mdi, uint8_t channel,
 
 static int midi_setup_aftertouch(struct _mdi *mdi, uint8_t channel,
                                  uint8_t note, uint8_t pressure) {
-    MIDI_EVENT_DEBUG(__FUNCTION__,channel, note);
+    MIDI_EVENT_DEBUG(__func__,channel, note);
     _WM_CheckEventMemoryPool(mdi);
     note &= 0x7f; /* silently bound note to 0..127 (github bug #180) */
     mdi->events[mdi->event_count].evtype = ev_aftertouch;
@@ -1512,7 +1512,7 @@ static int midi_setup_control(struct _mdi *mdi, uint8_t channel,
     void (*tmp_event)(struct _mdi *mdi, struct _event_data *data);
     enum _event_type ev;
 
-    MIDI_EVENT_DEBUG(__FUNCTION__,channel, controller);
+    MIDI_EVENT_DEBUG(__func__,channel, controller);
 
     switch (controller) {
         /*
@@ -1613,7 +1613,7 @@ static int midi_setup_control(struct _mdi *mdi, uint8_t channel,
 }
 
 static int midi_setup_patch(struct _mdi *mdi, uint8_t channel, uint8_t patch) {
-    MIDI_EVENT_DEBUG(__FUNCTION__,channel, patch);
+    MIDI_EVENT_DEBUG(__func__,channel, patch);
     _WM_CheckEventMemoryPool(mdi);
     mdi->events[mdi->event_count].evtype = ev_patch;
     mdi->events[mdi->event_count].do_event = _WM_do_patch;
@@ -1634,7 +1634,7 @@ static int midi_setup_patch(struct _mdi *mdi, uint8_t channel, uint8_t patch) {
 
 static int midi_setup_channel_pressure(struct _mdi *mdi, uint8_t channel,
                                        uint8_t pressure) {
-    MIDI_EVENT_DEBUG(__FUNCTION__,channel, pressure);
+    MIDI_EVENT_DEBUG(__func__,channel, pressure);
     _WM_CheckEventMemoryPool(mdi);
     mdi->events[mdi->event_count].evtype = ev_channel_pressure;
     mdi->events[mdi->event_count].do_event = _WM_do_channel_pressure;
@@ -1646,7 +1646,7 @@ static int midi_setup_channel_pressure(struct _mdi *mdi, uint8_t channel,
 }
 
 static int midi_setup_pitch(struct _mdi *mdi, uint8_t channel, uint16_t pitch) {
-    MIDI_EVENT_DEBUG(__FUNCTION__,channel, pitch);
+    MIDI_EVENT_DEBUG(__func__,channel, pitch);
     _WM_CheckEventMemoryPool(mdi);
     mdi->events[mdi->event_count].evtype = ev_pitch;
     mdi->events[mdi->event_count].do_event = _WM_do_pitch;
@@ -1659,7 +1659,7 @@ static int midi_setup_pitch(struct _mdi *mdi, uint8_t channel, uint16_t pitch) {
 
 static int midi_setup_sysex_roland_drum_track(struct _mdi *mdi,
                                               uint8_t channel, uint16_t setting) {
-    MIDI_EVENT_DEBUG(__FUNCTION__,channel, setting);
+    MIDI_EVENT_DEBUG(__func__,channel, setting);
     _WM_CheckEventMemoryPool(mdi);
     mdi->events[mdi->event_count].evtype = ev_sysex_roland_drum_track;
     mdi->events[mdi->event_count].do_event = _WM_do_sysex_roland_drum_track;
@@ -1677,7 +1677,7 @@ static int midi_setup_sysex_roland_drum_track(struct _mdi *mdi,
 }
 
 static int midi_setup_sysex_gm_reset(struct _mdi *mdi) {
-    MIDI_EVENT_DEBUG(__FUNCTION__,0,0);
+    MIDI_EVENT_DEBUG(__func__,0,0);
 
     _WM_CheckEventMemoryPool(mdi);
     mdi->events[mdi->event_count].evtype = ev_sysex_roland_reset;
@@ -1690,7 +1690,7 @@ static int midi_setup_sysex_gm_reset(struct _mdi *mdi) {
 }
 
 static int midi_setup_sysex_roland_reset(struct _mdi *mdi) {
-    MIDI_EVENT_DEBUG(__FUNCTION__,0,0);
+    MIDI_EVENT_DEBUG(__func__,0,0);
     _WM_CheckEventMemoryPool(mdi);
     mdi->events[mdi->event_count].evtype = ev_sysex_roland_reset;
     mdi->events[mdi->event_count].do_event = _WM_do_sysex_roland_reset;
@@ -1702,7 +1702,7 @@ static int midi_setup_sysex_roland_reset(struct _mdi *mdi) {
 }
 
 static int midi_setup_sysex_yamaha_reset(struct _mdi *mdi) {
-    MIDI_EVENT_DEBUG(__FUNCTION__,0,0);
+    MIDI_EVENT_DEBUG(__func__,0,0);
     _WM_CheckEventMemoryPool(mdi);
     mdi->events[mdi->event_count].evtype = ev_sysex_roland_reset;
     mdi->events[mdi->event_count].do_event = _WM_do_sysex_roland_reset;
@@ -1714,7 +1714,7 @@ static int midi_setup_sysex_yamaha_reset(struct _mdi *mdi) {
 }
 
 int _WM_midi_setup_endoftrack(struct _mdi *mdi) {
-    MIDI_EVENT_DEBUG(__FUNCTION__,0,0);
+    MIDI_EVENT_DEBUG(__func__,0,0);
     _WM_CheckEventMemoryPool(mdi);
     mdi->events[mdi->event_count].evtype = ev_meta_endoftrack;
     mdi->events[mdi->event_count].do_event = _WM_do_meta_endoftrack;
@@ -1726,7 +1726,7 @@ int _WM_midi_setup_endoftrack(struct _mdi *mdi) {
 }
 
 int _WM_midi_setup_tempo(struct _mdi *mdi, uint32_t setting) {
-    MIDI_EVENT_DEBUG(__FUNCTION__,0,setting);
+    MIDI_EVENT_DEBUG(__func__,0,setting);
     _WM_CheckEventMemoryPool(mdi);
     mdi->events[mdi->event_count].evtype = ev_meta_tempo;
     mdi->events[mdi->event_count].do_event = _WM_do_meta_tempo;
@@ -1738,7 +1738,7 @@ int _WM_midi_setup_tempo(struct _mdi *mdi, uint32_t setting) {
 }
 
 static int midi_setup_timesignature(struct _mdi *mdi, uint32_t setting) {
-    MIDI_EVENT_DEBUG(__FUNCTION__,0, setting);
+    MIDI_EVENT_DEBUG(__func__,0, setting);
     _WM_CheckEventMemoryPool(mdi);
     mdi->events[mdi->event_count].evtype = ev_meta_timesignature;
     mdi->events[mdi->event_count].do_event = _WM_do_meta_timesignature;
@@ -1750,7 +1750,7 @@ static int midi_setup_timesignature(struct _mdi *mdi, uint32_t setting) {
 }
 
 static int midi_setup_keysignature(struct _mdi *mdi, uint32_t setting) {
-    MIDI_EVENT_DEBUG(__FUNCTION__,0, setting);
+    MIDI_EVENT_DEBUG(__func__,0, setting);
     _WM_CheckEventMemoryPool(mdi);
     mdi->events[mdi->event_count].evtype = ev_meta_keysignature;
     mdi->events[mdi->event_count].do_event = _WM_do_meta_keysignature;
@@ -1762,7 +1762,7 @@ static int midi_setup_keysignature(struct _mdi *mdi, uint32_t setting) {
 }
 
 static int midi_setup_sequenceno(struct _mdi *mdi, uint32_t setting) {
-    MIDI_EVENT_DEBUG(__FUNCTION__,0, setting);
+    MIDI_EVENT_DEBUG(__func__,0, setting);
     _WM_CheckEventMemoryPool(mdi);
     mdi->events[mdi->event_count].evtype = ev_meta_sequenceno;
     mdi->events[mdi->event_count].do_event = _WM_do_meta_sequenceno;
@@ -1774,7 +1774,7 @@ static int midi_setup_sequenceno(struct _mdi *mdi, uint32_t setting) {
 }
 
 static int midi_setup_channelprefix(struct _mdi *mdi, uint32_t setting) {
-    MIDI_EVENT_DEBUG(__FUNCTION__,0, setting);
+    MIDI_EVENT_DEBUG(__func__,0, setting);
     _WM_CheckEventMemoryPool(mdi);
     mdi->events[mdi->event_count].evtype = ev_meta_channelprefix;
     mdi->events[mdi->event_count].do_event = _WM_do_meta_channelprefix;
@@ -1786,7 +1786,7 @@ static int midi_setup_channelprefix(struct _mdi *mdi, uint32_t setting) {
 }
 
 static int midi_setup_portprefix(struct _mdi *mdi, uint32_t setting) {
-    MIDI_EVENT_DEBUG(__FUNCTION__,0, setting);
+    MIDI_EVENT_DEBUG(__func__,0, setting);
     _WM_CheckEventMemoryPool(mdi);
     mdi->events[mdi->event_count].evtype = ev_meta_portprefix;
     mdi->events[mdi->event_count].do_event = _WM_do_meta_portprefix;
@@ -1798,7 +1798,7 @@ static int midi_setup_portprefix(struct _mdi *mdi, uint32_t setting) {
 }
 
 static int midi_setup_smpteoffset(struct _mdi *mdi, uint32_t setting) {
-    MIDI_EVENT_DEBUG(__FUNCTION__,0, setting);
+    MIDI_EVENT_DEBUG(__func__,0, setting);
     _WM_CheckEventMemoryPool(mdi);
     mdi->events[mdi->event_count].evtype = ev_meta_smpteoffset;
     mdi->events[mdi->event_count].do_event = _WM_do_meta_smpteoffset;
@@ -1825,7 +1825,7 @@ static void strip_text(char * text) {
 }
 
 static int midi_setup_text(struct _mdi *mdi, char * text) {
-    MIDI_EVENT_SDEBUG(__FUNCTION__,0, text);
+    MIDI_EVENT_SDEBUG(__func__,0, text);
     strip_text(text);
     _WM_CheckEventMemoryPool(mdi);
     mdi->events[mdi->event_count].evtype = ev_meta_text;
@@ -1838,7 +1838,7 @@ static int midi_setup_text(struct _mdi *mdi, char * text) {
 }
 
 static int midi_setup_copyright(struct _mdi *mdi, char * text) {
-    MIDI_EVENT_SDEBUG(__FUNCTION__,0, text);
+    MIDI_EVENT_SDEBUG(__func__,0, text);
     strip_text(text);
     _WM_CheckEventMemoryPool(mdi);
     mdi->events[mdi->event_count].evtype = ev_meta_copyright;
@@ -1851,7 +1851,7 @@ static int midi_setup_copyright(struct _mdi *mdi, char * text) {
 }
 
 static int midi_setup_trackname(struct _mdi *mdi, char * text) {
-    MIDI_EVENT_SDEBUG(__FUNCTION__,0, text);
+    MIDI_EVENT_SDEBUG(__func__,0, text);
     strip_text(text);
     _WM_CheckEventMemoryPool(mdi);
     mdi->events[mdi->event_count].evtype = ev_meta_trackname;
@@ -1864,7 +1864,7 @@ static int midi_setup_trackname(struct _mdi *mdi, char * text) {
 }
 
 static int midi_setup_instrumentname(struct _mdi *mdi, char * text) {
-    MIDI_EVENT_SDEBUG(__FUNCTION__,0, text);
+    MIDI_EVENT_SDEBUG(__func__,0, text);
     strip_text(text);
     _WM_CheckEventMemoryPool(mdi);
     mdi->events[mdi->event_count].evtype = ev_meta_instrumentname;
@@ -1877,7 +1877,7 @@ static int midi_setup_instrumentname(struct _mdi *mdi, char * text) {
 }
 
 static int midi_setup_lyric(struct _mdi *mdi, char * text) {
-    MIDI_EVENT_SDEBUG(__FUNCTION__,0, text);
+    MIDI_EVENT_SDEBUG(__func__,0, text);
     strip_text(text);
     _WM_CheckEventMemoryPool(mdi);
     mdi->events[mdi->event_count].evtype = ev_meta_lyric;
@@ -1890,7 +1890,7 @@ static int midi_setup_lyric(struct _mdi *mdi, char * text) {
 }
 
 static int midi_setup_marker(struct _mdi *mdi, char * text) {
-    MIDI_EVENT_SDEBUG(__FUNCTION__,0, text);
+    MIDI_EVENT_SDEBUG(__func__,0, text);
     strip_text(text);
     _WM_CheckEventMemoryPool(mdi);
     mdi->events[mdi->event_count].evtype = ev_meta_marker;
@@ -1903,7 +1903,7 @@ static int midi_setup_marker(struct _mdi *mdi, char * text) {
 }
 
 static int midi_setup_cuepoint(struct _mdi *mdi, char * text) {
-    MIDI_EVENT_SDEBUG(__FUNCTION__,0, text);
+    MIDI_EVENT_SDEBUG(__func__,0, text);
     strip_text(text);
     _WM_CheckEventMemoryPool(mdi);
     mdi->events[mdi->event_count].evtype = ev_meta_cuepoint;

--- a/src/internal_midi.c
+++ b/src/internal_midi.c
@@ -43,11 +43,11 @@
 //#define DEBUG_MIDI
 
 #ifdef DEBUG_MIDI
-#define MIDI_EVENT_DEBUG(dx,dy,dz) fprintf(stderr,"\r%s, 0x%.2x, 0x%.8x\n",dx,dy,dz)
-#define MIDI_EVENT_SDEBUG(dx,dy,dz) fprintf(stderr,"\r%s, 0x%.2x, %s\n",dx,dy,dz)
+#define MIDI_EVENT_DEBUG(dy,dz) fprintf(stderr,"\r%s, 0x%.2x, 0x%.8x\n",__func__,dy,dz)
+#define MIDI_EVENT_SDEBUG(dy,dz) fprintf(stderr,"\r%s, 0x%.2x, %s\n",__func__,dy,dz)
 #else
-#define MIDI_EVENT_DEBUG(dx,dy,dz)
-#define MIDI_EVENT_SDEBUG(dx,dy,dz)
+#define MIDI_EVENT_DEBUG(dy,dz)
+#define MIDI_EVENT_SDEBUG(dy,dz)
 #endif
 
 /* f: ( VOLUME / 127.0 ) * 1024.0 */
@@ -486,7 +486,7 @@ void _WM_AdjustNoteVolumes(struct _mdi *mdi, uint8_t ch, struct _note *nte) {
 #define VOL_DIVISOR 4.0
     volume_adj = ((double)_WM_MasterVolume / 1024.0) / VOL_DIVISOR;
 
-    MIDI_EVENT_DEBUG(__func__,ch, 0);
+    MIDI_EVENT_DEBUG(ch, 0);
 
     if (pan_ofs > 127) pan_ofs = 127;
     premix_dBm_left = dBm_pan_volume[(127-pan_ofs)];
@@ -555,7 +555,7 @@ static void _WM_CheckEventMemoryPool(struct _mdi *mdi) {
 
 void _WM_do_note_off_extra(struct _note *nte) {
 
-    MIDI_EVENT_DEBUG(__func__,0, 0);
+    MIDI_EVENT_DEBUG(0, 0);
     nte->is_off = 0;
 
     if (!(nte->modes & SAMPLE_ENVELOPE)) {
@@ -609,7 +609,7 @@ void _WM_do_note_off(struct _mdi *mdi, struct _event_data *data) {
     struct _note *nte;
     uint8_t ch = data->channel;
 
-    MIDI_EVENT_DEBUG(__func__,ch, data->data.value);
+    MIDI_EVENT_DEBUG(ch, data->data.value);
 
     nte = &mdi->note_table[0][ch][(data->data.value >> 8)];
     if (!nte->active) {
@@ -670,7 +670,7 @@ void _WM_do_note_on(struct _mdi *mdi, struct _event_data *data) {
         return;
     }
 
-    MIDI_EVENT_DEBUG(__func__,ch, data->data.value);
+    MIDI_EVENT_DEBUG(ch, data->data.value);
 
     if (!mdi->channel[ch].isdrum) {
         patch = mdi->channel[ch].patch;
@@ -752,7 +752,7 @@ void _WM_do_aftertouch(struct _mdi *mdi, struct _event_data *data) {
     struct _note *nte;
     uint8_t ch = data->channel;
 
-    MIDI_EVENT_DEBUG(__func__,ch, data->data.value);
+    MIDI_EVENT_DEBUG(ch, data->data.value);
 
     nte = &mdi->note_table[0][ch][(data->data.value >> 8)];
     if (!nte->active) {
@@ -772,7 +772,7 @@ void _WM_do_aftertouch(struct _mdi *mdi, struct _event_data *data) {
 
 void _WM_do_control_bank_select(struct _mdi *mdi, struct _event_data *data) {
     uint8_t ch = data->channel;
-    MIDI_EVENT_DEBUG(__func__,ch, data->data.value);
+    MIDI_EVENT_DEBUG(ch, data->data.value);
     mdi->channel[ch].bank = data->data.value;
 }
 
@@ -780,7 +780,7 @@ void _WM_do_control_data_entry_course(struct _mdi *mdi,
                                          struct _event_data *data) {
     uint8_t ch = data->channel;
     int data_tmp;
-    MIDI_EVENT_DEBUG(__func__,ch, data->data.value);
+    MIDI_EVENT_DEBUG(ch, data->data.value);
 
     if ((mdi->channel[ch].reg_non == 0)
         && (mdi->channel[ch].reg_data == 0x0000)) { /* Pitch Bend Range */
@@ -794,7 +794,7 @@ void _WM_do_control_data_entry_course(struct _mdi *mdi,
 void _WM_do_control_channel_volume(struct _mdi *mdi,
                                       struct _event_data *data) {
     uint8_t ch = data->channel;
-    MIDI_EVENT_DEBUG(__func__,ch, data->data.value);
+    MIDI_EVENT_DEBUG(ch, data->data.value);
 
     mdi->channel[ch].volume = data->data.value;
     _WM_AdjustChannelVolumes(mdi, ch);
@@ -803,7 +803,7 @@ void _WM_do_control_channel_volume(struct _mdi *mdi,
 void _WM_do_control_channel_balance(struct _mdi *mdi,
                                        struct _event_data *data) {
     uint8_t ch = data->channel;
-    MIDI_EVENT_DEBUG(__func__,ch, data->data.value);
+    MIDI_EVENT_DEBUG(ch, data->data.value);
 
     mdi->channel[ch].balance = data->data.value;
     _WM_AdjustChannelVolumes(mdi, ch);
@@ -811,7 +811,7 @@ void _WM_do_control_channel_balance(struct _mdi *mdi,
 
 void _WM_do_control_channel_pan(struct _mdi *mdi, struct _event_data *data) {
     uint8_t ch = data->channel;
-    MIDI_EVENT_DEBUG(__func__,ch, data->data.value);
+    MIDI_EVENT_DEBUG(ch, data->data.value);
 
     mdi->channel[ch].pan = data->data.value;
     _WM_AdjustChannelVolumes(mdi, ch);
@@ -820,7 +820,7 @@ void _WM_do_control_channel_pan(struct _mdi *mdi, struct _event_data *data) {
 void _WM_do_control_channel_expression(struct _mdi *mdi,
                                           struct _event_data *data) {
     uint8_t ch = data->channel;
-    MIDI_EVENT_DEBUG(__func__,ch, data->data.value);
+    MIDI_EVENT_DEBUG(ch, data->data.value);
 
     mdi->channel[ch].expression = data->data.value;
     _WM_AdjustChannelVolumes(mdi, ch);
@@ -830,7 +830,7 @@ void _WM_do_control_data_entry_fine(struct _mdi *mdi,
                                        struct _event_data *data) {
     uint8_t ch = data->channel;
     int data_tmp;
-    MIDI_EVENT_DEBUG(__func__,ch, data->data.value);
+    MIDI_EVENT_DEBUG(ch, data->data.value);
 
     if ((mdi->channel[ch].reg_non == 0)
       && (mdi->channel[ch].reg_data == 0x0000)) { /* Pitch Bend Range */
@@ -844,7 +844,7 @@ void _WM_do_control_data_entry_fine(struct _mdi *mdi,
 void _WM_do_control_channel_hold(struct _mdi *mdi, struct _event_data *data) {
     struct _note *note_data = mdi->note;
     uint8_t ch = data->channel;
-    MIDI_EVENT_DEBUG(__func__,ch, data->data.value);
+    MIDI_EVENT_DEBUG(ch, data->data.value);
 
     if (data->data.value > 63) {
         mdi->channel[ch].hold = 1;
@@ -910,7 +910,7 @@ void _WM_do_control_channel_hold(struct _mdi *mdi, struct _event_data *data) {
 void _WM_do_control_data_increment(struct _mdi *mdi,
                                       struct _event_data *data) {
     uint8_t ch = data->channel;
-    MIDI_EVENT_DEBUG(__func__,ch, data->data.value);
+    MIDI_EVENT_DEBUG(ch, data->data.value);
 
     if ((mdi->channel[ch].reg_non == 0)
         && (mdi->channel[ch].reg_data == 0x0000)) { /* Pitch Bend Range */
@@ -922,7 +922,7 @@ void _WM_do_control_data_increment(struct _mdi *mdi,
 void _WM_do_control_data_decrement(struct _mdi *mdi,
                                       struct _event_data *data) {
     uint8_t ch = data->channel;
-    MIDI_EVENT_DEBUG(__func__,ch, data->data.value);
+    MIDI_EVENT_DEBUG(ch, data->data.value);
 
     if ((mdi->channel[ch].reg_non == 0)
         && (mdi->channel[ch].reg_data == 0x0000)) { /* Pitch Bend Range */
@@ -933,7 +933,7 @@ void _WM_do_control_data_decrement(struct _mdi *mdi,
 void _WM_do_control_non_registered_param_fine(struct _mdi *mdi,
                                             struct _event_data *data) {
     uint8_t ch = data->channel;
-    MIDI_EVENT_DEBUG(__func__,ch, data->data.value);
+    MIDI_EVENT_DEBUG(ch, data->data.value);
     mdi->channel[ch].reg_data = (mdi->channel[ch].reg_data & 0x3F80)
                                 | data->data.value;
     mdi->channel[ch].reg_non = 1;
@@ -942,7 +942,7 @@ void _WM_do_control_non_registered_param_fine(struct _mdi *mdi,
 void _WM_do_control_non_registered_param_course(struct _mdi *mdi,
                                      struct _event_data *data) {
     uint8_t ch = data->channel;
-    MIDI_EVENT_DEBUG(__func__,ch, data->data.value);
+    MIDI_EVENT_DEBUG(ch, data->data.value);
     mdi->channel[ch].reg_data = (mdi->channel[ch].reg_data & 0x7F)
                                 | (data->data.value << 7);
     mdi->channel[ch].reg_non = 1;
@@ -951,7 +951,7 @@ void _WM_do_control_non_registered_param_course(struct _mdi *mdi,
 void _WM_do_control_registered_param_fine(struct _mdi *mdi,
                                           struct _event_data *data) {
     uint8_t ch = data->channel;
-    MIDI_EVENT_DEBUG(__func__,ch, data->data.value);
+    MIDI_EVENT_DEBUG(ch, data->data.value);
     mdi->channel[ch].reg_data = (mdi->channel[ch].reg_data & 0x3F80)
                                 | data->data.value;
     mdi->channel[ch].reg_non = 0;
@@ -960,7 +960,7 @@ void _WM_do_control_registered_param_fine(struct _mdi *mdi,
 void _WM_do_control_registered_param_course(struct _mdi *mdi,
                                             struct _event_data *data) {
     uint8_t ch = data->channel;
-    MIDI_EVENT_DEBUG(__func__,ch, data->data.value);
+    MIDI_EVENT_DEBUG(ch, data->data.value);
     mdi->channel[ch].reg_data = (mdi->channel[ch].reg_data & 0x7F)
                                 | (data->data.value << 7);
     mdi->channel[ch].reg_non = 0;
@@ -970,7 +970,7 @@ void _WM_do_control_channel_sound_off(struct _mdi *mdi,
                                       struct _event_data *data) {
     struct _note *note_data = mdi->note;
     uint8_t ch = data->channel;
-    MIDI_EVENT_DEBUG(__func__,ch, data->data.value);
+    MIDI_EVENT_DEBUG(ch, data->data.value);
 
     if (note_data) {
         do {
@@ -988,7 +988,7 @@ void _WM_do_control_channel_sound_off(struct _mdi *mdi,
 void _WM_do_control_channel_controllers_off(struct _mdi *mdi,
                                             struct _event_data *data) {
     uint8_t ch = data->channel;
-    MIDI_EVENT_DEBUG(__func__,ch, data->data.value);
+    MIDI_EVENT_DEBUG(ch, data->data.value);
 
     mdi->channel[ch].expression = 127;
     mdi->channel[ch].pressure = 127;
@@ -1005,7 +1005,7 @@ void _WM_do_control_channel_notes_off(struct _mdi *mdi,
                                       struct _event_data *data) {
     struct _note *note_data = mdi->note;
     uint8_t ch = data->channel;
-    MIDI_EVENT_DEBUG(__func__,ch, data->data.value);
+    MIDI_EVENT_DEBUG(ch, data->data.value);
 
     if (mdi->channel[ch].isdrum)
         return;
@@ -1038,7 +1038,7 @@ void _WM_do_control_channel_notes_off(struct _mdi *mdi,
 void _WM_do_control_dummy(struct _mdi *mdi, struct _event_data *data) {
 #ifdef DEBUG_MIDI
     uint8_t ch = data->channel;
-    MIDI_EVENT_DEBUG(__func__, ch, data->data.value);
+    MIDI_EVENT_DEBUG(ch, data->data.value);
 #else
     WMIDI_UNUSED(data);
 #endif
@@ -1047,7 +1047,7 @@ void _WM_do_control_dummy(struct _mdi *mdi, struct _event_data *data) {
 
 void _WM_do_patch(struct _mdi *mdi, struct _event_data *data) {
     uint8_t ch = data->channel;
-    MIDI_EVENT_DEBUG(__func__,ch, data->data.value);
+    MIDI_EVENT_DEBUG(ch, data->data.value);
     if (!mdi->channel[ch].isdrum) {
         mdi->channel[ch].patch = _WM_get_patch_data(mdi,
                                                 ((mdi->channel[ch].bank << 8) | data->data.value));
@@ -1059,7 +1059,7 @@ void _WM_do_patch(struct _mdi *mdi, struct _event_data *data) {
 void _WM_do_channel_pressure(struct _mdi *mdi, struct _event_data *data) {
     uint8_t ch = data->channel;
     struct _note *note_data = mdi->note;
-    MIDI_EVENT_DEBUG(__func__,ch, data->data.value);
+    MIDI_EVENT_DEBUG(ch, data->data.value);
 
     mdi->channel[ch].pressure = data->data.value;
 
@@ -1082,7 +1082,7 @@ void _WM_do_pitch(struct _mdi *mdi, struct _event_data *data) {
     struct _note *note_data = mdi->note;
     uint8_t ch = data->channel;
 
-    MIDI_EVENT_DEBUG(__func__,ch, data->data.value);
+    MIDI_EVENT_DEBUG(ch, data->data.value);
     mdi->channel[ch].pitch = data->data.value - 0x2000;
 
     if (mdi->channel[ch].pitch < 0) {
@@ -1106,7 +1106,7 @@ void _WM_do_pitch(struct _mdi *mdi, struct _event_data *data) {
 void _WM_do_sysex_roland_drum_track(struct _mdi *mdi, struct _event_data *data) {
     uint8_t ch = data->channel;
 
-    MIDI_EVENT_DEBUG(__func__,ch, data->data.value);
+    MIDI_EVENT_DEBUG(ch, data->data.value);
 
     if (data->data.value > 0) {
         mdi->channel[ch].isdrum = 1;
@@ -1121,9 +1121,9 @@ void _WM_do_sysex_gm_reset(struct _mdi *mdi, struct _event_data *data) {
     int i;
 
     if (data != NULL) {
-        MIDI_EVENT_DEBUG(__func__,data->channel, data->data.value);
+        MIDI_EVENT_DEBUG(data->channel, data->data.value);
     } else {
-        MIDI_EVENT_DEBUG(__func__,0, 0);
+        MIDI_EVENT_DEBUG(0, 0);
     }
 
     for (i = 0; i < 16; i++) {
@@ -1154,7 +1154,7 @@ void _WM_do_sysex_gm_reset(struct _mdi *mdi, struct _event_data *data) {
 void _WM_do_sysex_roland_reset(struct _mdi *mdi, struct _event_data *data) {
 #ifdef DEBUG_MIDI
     uint8_t ch = data->channel;
-    MIDI_EVENT_DEBUG(__func__, ch, data->data.value);
+    MIDI_EVENT_DEBUG(ch, data->data.value);
 #else
     WMIDI_UNUSED(data);
 #endif
@@ -1164,7 +1164,7 @@ void _WM_do_sysex_roland_reset(struct _mdi *mdi, struct _event_data *data) {
 void _WM_do_sysex_yamaha_reset(struct _mdi *mdi, struct _event_data *data) {
 #ifdef DEBUG_MIDI
     uint8_t ch = data->channel;
-    MIDI_EVENT_DEBUG(__func__, ch, data->data.value);
+    MIDI_EVENT_DEBUG(ch, data->data.value);
 #else
     WMIDI_UNUSED(data);
 #endif
@@ -1212,7 +1212,7 @@ void _WM_do_meta_endoftrack(struct _mdi *mdi, struct _event_data *data) {
  * for conversion function _WM_Event2Midi */
 #ifdef DEBUG_MIDI
     uint8_t ch = data->channel;
-    MIDI_EVENT_DEBUG(__func__, ch, data->data.value);
+    MIDI_EVENT_DEBUG(ch, data->data.value);
 #else
     WMIDI_UNUSED(data);
 #endif
@@ -1226,7 +1226,7 @@ void _WM_do_meta_tempo(struct _mdi *mdi, struct _event_data *data) {
  * for conversion function _WM_Event2Midi */
 #ifdef DEBUG_MIDI
     uint8_t ch = data->channel;
-    MIDI_EVENT_DEBUG(__func__, ch, data->data.value);
+    MIDI_EVENT_DEBUG(ch, data->data.value);
 #else
     WMIDI_UNUSED(data);
 #endif
@@ -1239,7 +1239,7 @@ void _WM_do_meta_timesignature(struct _mdi *mdi, struct _event_data *data) {
  * for conversion function _WM_Event2Midi */
 #ifdef DEBUG_MIDI
     uint8_t ch = data->channel;
-    MIDI_EVENT_DEBUG(__func__, ch, data->data.value);
+    MIDI_EVENT_DEBUG(ch, data->data.value);
 #else
     WMIDI_UNUSED(data);
 #endif
@@ -1252,7 +1252,7 @@ void _WM_do_meta_keysignature(struct _mdi *mdi, struct _event_data *data) {
  * for conversion function _WM_Event2Midi */
 #ifdef DEBUG_MIDI
     uint8_t ch = data->channel;
-    MIDI_EVENT_DEBUG(__func__, ch, data->data.value);
+    MIDI_EVENT_DEBUG(ch, data->data.value);
 #else
     WMIDI_UNUSED(data);
 #endif
@@ -1265,7 +1265,7 @@ void _WM_do_meta_sequenceno(struct _mdi *mdi, struct _event_data *data) {
  * for conversion function _WM_Event2Midi */
 #ifdef DEBUG_MIDI
     uint8_t ch = data->channel;
-    MIDI_EVENT_DEBUG(__func__, ch, data->data.value);
+    MIDI_EVENT_DEBUG(ch, data->data.value);
 #else
     WMIDI_UNUSED(data);
 #endif
@@ -1278,7 +1278,7 @@ void _WM_do_meta_channelprefix(struct _mdi *mdi, struct _event_data *data) {
  * for conversion function _WM_Event2Midi */
 #ifdef DEBUG_MIDI
     uint8_t ch = data->channel;
-    MIDI_EVENT_DEBUG(__func__, ch, data->data.value);
+    MIDI_EVENT_DEBUG(ch, data->data.value);
 #else
     WMIDI_UNUSED(data);
 #endif
@@ -1291,7 +1291,7 @@ void _WM_do_meta_portprefix(struct _mdi *mdi, struct _event_data *data) {
  * for conversion function _WM_Event2Midi */
 #ifdef DEBUG_MIDI
     uint8_t ch = data->channel;
-    MIDI_EVENT_DEBUG(__func__, ch, data->data.value);
+    MIDI_EVENT_DEBUG(ch, data->data.value);
 #else
     WMIDI_UNUSED(data);
 #endif
@@ -1304,7 +1304,7 @@ void _WM_do_meta_smpteoffset(struct _mdi *mdi, struct _event_data *data) {
  * for conversion function _WM_Event2Midi */
 #ifdef DEBUG_MIDI
     uint8_t ch = data->channel;
-    MIDI_EVENT_DEBUG(__func__, ch, data->data.value);
+    MIDI_EVENT_DEBUG(ch, data->data.value);
 #else
     WMIDI_UNUSED(data);
 #endif
@@ -1317,7 +1317,7 @@ void _WM_do_meta_text(struct _mdi *mdi, struct _event_data *data) {
  * for conversion function _WM_Event2Midi */
 #ifdef DEBUG_MIDI
     uint8_t ch = data->channel;
-    MIDI_EVENT_SDEBUG(__func__, ch, data->data.string);
+    MIDI_EVENT_SDEBUG(ch, data->data.string);
 #endif
     if (mdi->extra_info.mixer_options & WM_MO_TEXTASLYRIC) {
         mdi->lyric = data->data.string;
@@ -1331,7 +1331,7 @@ void _WM_do_meta_copyright(struct _mdi *mdi, struct _event_data *data) {
  * for conversion function _WM_Event2Midi */
 #ifdef DEBUG_MIDI
     uint8_t ch = data->channel;
-    MIDI_EVENT_SDEBUG(__func__, ch, data->data.string);
+    MIDI_EVENT_SDEBUG(ch, data->data.string);
 #else
     WMIDI_UNUSED(data);
 #endif
@@ -1344,7 +1344,7 @@ void _WM_do_meta_trackname(struct _mdi *mdi, struct _event_data *data) {
  * for conversion function _WM_Event2Midi */
 #ifdef DEBUG_MIDI
     uint8_t ch = data->channel;
-    MIDI_EVENT_SDEBUG(__func__, ch, data->data.string);
+    MIDI_EVENT_SDEBUG(ch, data->data.string);
 #else
     WMIDI_UNUSED(data);
 #endif
@@ -1357,7 +1357,7 @@ void _WM_do_meta_instrumentname(struct _mdi *mdi, struct _event_data *data) {
  * for conversion function _WM_Event2Midi */
 #ifdef DEBUG_MIDI
     uint8_t ch = data->channel;
-    MIDI_EVENT_SDEBUG(__func__, ch, data->data.string);
+    MIDI_EVENT_SDEBUG(ch, data->data.string);
 #else
     WMIDI_UNUSED(data);
 #endif
@@ -1370,7 +1370,7 @@ void _WM_do_meta_lyric(struct _mdi *mdi, struct _event_data *data) {
  * for conversion function _WM_Event2Midi */
 #ifdef DEBUG_MIDI
     uint8_t ch = data->channel;
-    MIDI_EVENT_SDEBUG(__func__, ch, data->data.string);
+    MIDI_EVENT_SDEBUG(ch, data->data.string);
 #endif
     if (!(mdi->extra_info.mixer_options & WM_MO_TEXTASLYRIC)) {
         mdi->lyric = data->data.string;
@@ -1383,7 +1383,7 @@ void _WM_do_meta_marker(struct _mdi *mdi, struct _event_data *data) {
  * for conversion function _WM_Event2Midi */
 #ifdef DEBUG_MIDI
     uint8_t ch = data->channel;
-    MIDI_EVENT_SDEBUG(__func__, ch, data->data.string);
+    MIDI_EVENT_SDEBUG(ch, data->data.string);
 #else
     WMIDI_UNUSED(data);
 #endif
@@ -1396,7 +1396,7 @@ void _WM_do_meta_cuepoint(struct _mdi *mdi, struct _event_data *data) {
  * for conversion function _WM_Event2Midi */
 #ifdef DEBUG_MIDI
     uint8_t ch = data->channel;
-    MIDI_EVENT_SDEBUG(__func__, ch, data->data.string);
+    MIDI_EVENT_SDEBUG(ch, data->data.string);
 #else
     WMIDI_UNUSED(data);
 #endif
@@ -1451,7 +1451,7 @@ void _WM_ResetToStart(struct _mdi *mdi) {
 }
 
 int _WM_midi_setup_divisions(struct _mdi *mdi, uint32_t divisions) {
-    MIDI_EVENT_DEBUG(__func__,0,0);
+    MIDI_EVENT_DEBUG(0,0);
     _WM_CheckEventMemoryPool(mdi);
     mdi->events[mdi->event_count].evtype = ev_midi_divisions;
     mdi->events[mdi->event_count].do_event = _WM_do_midi_divisions;
@@ -1464,7 +1464,7 @@ int _WM_midi_setup_divisions(struct _mdi *mdi, uint32_t divisions) {
 
 int _WM_midi_setup_noteoff(struct _mdi *mdi, uint8_t channel,
                            uint8_t note, uint8_t velocity) {
-    MIDI_EVENT_DEBUG(__func__,channel, note);
+    MIDI_EVENT_DEBUG(channel, note);
     _WM_CheckEventMemoryPool(mdi);
     note &= 0x7f; /* silently bound note to 0..127 (github bug #180) */
     mdi->events[mdi->event_count].evtype = ev_note_off;
@@ -1478,7 +1478,7 @@ int _WM_midi_setup_noteoff(struct _mdi *mdi, uint8_t channel,
 
 static int midi_setup_noteon(struct _mdi *mdi, uint8_t channel,
                              uint8_t note, uint8_t velocity) {
-    MIDI_EVENT_DEBUG(__func__,channel, note);
+    MIDI_EVENT_DEBUG(channel, note);
     _WM_CheckEventMemoryPool(mdi);
     note &= 0x7f; /* silently bound note to 0..127 (github bug #180) */
     mdi->events[mdi->event_count].evtype = ev_note_on;
@@ -1495,7 +1495,7 @@ static int midi_setup_noteon(struct _mdi *mdi, uint8_t channel,
 
 static int midi_setup_aftertouch(struct _mdi *mdi, uint8_t channel,
                                  uint8_t note, uint8_t pressure) {
-    MIDI_EVENT_DEBUG(__func__,channel, note);
+    MIDI_EVENT_DEBUG(channel, note);
     _WM_CheckEventMemoryPool(mdi);
     note &= 0x7f; /* silently bound note to 0..127 (github bug #180) */
     mdi->events[mdi->event_count].evtype = ev_aftertouch;
@@ -1512,7 +1512,7 @@ static int midi_setup_control(struct _mdi *mdi, uint8_t channel,
     void (*tmp_event)(struct _mdi *mdi, struct _event_data *data);
     enum _event_type ev;
 
-    MIDI_EVENT_DEBUG(__func__,channel, controller);
+    MIDI_EVENT_DEBUG(channel, controller);
 
     switch (controller) {
         /*
@@ -1613,7 +1613,7 @@ static int midi_setup_control(struct _mdi *mdi, uint8_t channel,
 }
 
 static int midi_setup_patch(struct _mdi *mdi, uint8_t channel, uint8_t patch) {
-    MIDI_EVENT_DEBUG(__func__,channel, patch);
+    MIDI_EVENT_DEBUG(channel, patch);
     _WM_CheckEventMemoryPool(mdi);
     mdi->events[mdi->event_count].evtype = ev_patch;
     mdi->events[mdi->event_count].do_event = _WM_do_patch;
@@ -1634,7 +1634,7 @@ static int midi_setup_patch(struct _mdi *mdi, uint8_t channel, uint8_t patch) {
 
 static int midi_setup_channel_pressure(struct _mdi *mdi, uint8_t channel,
                                        uint8_t pressure) {
-    MIDI_EVENT_DEBUG(__func__,channel, pressure);
+    MIDI_EVENT_DEBUG(channel, pressure);
     _WM_CheckEventMemoryPool(mdi);
     mdi->events[mdi->event_count].evtype = ev_channel_pressure;
     mdi->events[mdi->event_count].do_event = _WM_do_channel_pressure;
@@ -1646,7 +1646,7 @@ static int midi_setup_channel_pressure(struct _mdi *mdi, uint8_t channel,
 }
 
 static int midi_setup_pitch(struct _mdi *mdi, uint8_t channel, uint16_t pitch) {
-    MIDI_EVENT_DEBUG(__func__,channel, pitch);
+    MIDI_EVENT_DEBUG(channel, pitch);
     _WM_CheckEventMemoryPool(mdi);
     mdi->events[mdi->event_count].evtype = ev_pitch;
     mdi->events[mdi->event_count].do_event = _WM_do_pitch;
@@ -1659,7 +1659,7 @@ static int midi_setup_pitch(struct _mdi *mdi, uint8_t channel, uint16_t pitch) {
 
 static int midi_setup_sysex_roland_drum_track(struct _mdi *mdi,
                                               uint8_t channel, uint16_t setting) {
-    MIDI_EVENT_DEBUG(__func__,channel, setting);
+    MIDI_EVENT_DEBUG(channel, setting);
     _WM_CheckEventMemoryPool(mdi);
     mdi->events[mdi->event_count].evtype = ev_sysex_roland_drum_track;
     mdi->events[mdi->event_count].do_event = _WM_do_sysex_roland_drum_track;
@@ -1677,7 +1677,7 @@ static int midi_setup_sysex_roland_drum_track(struct _mdi *mdi,
 }
 
 static int midi_setup_sysex_gm_reset(struct _mdi *mdi) {
-    MIDI_EVENT_DEBUG(__func__,0,0);
+    MIDI_EVENT_DEBUG(0,0);
 
     _WM_CheckEventMemoryPool(mdi);
     mdi->events[mdi->event_count].evtype = ev_sysex_roland_reset;
@@ -1690,7 +1690,7 @@ static int midi_setup_sysex_gm_reset(struct _mdi *mdi) {
 }
 
 static int midi_setup_sysex_roland_reset(struct _mdi *mdi) {
-    MIDI_EVENT_DEBUG(__func__,0,0);
+    MIDI_EVENT_DEBUG(0,0);
     _WM_CheckEventMemoryPool(mdi);
     mdi->events[mdi->event_count].evtype = ev_sysex_roland_reset;
     mdi->events[mdi->event_count].do_event = _WM_do_sysex_roland_reset;
@@ -1702,7 +1702,7 @@ static int midi_setup_sysex_roland_reset(struct _mdi *mdi) {
 }
 
 static int midi_setup_sysex_yamaha_reset(struct _mdi *mdi) {
-    MIDI_EVENT_DEBUG(__func__,0,0);
+    MIDI_EVENT_DEBUG(0,0);
     _WM_CheckEventMemoryPool(mdi);
     mdi->events[mdi->event_count].evtype = ev_sysex_roland_reset;
     mdi->events[mdi->event_count].do_event = _WM_do_sysex_roland_reset;
@@ -1714,7 +1714,7 @@ static int midi_setup_sysex_yamaha_reset(struct _mdi *mdi) {
 }
 
 int _WM_midi_setup_endoftrack(struct _mdi *mdi) {
-    MIDI_EVENT_DEBUG(__func__,0,0);
+    MIDI_EVENT_DEBUG(0,0);
     _WM_CheckEventMemoryPool(mdi);
     mdi->events[mdi->event_count].evtype = ev_meta_endoftrack;
     mdi->events[mdi->event_count].do_event = _WM_do_meta_endoftrack;
@@ -1726,7 +1726,7 @@ int _WM_midi_setup_endoftrack(struct _mdi *mdi) {
 }
 
 int _WM_midi_setup_tempo(struct _mdi *mdi, uint32_t setting) {
-    MIDI_EVENT_DEBUG(__func__,0,setting);
+    MIDI_EVENT_DEBUG(0,setting);
     _WM_CheckEventMemoryPool(mdi);
     mdi->events[mdi->event_count].evtype = ev_meta_tempo;
     mdi->events[mdi->event_count].do_event = _WM_do_meta_tempo;
@@ -1738,7 +1738,7 @@ int _WM_midi_setup_tempo(struct _mdi *mdi, uint32_t setting) {
 }
 
 static int midi_setup_timesignature(struct _mdi *mdi, uint32_t setting) {
-    MIDI_EVENT_DEBUG(__func__,0, setting);
+    MIDI_EVENT_DEBUG(0, setting);
     _WM_CheckEventMemoryPool(mdi);
     mdi->events[mdi->event_count].evtype = ev_meta_timesignature;
     mdi->events[mdi->event_count].do_event = _WM_do_meta_timesignature;
@@ -1750,7 +1750,7 @@ static int midi_setup_timesignature(struct _mdi *mdi, uint32_t setting) {
 }
 
 static int midi_setup_keysignature(struct _mdi *mdi, uint32_t setting) {
-    MIDI_EVENT_DEBUG(__func__,0, setting);
+    MIDI_EVENT_DEBUG(0, setting);
     _WM_CheckEventMemoryPool(mdi);
     mdi->events[mdi->event_count].evtype = ev_meta_keysignature;
     mdi->events[mdi->event_count].do_event = _WM_do_meta_keysignature;
@@ -1762,7 +1762,7 @@ static int midi_setup_keysignature(struct _mdi *mdi, uint32_t setting) {
 }
 
 static int midi_setup_sequenceno(struct _mdi *mdi, uint32_t setting) {
-    MIDI_EVENT_DEBUG(__func__,0, setting);
+    MIDI_EVENT_DEBUG(0, setting);
     _WM_CheckEventMemoryPool(mdi);
     mdi->events[mdi->event_count].evtype = ev_meta_sequenceno;
     mdi->events[mdi->event_count].do_event = _WM_do_meta_sequenceno;
@@ -1774,7 +1774,7 @@ static int midi_setup_sequenceno(struct _mdi *mdi, uint32_t setting) {
 }
 
 static int midi_setup_channelprefix(struct _mdi *mdi, uint32_t setting) {
-    MIDI_EVENT_DEBUG(__func__,0, setting);
+    MIDI_EVENT_DEBUG(0, setting);
     _WM_CheckEventMemoryPool(mdi);
     mdi->events[mdi->event_count].evtype = ev_meta_channelprefix;
     mdi->events[mdi->event_count].do_event = _WM_do_meta_channelprefix;
@@ -1786,7 +1786,7 @@ static int midi_setup_channelprefix(struct _mdi *mdi, uint32_t setting) {
 }
 
 static int midi_setup_portprefix(struct _mdi *mdi, uint32_t setting) {
-    MIDI_EVENT_DEBUG(__func__,0, setting);
+    MIDI_EVENT_DEBUG(0, setting);
     _WM_CheckEventMemoryPool(mdi);
     mdi->events[mdi->event_count].evtype = ev_meta_portprefix;
     mdi->events[mdi->event_count].do_event = _WM_do_meta_portprefix;
@@ -1798,7 +1798,7 @@ static int midi_setup_portprefix(struct _mdi *mdi, uint32_t setting) {
 }
 
 static int midi_setup_smpteoffset(struct _mdi *mdi, uint32_t setting) {
-    MIDI_EVENT_DEBUG(__func__,0, setting);
+    MIDI_EVENT_DEBUG(0, setting);
     _WM_CheckEventMemoryPool(mdi);
     mdi->events[mdi->event_count].evtype = ev_meta_smpteoffset;
     mdi->events[mdi->event_count].do_event = _WM_do_meta_smpteoffset;
@@ -1825,7 +1825,7 @@ static void strip_text(char * text) {
 }
 
 static int midi_setup_text(struct _mdi *mdi, char * text) {
-    MIDI_EVENT_SDEBUG(__func__,0, text);
+    MIDI_EVENT_SDEBUG(0, text);
     strip_text(text);
     _WM_CheckEventMemoryPool(mdi);
     mdi->events[mdi->event_count].evtype = ev_meta_text;
@@ -1838,7 +1838,7 @@ static int midi_setup_text(struct _mdi *mdi, char * text) {
 }
 
 static int midi_setup_copyright(struct _mdi *mdi, char * text) {
-    MIDI_EVENT_SDEBUG(__func__,0, text);
+    MIDI_EVENT_SDEBUG(0, text);
     strip_text(text);
     _WM_CheckEventMemoryPool(mdi);
     mdi->events[mdi->event_count].evtype = ev_meta_copyright;
@@ -1851,7 +1851,7 @@ static int midi_setup_copyright(struct _mdi *mdi, char * text) {
 }
 
 static int midi_setup_trackname(struct _mdi *mdi, char * text) {
-    MIDI_EVENT_SDEBUG(__func__,0, text);
+    MIDI_EVENT_SDEBUG(0, text);
     strip_text(text);
     _WM_CheckEventMemoryPool(mdi);
     mdi->events[mdi->event_count].evtype = ev_meta_trackname;
@@ -1864,7 +1864,7 @@ static int midi_setup_trackname(struct _mdi *mdi, char * text) {
 }
 
 static int midi_setup_instrumentname(struct _mdi *mdi, char * text) {
-    MIDI_EVENT_SDEBUG(__func__,0, text);
+    MIDI_EVENT_SDEBUG(0, text);
     strip_text(text);
     _WM_CheckEventMemoryPool(mdi);
     mdi->events[mdi->event_count].evtype = ev_meta_instrumentname;
@@ -1877,7 +1877,7 @@ static int midi_setup_instrumentname(struct _mdi *mdi, char * text) {
 }
 
 static int midi_setup_lyric(struct _mdi *mdi, char * text) {
-    MIDI_EVENT_SDEBUG(__func__,0, text);
+    MIDI_EVENT_SDEBUG(0, text);
     strip_text(text);
     _WM_CheckEventMemoryPool(mdi);
     mdi->events[mdi->event_count].evtype = ev_meta_lyric;
@@ -1890,7 +1890,7 @@ static int midi_setup_lyric(struct _mdi *mdi, char * text) {
 }
 
 static int midi_setup_marker(struct _mdi *mdi, char * text) {
-    MIDI_EVENT_SDEBUG(__func__,0, text);
+    MIDI_EVENT_SDEBUG(0, text);
     strip_text(text);
     _WM_CheckEventMemoryPool(mdi);
     mdi->events[mdi->event_count].evtype = ev_meta_marker;
@@ -1903,7 +1903,7 @@ static int midi_setup_marker(struct _mdi *mdi, char * text) {
 }
 
 static int midi_setup_cuepoint(struct _mdi *mdi, char * text) {
-    MIDI_EVENT_SDEBUG(__func__,0, text);
+    MIDI_EVENT_SDEBUG(0, text);
     strip_text(text);
     _WM_CheckEventMemoryPool(mdi);
     mdi->events[mdi->event_count].evtype = ev_meta_cuepoint;

--- a/src/internal_midi.c
+++ b/src/internal_midi.c
@@ -40,7 +40,7 @@
 
 #define HOLD_OFF 0x02
 
-//#define DEBUG_MIDI
+/* #define DEBUG_MIDI */
 
 #ifdef DEBUG_MIDI
 #define MIDI_EVENT_DEBUG(dy,dz) fprintf(stderr,"\r%s, 0x%.2x, 0x%.8x\n",__func__,dy,dz)
@@ -342,42 +342,42 @@ void _WM_DynamicVolumeAdjust(struct _mdi *mdi, int32_t *tmp_buffer, uint32_t buf
 
     for (i = 0; i < buffer_used; i++) {
         if ((i == 0) || (i > peak_ofs)) {
-            // Find Next Peak/Troff
+            /* Find Next Peak/Troff */
             peak_set = 0;
             prev_val = peak;
             peak_ofs = 0;
             for (j = i; j < buffer_used; j++) {
                 if (peak_set == 0) {
-                    // find what direction the data is going
+                    /* find what direction the data is going */
                     if (prev_val > tmp_buffer[j]) {
-                        // Going Down
+                        /* Going Down */
                         peak_set = -1;
                     } else if (prev_val < tmp_buffer[j]) {
-                        // Doing Up
+                        /* Doing Up */
                         peak_set = 1;
                     } else {
-                        // No direction, keep looking
+                        /* No direction, keep looking */
                         prev_val = tmp_buffer[j];
                         continue;
                     }
                 }
 
                 if (peak_set == 1) {
-                    // Data is going up
+                    /* Data is going up */
                     if (peak < tmp_buffer[j]) {
                         peak = tmp_buffer[j];
                         peak_ofs = j;
                     } else if (peak > tmp_buffer[j]) {
-                        // Data is starting to go down, we found the peak
+                        /* Data is starting to go down, we found the peak */
                         break;
                     }
-                } else { // assume peak_set == -1
-                    // Data is going down
+                } else { /* assume peak_set == -1 */
+                    /* Data is going down */
                     if (peak > tmp_buffer[j]) {
                         peak = tmp_buffer[j];
                         peak_ofs = j;
                     } else if (peak < tmp_buffer[j]) {
-                        // Data is starting to go up, we found the troff
+                        /* Data is starting to go up, we found the troff */
                         break;
                     }
                 }
@@ -392,7 +392,7 @@ void _WM_DynamicVolumeAdjust(struct _mdi *mdi, int32_t *tmp_buffer, uint32_t buf
                     } else {
                         volume_to_reach = MAX_DYN_VOL;
                     }
-                } else { // assume peak_set == -1
+                } else { /* assume peak_set == -1 */
                     if (peak < -32768) {
                         volume_to_reach = -32768.0 / (double)peak;
                     } else {
@@ -400,51 +400,51 @@ void _WM_DynamicVolumeAdjust(struct _mdi *mdi, int32_t *tmp_buffer, uint32_t buf
                     }
                 }
             } else {
-                // No peak found, set volume we want to normal
+                /* No peak found, set volume we want to normal */
                 volume_to_reach = MAX_DYN_VOL;
             }
 
             if (volume != volume_to_reach) {
                 if (volume_to_reach == MAX_DYN_VOL) {
-                    // if we want normal volume then adjust to it slower
+                    /* if we want normal volume then adjust to it slower */
                     volume_adjust = (volume_to_reach - volume) / ((double)_WM_SampleRate * 0.1);
                 } else {
-                    // if we want to clamp the volume then adjust quickly
+                    /* if we want to clamp the volume then adjust quickly */
                     volume_adjust = (volume_to_reach - volume) / ((double)_WM_SampleRate * 0.0001);
                 }
             }
         }
 
-        // First do we need to do volume adjustments
+        /* First do we need to do volume adjustments */
         if ((volume_adjust != 0.0) && (volume != volume_to_reach)) {
                 volume += volume_adjust;
                 if (volume_adjust > 0.0) {
-                    // if increasing the volume
+                    /* if increasing the volume */
                     if (volume >= MAX_DYN_VOL) {
-                        // we dont boost volume
+                        /* we dont boost volume */
                         volume = MAX_DYN_VOL;
                         volume_adjust = 0.0;
                     } else if (volume > volume_to_reach) {
-                        // we dont want to go above the level we wanted
+                        /* we dont want to go above the level we wanted */
                         volume = volume_to_reach;
                         volume_adjust = 0.0;
                     }
                 } else {
-                    // decreasing the volume
+                    /* decreasing the volume */
                     if (volume < volume_to_reach) {
-                        // we dont want to go below the level we wanted
+                        /* we dont want to go below the level we wanted */
                         volume = volume_to_reach;
                         volume_adjust = 0.0;
                     }
                 }
             }
 
-        // adjust buffer volume
+        /* adjust buffer volume */
         tmp_output = (double)tmp_buffer[i] * volume;
         tmp_buffer[i] = (int32_t)tmp_output;
     }
 
-    // store required values
+    /* store required values */
     mdi->dyn_vol_adjust = volume_adjust;
     mdi->dyn_vol_peak = peak;
     mdi->dyn_vol = volume;
@@ -598,8 +598,8 @@ void _WM_do_note_off_extra(struct _note *nte) {
 
 
 void _WM_do_midi_divisions(struct _mdi *mdi, struct _event_data *data) {
-    // placeholder function so we can record divisions in the event stream
-    // for conversion function _WM_Event2Midi()
+    /* placeholder function so we can record divisions in the event stream
+       for conversion function _WM_Event2Midi() */
     WMIDI_UNUSED(mdi);
     WMIDI_UNUSED(data);
     return;
@@ -624,9 +624,9 @@ void _WM_do_note_off(struct _mdi *mdi, struct _event_data *data) {
     }
 
     if ((nte->modes & SAMPLE_ENVELOPE) && (nte->env == 0)) {
-        // This is a fix for notes that end before the
-        // initial step of the envelope has completed
-        // making it impossible to hear them at times.
+        /* This is a fix for notes that end before the
+           initial step of the envelope has completed
+           making it impossible to hear them at times. */
         nte->is_off = 1;
     } else {
         _WM_do_note_off_extra(nte);
@@ -1146,7 +1146,7 @@ void _WM_do_sysex_gm_reset(struct _mdi *mdi, struct _event_data *data) {
     }
     /* I would not expect notes to be active when this event
      triggers but we'll adjust active notes as well just in case */
-    _WM_AdjustChannelVolumes(mdi,16); // A setting > 15 adjusts all channels
+    _WM_AdjustChannelVolumes(mdi,16); /* A setting > 15 adjusts all channels */
 
     mdi->channel[9].isdrum = 1;
 }
@@ -1180,17 +1180,17 @@ void _WM_Release_Allowance(struct _mdi *mdi) {
     while (note != NULL) {
 
         if (note->modes & SAMPLE_ENVELOPE) {
-            //ensure envelope isin a release state
+            /* ensure envelope isin a release state */
             if (note->env < 4) {
                 note->env = 4;
             }
 
-            // make sure this is set
+            /* make sure this is set */
             note->env_inc = -note->sample->env_rate[note->env];
 
             release = note->env_level / -note->env_inc;
         } else {
-            // Sample release
+            /* Sample release */
             if (note->modes & SAMPLE_LOOP) {
                 note->modes ^= SAMPLE_LOOP;
             }

--- a/src/internal_midi.c
+++ b/src/internal_midi.c
@@ -2471,7 +2471,7 @@ uint32_t _WM_SetupMidiEvent(struct _mdi *mdi, uint8_t * event_data, uint32_t inp
                 */
                 ret_cnt += sysex_len;
             } else {
-                _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_CORUPT, "(unrecognized meta type event)", 0);
+                _WM_GLOBAL_ERROR(WM_ERR_CORUPT, "(unrecognized meta type event)", 0);
                 return 0;
             }
             break;
@@ -2481,11 +2481,11 @@ uint32_t _WM_SetupMidiEvent(struct _mdi *mdi, uint8_t * event_data, uint32_t inp
             break;
     }
     if (ret_cnt == 0)
-        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_CORUPT, "(missing event)", 0);
+        _WM_GLOBAL_ERROR(WM_ERR_CORUPT, "(missing event)", 0);
     return ret_cnt;
 
 shortbuf:
-    _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_CORUPT, "(input too short)", 0);
+    _WM_GLOBAL_ERROR(WM_ERR_CORUPT, "(input too short)", 0);
     return 0;
 }
 

--- a/src/mus2mid.c
+++ b/src/mus2mid.c
@@ -227,7 +227,7 @@ int _WM_mus2midi(const uint8_t *in, uint32_t insize,
     int currentChannel;
 
     if (insize < MUS_HEADERSIZE) {
-        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_CORUPT, "(too short)", 0);
+        _WM_GLOBAL_ERROR(WM_ERR_CORUPT, "(too short)", 0);
         return (-1);
     }
 
@@ -243,16 +243,16 @@ int _WM_mus2midi(const uint8_t *in, uint32_t insize,
     header.instrCnt = READ_INT16(&in[12]);
 
     if (memcmp(header.ID, MUS_ID, 4)) {
-        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_NOT_MUS, NULL, 0);
+        _WM_GLOBAL_ERROR(WM_ERR_NOT_MUS, NULL, 0);
         return (-1);
     }
     if (insize < (uint32_t)header.scoreLen + (uint32_t)header.scoreStart) {
-        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_CORUPT, "(too short)", 0);
+        _WM_GLOBAL_ERROR(WM_ERR_CORUPT, "(too short)", 0);
         return (-1);
     }
     /* channel #15 should be excluded in the numchannels field: */
     if (header.channels > MIDI_MAXCHANNELS - 1) {
-        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_INVALID, NULL, 0);
+        _WM_GLOBAL_ERROR(WM_ERR_INVALID, NULL, 0);
         return (-1);
     }
 

--- a/src/mus2mid.c
+++ b/src/mus2mid.c
@@ -371,7 +371,7 @@ int _WM_mus2midi(const uint8_t *in, uint32_t insize,
                 status |= 0xB0;
                 if (*cur >= sizeof(midimap) / sizeof(midimap[0])) {
                     _WM_ERROR_NEW("%s:%i: can't map %u to midi",
-                                  __FUNCTION__, __LINE__, *cur);
+                                  __func__, __LINE__, *cur);
                     goto _end;
                 }
                 bit1 = midimap[*cur++];
@@ -388,7 +388,7 @@ int _WM_mus2midi(const uint8_t *in, uint32_t insize,
                     status |= 0xB0;
                     if (*cur >= sizeof(midimap) / sizeof(midimap[0])) {
                         _WM_ERROR_NEW("%s:%i: can't map %u to midi",
-                                      __FUNCTION__, __LINE__, *cur);
+                                      __func__, __LINE__, *cur);
                         goto _end;
                     }
                     bit1 = midimap[*cur++];
@@ -406,14 +406,14 @@ int _WM_mus2midi(const uint8_t *in, uint32_t insize,
                 bit2 = 0x00;
                 if (cur != end) { /* should we error here or report-only? */
                     _WM_DEBUG_MSG("%s:%i: MUS buffer off by %ld bytes",
-                                  __FUNCTION__, __LINE__, (long)(cur - end));
+                                  __func__, __LINE__, (long)(cur - end));
                 }
                 break;
             case 5:/* Unknown */
             case 7:/* Unknown */
             default:/* shouldn't happen */
                 _WM_ERROR_NEW("%s:%i: unrecognized event (%u)",
-                              __FUNCTION__, __LINE__, event);
+                              __func__, __LINE__, event);
                 goto _end;
         }
 

--- a/src/mus2mid.c
+++ b/src/mus2mid.c
@@ -371,7 +371,7 @@ int _WM_mus2midi(const uint8_t *in, uint32_t insize,
                 status |= 0xB0;
                 if (*cur >= sizeof(midimap) / sizeof(midimap[0])) {
                     _WM_ERROR_NEW("%s:%i: can't map %u to midi",
-                                  __func__, __LINE__, *cur);
+                                  __FILE__, __LINE__, *cur);
                     goto _end;
                 }
                 bit1 = midimap[*cur++];
@@ -388,7 +388,7 @@ int _WM_mus2midi(const uint8_t *in, uint32_t insize,
                     status |= 0xB0;
                     if (*cur >= sizeof(midimap) / sizeof(midimap[0])) {
                         _WM_ERROR_NEW("%s:%i: can't map %u to midi",
-                                      __func__, __LINE__, *cur);
+                                      __FILE__, __LINE__, *cur);
                         goto _end;
                     }
                     bit1 = midimap[*cur++];
@@ -406,14 +406,14 @@ int _WM_mus2midi(const uint8_t *in, uint32_t insize,
                 bit2 = 0x00;
                 if (cur != end) { /* should we error here or report-only? */
                     _WM_DEBUG_MSG("%s:%i: MUS buffer off by %ld bytes",
-                                  __func__, __LINE__, (long)(cur - end));
+                                  __FILE__, __LINE__, (long)(cur - end));
                 }
                 break;
             case 5:/* Unknown */
             case 7:/* Unknown */
             default:/* shouldn't happen */
                 _WM_ERROR_NEW("%s:%i: unrecognized event (%u)",
-                              __func__, __LINE__, event);
+                              __FILE__, __LINE__, event);
                 goto _end;
         }
 

--- a/src/reverb.c
+++ b/src/reverb.c
@@ -95,14 +95,14 @@ _WM_init_reverb(int rate, float room_x, float room_y, float listen_x,
         {-0.131, -6.205, -12.059, -20.933, -20.933, -15.944},
         {-1.839, -6.205, -8.891, -12.059, -15.935, -20.942}
     };
-    /*
+#if 0
     double dbAttn[6] = {
-    // concrete covered in carpet
-    //  -0.175, -0.537, -1.412, -4.437, -7.959, -7.959
-    // pleated drapes
+    /* concrete covered in carpet */
+    /*  -0.175, -0.537, -1.412, -4.437, -7.959, -7.959 */
+    /* pleated drapes */
         -0.630, -3.223, -5.849, -12.041, -10.458, -7.959
     };
-    */
+#endif
 
     /* distance */
     double SPL_DST[8] = {0.0};

--- a/src/wildmidi.c
+++ b/src/wildmidi.c
@@ -1880,7 +1880,7 @@ int main(int argc, char **argv) {
         if (play_from != 0) {
             WildMidi_FastSeek(midi_ptr, &play_from);
             if (play_to < play_from) {
-                // Ignore --playto if set less than --playfrom
+                /* Ignore --playto if set less than --playfrom */
                 play_to = 0;
             }
         }
@@ -2034,7 +2034,7 @@ int main(int argc, char **argv) {
                 } else {
                     samples = (play_to - wm_info->current_sample) << 2;
                     if (!samples) {
-                        // We are at or past where we wanted to play to
+                        /* We are at or past where we wanted to play to */
                         break;
                     }
                 }

--- a/src/wildmidi_lib.c
+++ b/src/wildmidi_lib.c
@@ -1493,7 +1493,7 @@ WM_SYMBOL int WildMidi_ConvertToMidi (const char *file, uint8_t **out, uint32_t 
     return ret;
 }
 
-WM_SYMBOL int WildMidi_ConvertBufferToMidi (uint8_t *in, uint32_t insize,
+WM_SYMBOL int WildMidi_ConvertBufferToMidi (const uint8_t *in, uint32_t insize,
                                             uint8_t **out, uint32_t *outsize) {
     if (!in || !out || !outsize) {
         _WM_GLOBAL_ERROR(WM_ERR_INVALID_ARG, "(NULL params)", 0);

--- a/src/wildmidi_lib.c
+++ b/src/wildmidi_lib.c
@@ -806,7 +806,7 @@ static int add_handle(void * handle) {
     return (0);
 }
 
-//#define DEBUG_RESAMPLE
+/* #define DEBUG_RESAMPLE */
 
 #ifdef DEBUG_RESAMPLE
 #define RESAMPLE_DEBUGI(dx,dy) fprintf(stderr,"\r%s, %i\n",dx,dy)
@@ -826,7 +826,7 @@ static int WM_GetOutput_Linear(midi * handle, int8_t *buffer, uint32_t size) {
     uint32_t real_samples_to_mix = 0;
     uint32_t data_pos;
     int32_t premix, left_mix, right_mix;
-//  int32_t vol_mul;
+/*  int32_t vol_mul; */
     struct _note *note_data = NULL;
     uint32_t count;
     struct _event *event = mdi->current_event;
@@ -973,8 +973,8 @@ static int WM_GetOutput_Linear(midi * handle, int8_t *buffer, uint32_t size) {
                         }
                     }
 
-                    // Yes could have a condition here but
-                    // it would crete another bottleneck
+                    /* Yes could have a condition here but
+                       it would create another bottleneck */
                     note_data->env_level =
                             note_data->sample->env_target[note_data->env];
                     switch (note_data->env) {
@@ -1106,7 +1106,7 @@ static int WM_GetOutput_Linear(midi * handle, int8_t *buffer, uint32_t size) {
         _WM_do_reverb(mdi->reverb, tmp_buffer, (buffer_used / 2));
     }
 
-    //_WM_DynamicVolumeAdjust(mdi, tmp_buffer, (buffer_used/2));
+    /* _WM_DynamicVolumeAdjust(mdi, tmp_buffer, (buffer_used/2)); */
 
     for (i = 0; i < buffer_used; i += 4) {
         left_mix = *tmp_buffer++;
@@ -1320,8 +1320,8 @@ static int WM_GetOutput_Gauss(midi * handle, int8_t *buffer, uint32_t size) {
                         }
                     }
 
-                    // Yes could have a condition here but
-                    // it would crete another bottleneck
+                    /* Yes could have a condition here but
+                       it would create another bottleneck */
 
                     note_data->env_level =
                     note_data->sample->env_target[note_data->env];
@@ -1443,7 +1443,7 @@ static int WM_GetOutput_Gauss(midi * handle, int8_t *buffer, uint32_t size) {
         _WM_do_reverb(mdi->reverb, tmp_buffer, (buffer_used / 2));
     }
 
-    // _WM_DynamicVolumeAdjust(mdi, tmp_buffer, (buffer_used/2));
+    /* _WM_DynamicVolumeAdjust(mdi, tmp_buffer, (buffer_used/2)); */
 
     for (i = 0; i < buffer_used; i += 4) {
         left_mix = *tmp_buffer++;
@@ -2022,8 +2022,8 @@ WM_SYMBOL int WildMidi_SetOption(midi * handle, uint16_t options, uint16_t setti
                                     | (options & setting));
 
     if (options & WM_MO_LOG_VOLUME) {
-            _WM_AdjustChannelVolumes(mdi, 16);  // Settings greater than 15
-                                                // adjusts all channels
+            _WM_AdjustChannelVolumes(mdi, 16);  /* Settings greater than 15
+                                                   adjusts all channels */
     } else if (options & WM_MO_REVERB) {
         _WM_reset_reverb(mdi->reverb);
     }

--- a/src/wildmidi_lib.c
+++ b/src/wildmidi_lib.c
@@ -1703,7 +1703,7 @@ WM_SYMBOL midi *WildMidi_Open(const char *midifile) {
     return (ret);
 }
 
-WM_SYMBOL midi *WildMidi_OpenBuffer(uint8_t *midibuffer, uint32_t size) {
+WM_SYMBOL midi *WildMidi_OpenBuffer(const uint8_t *midibuffer, uint32_t size) {
     uint8_t mus_hdr[] = { 'M', 'U', 'S', 0x1A };
     uint8_t xmi_hdr[] = { 'F', 'O', 'R', 'M' };
     midi * ret = NULL;

--- a/src/wildmidi_lib.c
+++ b/src/wildmidi_lib.c
@@ -330,7 +330,7 @@ static char** WM_LC_Tokenize_Line(char *line_data) {
                     token_data_length += TOKEN_CNT_INC;
                     token_data = (char **) realloc(token_data, token_data_length * sizeof(char *));
                     if (token_data == NULL) {
-                        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_MEM, NULL, errno);
+                        _WM_GLOBAL_ERROR(WM_ERR_MEM, NULL, errno);
                         return (NULL);
                     }
                 }
@@ -374,7 +374,7 @@ static int load_config(const char *config_file, const char *conf_dir) {
 
     if (conf_dir) {
         if (!(config_dir = wm_strdup(conf_dir))) {
-            _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_MEM, NULL, errno);
+            _WM_GLOBAL_ERROR(WM_ERR_MEM, NULL, errno);
             WM_FreePatches();
             _WM_FreeBufferFile(config_buffer);
             return (-1);
@@ -384,7 +384,7 @@ static int load_config(const char *config_file, const char *conf_dir) {
         if (dir_end) {
             config_dir = (char *) malloc((dir_end - config_file + 2));
             if (config_dir == NULL) {
-                _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_MEM, NULL, errno);
+                _WM_GLOBAL_ERROR(WM_ERR_MEM, NULL, errno);
                 WM_FreePatches();
                 free(config_buffer);
                 return (-1);
@@ -414,13 +414,13 @@ static int load_config(const char *config_file, const char *conf_dir) {
                     if (wm_strcasecmp(line_tokens[0], "dir") == 0) {
                         free(config_dir);
                         if (!line_tokens[1]) {
-                            _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_INVALID_ARG, "(missing name in dir line)", 0);
+                            _WM_GLOBAL_ERROR(WM_ERR_INVALID_ARG, "(missing name in dir line)", 0);
                             WM_FreePatches();
                             free(line_tokens);
                             _WM_FreeBufferFile(config_buffer);
                             return (-1);
                         } else if (!(config_dir = wm_strdup(line_tokens[1]))) {
-                            _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_MEM, NULL, errno);
+                            _WM_GLOBAL_ERROR(WM_ERR_MEM, NULL, errno);
                             WM_FreePatches();
                             free(line_tokens);
                             _WM_FreeBufferFile(config_buffer);
@@ -433,7 +433,7 @@ static int load_config(const char *config_file, const char *conf_dir) {
                     } else if (wm_strcasecmp(line_tokens[0], "source") == 0) {
                         char *new_config = NULL;
                         if (!line_tokens[1]) {
-                            _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_INVALID_ARG, "(missing name in source line)", 0);
+                            _WM_GLOBAL_ERROR(WM_ERR_INVALID_ARG, "(missing name in source line)", 0);
                             WM_FreePatches();
                             free(line_tokens);
                             _WM_FreeBufferFile(config_buffer);
@@ -441,7 +441,7 @@ static int load_config(const char *config_file, const char *conf_dir) {
                         } else if (!IS_ABSOLUTE_PATH(line_tokens[1]) && config_dir) {
                             new_config = (char *) malloc(strlen(config_dir) + strlen(line_tokens[1]) + 1);
                             if (new_config == NULL) {
-                                _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_MEM, NULL, errno);
+                                _WM_GLOBAL_ERROR(WM_ERR_MEM, NULL, errno);
                                 WM_FreePatches();
                                 free(config_dir);
                                 free(line_tokens);
@@ -452,7 +452,7 @@ static int load_config(const char *config_file, const char *conf_dir) {
                             strcpy(&new_config[strlen(config_dir)], line_tokens[1]);
                         } else {
                             if (!(new_config = wm_strdup(line_tokens[1]))) {
-                                _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_MEM, NULL, errno);
+                                _WM_GLOBAL_ERROR(WM_ERR_MEM, NULL, errno);
                                 WM_FreePatches();
                                 free(line_tokens);
                                 _WM_FreeBufferFile(config_buffer);
@@ -469,7 +469,7 @@ static int load_config(const char *config_file, const char *conf_dir) {
                         free(new_config);
                     } else if (wm_strcasecmp(line_tokens[0], "bank") == 0) {
                         if (!line_tokens[1] || !wm_isdigit(line_tokens[1][0])) {
-                            _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_INVALID_ARG, "(syntax error in bank line)", 0);
+                            _WM_GLOBAL_ERROR(WM_ERR_INVALID_ARG, "(syntax error in bank line)", 0);
                             WM_FreePatches();
                             free(config_dir);
                             free(line_tokens);
@@ -479,7 +479,7 @@ static int load_config(const char *config_file, const char *conf_dir) {
                         patchid = (atoi(line_tokens[1]) & 0xFF) << 8;
                     } else if (wm_strcasecmp(line_tokens[0], "drumset") == 0) {
                         if (!line_tokens[1] || !wm_isdigit(line_tokens[1][0])) {
-                            _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_INVALID_ARG, "(syntax error in drumset line)", 0);
+                            _WM_GLOBAL_ERROR(WM_ERR_INVALID_ARG, "(syntax error in drumset line)", 0);
                             WM_FreePatches();
                             free(config_dir);
                             free(line_tokens);
@@ -489,7 +489,7 @@ static int load_config(const char *config_file, const char *conf_dir) {
                         patchid = ((atoi(line_tokens[1]) & 0xFF) << 8) | 0x80;
                     } else if (wm_strcasecmp(line_tokens[0], "reverb_room_width") == 0) {
                         if (!line_tokens[1] || !wm_isdigit(line_tokens[1][0])) {
-                            _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_INVALID_ARG, "(syntax error in reverb_room_width line)", 0);
+                            _WM_GLOBAL_ERROR(WM_ERR_INVALID_ARG, "(syntax error in reverb_room_width line)", 0);
                             WM_FreePatches();
                             free(config_dir);
                             free(line_tokens);
@@ -506,7 +506,7 @@ static int load_config(const char *config_file, const char *conf_dir) {
                         }
                     } else if (wm_strcasecmp(line_tokens[0], "reverb_room_length") == 0) {
                         if (!line_tokens[1] || !wm_isdigit(line_tokens[1][0])) {
-                            _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_INVALID_ARG, "(syntax error in reverb_room_length line)", 0);
+                            _WM_GLOBAL_ERROR(WM_ERR_INVALID_ARG, "(syntax error in reverb_room_length line)", 0);
                             WM_FreePatches();
                             free(config_dir);
                             free(line_tokens);
@@ -523,7 +523,7 @@ static int load_config(const char *config_file, const char *conf_dir) {
                         }
                     } else if (wm_strcasecmp(line_tokens[0], "reverb_listener_posx") == 0) {
                         if (!line_tokens[1] || !wm_isdigit(line_tokens[1][0])) {
-                            _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_INVALID_ARG, "(syntax error in reverb_listen_posx line)", 0);
+                            _WM_GLOBAL_ERROR(WM_ERR_INVALID_ARG, "(syntax error in reverb_listen_posx line)", 0);
                             WM_FreePatches();
                             free(config_dir);
                             free(line_tokens);
@@ -539,7 +539,7 @@ static int load_config(const char *config_file, const char *conf_dir) {
                     } else if (wm_strcasecmp(line_tokens[0],
                             "reverb_listener_posy") == 0) {
                         if (!line_tokens[1] || !wm_isdigit(line_tokens[1][0])) {
-                            _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_INVALID_ARG, "(syntax error in reverb_listen_posy line)", 0);
+                            _WM_GLOBAL_ERROR(WM_ERR_INVALID_ARG, "(syntax error in reverb_listen_posy line)", 0);
                             WM_FreePatches();
                             free(config_dir);
                             free(line_tokens);
@@ -565,7 +565,7 @@ static int load_config(const char *config_file, const char *conf_dir) {
                         if (_WM_patch[(patchid & 0x7F)] == NULL) {
                             _WM_patch[(patchid & 0x7F)] = (struct _patch *) malloc(sizeof(struct _patch));
                             if (_WM_patch[(patchid & 0x7F)] == NULL) {
-                                _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_MEM, NULL, errno);
+                                _WM_GLOBAL_ERROR(WM_ERR_MEM, NULL, errno);
                                 WM_FreePatches();
                                 free(config_dir);
                                 free(line_tokens);
@@ -597,7 +597,7 @@ static int load_config(const char *config_file, const char *conf_dir) {
                                     }
                                     if (tmp_patch->next == NULL) {
                                         if ((tmp_patch->next = (struct _patch *) malloc(sizeof(struct _patch))) == NULL) {
-                                            _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_MEM, NULL, 0);
+                                            _WM_GLOBAL_ERROR(WM_ERR_MEM, NULL, 0);
                                             WM_FreePatches();
                                             free(config_dir);
                                             free(line_tokens);
@@ -623,7 +623,7 @@ static int load_config(const char *config_file, const char *conf_dir) {
                                 } else {
                                     tmp_patch->next = (struct _patch *) malloc(sizeof(struct _patch));
                                     if (tmp_patch->next == NULL) {
-                                        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_MEM, NULL, errno);
+                                        _WM_GLOBAL_ERROR(WM_ERR_MEM, NULL, errno);
                                         WM_FreePatches();
                                         free(config_dir);
                                         free(line_tokens);
@@ -643,7 +643,7 @@ static int load_config(const char *config_file, const char *conf_dir) {
                             }
                         }
                         if (!line_tokens[1]) {
-                            _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_INVALID_ARG, "(missing name in patch line)", 0);
+                            _WM_GLOBAL_ERROR(WM_ERR_INVALID_ARG, "(missing name in patch line)", 0);
                             WM_FreePatches();
                             free(config_dir);
                             free(line_tokens);
@@ -652,7 +652,7 @@ static int load_config(const char *config_file, const char *conf_dir) {
                         } else if (!IS_ABSOLUTE_PATH(line_tokens[1]) && config_dir) {
                             tmp_patch->filename = (char *) malloc(strlen(config_dir) + strlen(line_tokens[1]) + 5);
                             if (tmp_patch->filename == NULL) {
-                                _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_MEM, NULL, 0);
+                                _WM_GLOBAL_ERROR(WM_ERR_MEM, NULL, 0);
                                 WM_FreePatches();
                                 free(config_dir);
                                 free(line_tokens);
@@ -663,7 +663,7 @@ static int load_config(const char *config_file, const char *conf_dir) {
                             strcat(tmp_patch->filename, line_tokens[1]);
                         } else {
                             if (!(tmp_patch->filename = wm_strdup(line_tokens[1]))) {
-                                _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_MEM, NULL, 0);
+                                _WM_GLOBAL_ERROR(WM_ERR_MEM, NULL, 0);
                                 WM_FreePatches();
                                 free(config_dir);
                                 free(line_tokens);
@@ -781,7 +781,7 @@ static int add_handle(void * handle) {
     if (first_handle == NULL) {
         first_handle = (struct _hndl *) malloc(sizeof(struct _hndl));
         if (first_handle == NULL) {
-            _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_MEM, NULL, errno);
+            _WM_GLOBAL_ERROR(WM_ERR_MEM, NULL, errno);
             return (-1);
         }
         first_handle->handle = handle;
@@ -795,7 +795,7 @@ static int add_handle(void * handle) {
         }
         tmp_handle->next = (struct _hndl *) malloc(sizeof(struct _hndl));
         if (tmp_handle->next == NULL) {
-            _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_MEM, NULL, errno);
+            _WM_GLOBAL_ERROR(WM_ERR_MEM, NULL, errno);
             return (-1);
         }
         tmp_handle->next->prev = tmp_handle;
@@ -1481,7 +1481,7 @@ WM_SYMBOL int WildMidi_ConvertToMidi (const char *file, uint8_t **out, uint32_t 
     int ret;
 
     if (!file) {
-        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_INVALID_ARG, "(NULL filename)", 0);
+        _WM_GLOBAL_ERROR(WM_ERR_INVALID_ARG, "(NULL filename)", 0);
         return (-1);
     }
     if ((buf = (uint8_t *) _WM_BufferFile(file, size)) == NULL) {
@@ -1496,7 +1496,7 @@ WM_SYMBOL int WildMidi_ConvertToMidi (const char *file, uint8_t **out, uint32_t 
 WM_SYMBOL int WildMidi_ConvertBufferToMidi (uint8_t *in, uint32_t insize,
                                             uint8_t **out, uint32_t *outsize) {
     if (!in || !out || !outsize) {
-        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_INVALID_ARG, "(NULL params)", 0);
+        _WM_GLOBAL_ERROR(WM_ERR_INVALID_ARG, "(NULL params)", 0);
         return (-1);
     }
 
@@ -1513,11 +1513,11 @@ WM_SYMBOL int WildMidi_ConvertBufferToMidi (uint8_t *in, uint32_t insize,
         }
     }
     else if (!memcmp(in, "MThd", 4)) {
-        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, 0, "Already a midi file", 0);
+        _WM_GLOBAL_ERROR(0, "Already a midi file", 0);
         return (-1);
     }
     else {
-        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_INVALID, NULL, 0);
+        _WM_GLOBAL_ERROR(WM_ERR_INVALID, NULL, 0);
         return (-1);
     }
 
@@ -1540,12 +1540,12 @@ WM_SYMBOL long WildMidi_GetVersion (void) {
 static int _WM_Init(const struct _WM_VIO *callbacks,
                     const char *config_file, uint16_t rate, uint16_t mixer_options) {
     if (WM_Initialized) {
-        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_ALR_INIT, NULL, 0);
+        _WM_GLOBAL_ERROR(WM_ERR_ALR_INIT, NULL, 0);
         return (-1);
     }
 
     if (config_file == NULL) {
-        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_INVALID_ARG,
+        _WM_GLOBAL_ERROR(WM_ERR_INVALID_ARG,
                 "(NULL config file pointer)", 0);
         return (-1);
     }
@@ -1559,7 +1559,7 @@ static int _WM_Init(const struct _WM_VIO *callbacks,
     }
 
     if (mixer_options & 0x0FF0) {
-        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_INVALID_ARG, "(invalid option)",
+        _WM_GLOBAL_ERROR(WM_ERR_INVALID_ARG, "(invalid option)",
                 0);
         WM_FreePatches();
         return (-1);
@@ -1567,7 +1567,7 @@ static int _WM_Init(const struct _WM_VIO *callbacks,
     _WM_MixerOptions = mixer_options;
 
     if (rate < 11025) {
-        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_INVALID_ARG,
+        _WM_GLOBAL_ERROR(WM_ERR_INVALID_ARG,
                 "(rate out of bounds, range is 11025 - 65535)", 0);
         WM_FreePatches();
         return (-1);
@@ -1589,7 +1589,7 @@ WM_SYMBOL int WildMidi_Init(const char *config_file, uint16_t rate, uint16_t mix
 
 WM_SYMBOL int WildMidi_InitVIO(struct _WM_VIO *callbacks, const char *config_file, uint16_t rate, uint16_t mixer_options) {
     if (!callbacks || !callbacks->allocate_file || !callbacks->free_file) {
-        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_INVALID_ARG, "(NULL VIO callbacks)", 0);
+        _WM_GLOBAL_ERROR(WM_ERR_INVALID_ARG, "(NULL VIO callbacks)", 0);
         return (-1);
     }
 
@@ -1598,11 +1598,11 @@ WM_SYMBOL int WildMidi_InitVIO(struct _WM_VIO *callbacks, const char *config_fil
 
 WM_SYMBOL int WildMidi_MasterVolume(uint8_t master_volume) {
     if (!WM_Initialized) {
-        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_NOT_INIT, NULL, 0);
+        _WM_GLOBAL_ERROR(WM_ERR_NOT_INIT, NULL, 0);
         return (-1);
     }
     if (master_volume > 127) {
-        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_INVALID_ARG,
+        _WM_GLOBAL_ERROR(WM_ERR_INVALID_ARG,
                 "(master volume out of range, range is 0-127)", 0);
         return (-1);
     }
@@ -1617,15 +1617,15 @@ WM_SYMBOL int WildMidi_Close(midi * handle) {
     struct _hndl * tmp_handle;
 
     if (!WM_Initialized) {
-        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_NOT_INIT, NULL, 0);
+        _WM_GLOBAL_ERROR(WM_ERR_NOT_INIT, NULL, 0);
         return (-1);
     }
     if (handle == NULL) {
-        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_INVALID_ARG, "(NULL handle)", 0);
+        _WM_GLOBAL_ERROR(WM_ERR_INVALID_ARG, "(NULL handle)", 0);
         return (-1);
     }
     if (first_handle == NULL) {
-        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_INVALID_ARG, "(no midi's open)", 0);
+        _WM_GLOBAL_ERROR(WM_ERR_INVALID_ARG, "(no midi's open)", 0);
         return (-1);
     }
     _WM_Lock(&mdi->lock);
@@ -1665,11 +1665,11 @@ WM_SYMBOL midi *WildMidi_Open(const char *midifile) {
     midi * ret = NULL;
 
     if (!WM_Initialized) {
-        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_NOT_INIT, NULL, 0);
+        _WM_GLOBAL_ERROR(WM_ERR_NOT_INIT, NULL, 0);
         return (NULL);
     }
     if (midifile == NULL) {
-        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_INVALID_ARG, "(NULL filename)", 0);
+        _WM_GLOBAL_ERROR(WM_ERR_INVALID_ARG, "(NULL filename)", 0);
         return (NULL);
     }
 
@@ -1677,7 +1677,7 @@ WM_SYMBOL midi *WildMidi_Open(const char *midifile) {
         return (NULL);
     }
     if (midisize < 18) {
-        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_CORUPT, "(too short)", 0);
+        _WM_GLOBAL_ERROR(WM_ERR_CORUPT, "(too short)", 0);
         return (NULL);
     }
     if (memcmp(mididata,"HMIMIDIP", 8) == 0) {
@@ -1709,20 +1709,20 @@ WM_SYMBOL midi *WildMidi_OpenBuffer(uint8_t *midibuffer, uint32_t size) {
     midi * ret = NULL;
 
     if (!WM_Initialized) {
-        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_NOT_INIT, NULL, 0);
+        _WM_GLOBAL_ERROR(WM_ERR_NOT_INIT, NULL, 0);
         return (NULL);
     }
     if (midibuffer == NULL) {
-        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_INVALID_ARG, "(NULL midi data buffer)", 0);
+        _WM_GLOBAL_ERROR(WM_ERR_INVALID_ARG, "(NULL midi data buffer)", 0);
         return (NULL);
     }
     if (size > WM_MAXFILESIZE) {
         /* don't bother loading suspiciously long files */
-        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_LONGFIL, NULL, 0);
+        _WM_GLOBAL_ERROR(WM_ERR_LONGFIL, NULL, 0);
         return (NULL);
     }
     if (size < 18) {
-        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_CORUPT, "(too short)", 0);
+        _WM_GLOBAL_ERROR(WM_ERR_CORUPT, "(too short)", 0);
         return (NULL);
     }
     if (memcmp(midibuffer,"HMIMIDIP", 8) == 0) {
@@ -1753,15 +1753,15 @@ WM_SYMBOL int WildMidi_FastSeek(midi * handle, unsigned long int *sample_pos) {
     struct _note *note_data;
 
     if (!WM_Initialized) {
-        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_NOT_INIT, NULL, 0);
+        _WM_GLOBAL_ERROR(WM_ERR_NOT_INIT, NULL, 0);
         return (-1);
     }
     if (handle == NULL) {
-        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_INVALID_ARG, "(NULL handle)", 0);
+        _WM_GLOBAL_ERROR(WM_ERR_INVALID_ARG, "(NULL handle)", 0);
         return (-1);
     }
     if (sample_pos == NULL) {
-        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_INVALID_ARG, "(NULL seek position pointer)", 0);
+        _WM_GLOBAL_ERROR(WM_ERR_INVALID_ARG, "(NULL seek position pointer)", 0);
         return (-1);
     }
 
@@ -1846,23 +1846,23 @@ WM_SYMBOL int WildMidi_SongSeek (midi * handle, int8_t nextsong) {
     struct _note *note_data;
 
     if (!WM_Initialized) {
-        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_NOT_INIT, NULL, 0);
+        _WM_GLOBAL_ERROR(WM_ERR_NOT_INIT, NULL, 0);
         return (-1);
     }
     if (handle == NULL) {
-        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_INVALID_ARG, "(NULL handle)", 0);
+        _WM_GLOBAL_ERROR(WM_ERR_INVALID_ARG, "(NULL handle)", 0);
         return (-1);
     }
     mdi = (struct _mdi *) handle;
     _WM_Lock(&mdi->lock);
 
     if ((!mdi->is_type2) && (nextsong != 0)) {
-        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_INVALID_ARG, "(Illegal use. Only usable with files detected to be type 2 compatible.", 0);
+        _WM_GLOBAL_ERROR(WM_ERR_INVALID_ARG, "(Illegal use. Only usable with files detected to be type 2 compatible.", 0);
         _WM_Unlock(&mdi->lock);
         return (-1);
     }
     if ((nextsong > 1) || (nextsong < -1)) {
-        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_INVALID_ARG, "(Invalid nextsong: -1 is previous song, 0 is start of current song, 1 is next song)", 0);
+        _WM_GLOBAL_ERROR(WM_ERR_INVALID_ARG, "(Invalid nextsong: -1 is previous song, 0 is start of current song, 1 is next song)", 0);
         _WM_Unlock(&mdi->lock);
         return (-1);
     }
@@ -1950,22 +1950,22 @@ WM_SYMBOL int WildMidi_SongSeek (midi * handle, int8_t nextsong) {
 
 WM_SYMBOL int WildMidi_GetOutput(midi * handle, int8_t *buffer, uint32_t size) {
     if (__builtin_expect((!WM_Initialized), 0)) {
-        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_NOT_INIT, NULL, 0);
+        _WM_GLOBAL_ERROR(WM_ERR_NOT_INIT, NULL, 0);
         return (-1);
     }
     if (__builtin_expect((handle == NULL), 0)) {
-        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_INVALID_ARG, "(NULL handle)", 0);
+        _WM_GLOBAL_ERROR(WM_ERR_INVALID_ARG, "(NULL handle)", 0);
         return (-1);
     }
     if (__builtin_expect((buffer == NULL), 0)) {
-        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_INVALID_ARG, "(NULL buffer pointer)", 0);
+        _WM_GLOBAL_ERROR(WM_ERR_INVALID_ARG, "(NULL buffer pointer)", 0);
         return (-1);
     }
     if (__builtin_expect((size == 0), 0)) {
         return (0);
     }
     if (__builtin_expect((!!(size % 4)), 0)) {
-        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_INVALID_ARG, "(size not a multiple of 4)", 0);
+        _WM_GLOBAL_ERROR(WM_ERR_INVALID_ARG, "(size not a multiple of 4)", 0);
         return (-1);
     }
 
@@ -1978,15 +1978,15 @@ WM_SYMBOL int WildMidi_GetOutput(midi * handle, int8_t *buffer, uint32_t size) {
 
 WM_SYMBOL int WildMidi_GetMidiOutput(midi * handle, int8_t **buffer, uint32_t *size) {
     if (__builtin_expect((!WM_Initialized), 0)) {
-        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_NOT_INIT, NULL, 0);
+        _WM_GLOBAL_ERROR(WM_ERR_NOT_INIT, NULL, 0);
         return (-1);
     }
     if (__builtin_expect((handle == NULL), 0)) {
-        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_INVALID_ARG, "(NULL handle)", 0);
+        _WM_GLOBAL_ERROR(WM_ERR_INVALID_ARG, "(NULL handle)", 0);
         return (-1);
     }
     if (__builtin_expect((buffer == NULL), 0)) {
-        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_INVALID_ARG, "(NULL buffer pointer)", 0);
+        _WM_GLOBAL_ERROR(WM_ERR_INVALID_ARG, "(NULL buffer pointer)", 0);
         return (-1);
     }
     return _WM_Event2Midi((struct _mdi *)handle, (uint8_t **)buffer, size);
@@ -1997,23 +1997,23 @@ WM_SYMBOL int WildMidi_SetOption(midi * handle, uint16_t options, uint16_t setti
     struct _mdi *mdi;
 
     if (!WM_Initialized) {
-        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_NOT_INIT, NULL, 0);
+        _WM_GLOBAL_ERROR(WM_ERR_NOT_INIT, NULL, 0);
         return (-1);
     }
     if (handle == NULL) {
-        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_INVALID_ARG, "(NULL handle)", 0);
+        _WM_GLOBAL_ERROR(WM_ERR_INVALID_ARG, "(NULL handle)", 0);
         return (-1);
     }
 
     mdi = (struct _mdi *) handle;
     _WM_Lock(&mdi->lock);
     if ((!(options & 0x800F)) || (options & 0x7FF0)) {
-        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_INVALID_ARG, "(invalid option)", 0);
+        _WM_GLOBAL_ERROR(WM_ERR_INVALID_ARG, "(invalid option)", 0);
         _WM_Unlock(&mdi->lock);
         return (-1);
     }
     if (setting & 0x7FF0) {
-        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_INVALID_ARG, "(invalid setting)", 0);
+        _WM_GLOBAL_ERROR(WM_ERR_INVALID_ARG, "(invalid setting)", 0);
         _WM_Unlock(&mdi->lock);
         return (-1);
     }
@@ -2042,7 +2042,7 @@ WM_SYMBOL int WildMidi_SetCvtOption(uint16_t tag, uint16_t setting) {
         WM_ConvertOptions.frequency = setting;
         break;
     default:
-        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_INVALID_ARG, "(invalid setting)", 0);
+        _WM_GLOBAL_ERROR(WM_ERR_INVALID_ARG, "(invalid setting)", 0);
         _WM_Unlock(&WM_ConvertOptions.lock);
         return (-1);
     }
@@ -2054,18 +2054,18 @@ WM_SYMBOL struct _WM_Info *
 WildMidi_GetInfo(midi * handle) {
     struct _mdi *mdi = (struct _mdi *) handle;
     if (!WM_Initialized) {
-        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_NOT_INIT, NULL, 0);
+        _WM_GLOBAL_ERROR(WM_ERR_NOT_INIT, NULL, 0);
         return (NULL);
     }
     if (handle == NULL) {
-        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_INVALID_ARG, "(NULL handle)", 0);
+        _WM_GLOBAL_ERROR(WM_ERR_INVALID_ARG, "(NULL handle)", 0);
         return (NULL);
     }
     _WM_Lock(&mdi->lock);
     if (mdi->tmp_info == NULL) {
         mdi->tmp_info = (struct _WM_Info *) malloc(sizeof(struct _WM_Info));
         if (mdi->tmp_info == NULL) {
-            _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_MEM, NULL, 0);
+            _WM_GLOBAL_ERROR(WM_ERR_MEM, NULL, 0);
             _WM_Unlock(&mdi->lock);
             return (NULL);
         }
@@ -2081,7 +2081,7 @@ WildMidi_GetInfo(midi * handle) {
         if (mdi->tmp_info->copyright == NULL) {
             free(mdi->tmp_info);
             mdi->tmp_info = NULL;
-            _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_MEM, NULL, 0);
+            _WM_GLOBAL_ERROR(WM_ERR_MEM, NULL, 0);
             _WM_Unlock(&mdi->lock);
             return (NULL);
         } else {
@@ -2096,7 +2096,7 @@ WildMidi_GetInfo(midi * handle) {
 
 WM_SYMBOL int WildMidi_Shutdown(void) {
     if (!WM_Initialized) {
-        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_NOT_INIT, NULL, 0);
+        _WM_GLOBAL_ERROR(WM_ERR_NOT_INIT, NULL, 0);
         return (-1);
     }
     while (first_handle) {
@@ -2150,11 +2150,11 @@ WM_SYMBOL char * WildMidi_GetLyric (midi * handle) {
     char * lyric = NULL;
 
     if (!WM_Initialized) {
-        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_NOT_INIT, NULL, 0);
+        _WM_GLOBAL_ERROR(WM_ERR_NOT_INIT, NULL, 0);
         return (NULL);
     }
     if (handle == NULL) {
-        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_INVALID_ARG, "(NULL handle)", 0);
+        _WM_GLOBAL_ERROR(WM_ERR_INVALID_ARG, "(NULL handle)", 0);
         return (NULL);
     }
     _WM_Lock(&mdi->lock);

--- a/src/wm_error.c
+++ b/src/wm_error.c
@@ -67,7 +67,7 @@ static const char *errors[WM_ERR_MAX+1] = {
 char * _WM_Global_ErrorS = NULL;
 int _WM_Global_ErrorI = 0;
 
-void _WM_GLOBAL_ERROR(const char *func, int lne, int wmerno, const char *wmfor, int error) {
+void _WM_GLOBAL_ERROR_INTERNAL(const char *func, int lne, int wmerno, const char *wmfor, int error) {
 
     char *errorstring;
 

--- a/src/xmi2mid.c
+++ b/src/xmi2mid.c
@@ -479,12 +479,12 @@ int _WM_xmi2midi(const uint8_t *in, uint32_t insize,
     ctx.convert_type = convert_type;
 
     if (ParseXMI(&ctx) < 0) {
-        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_NOT_XMI, NULL, 0);
+        _WM_GLOBAL_ERROR(WM_ERR_NOT_XMI, NULL, 0);
         goto _end;
     }
 
     if (ExtractTracks(&ctx) < 0) {
-        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_NOT_MIDI, NULL, 0);
+        _WM_GLOBAL_ERROR(WM_ERR_NOT_MIDI, NULL, 0);
         goto _end;
     }
 
@@ -957,7 +957,7 @@ static uint32_t ExtractTracksFromXmi(struct xmi_ctx *ctx) {
 
         /* Convert it */
         if (!(ppqn = ConvertFiletoList(ctx))) {
-            _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_CORUPT, NULL, 0);
+            _WM_GLOBAL_ERROR(WM_ERR_CORUPT, NULL, 0);
             break;
         }
         ctx->timing[num] = ppqn;
@@ -984,7 +984,7 @@ static int ParseXMI(struct xmi_ctx *ctx) {
 
     file_size = getsrcsize(ctx);
     if (getsrcpos(ctx) + 8 > file_size) {
-badfile:    _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_CORUPT, "(too short)", 0);
+badfile:    _WM_GLOBAL_ERROR(WM_ERR_CORUPT, "(too short)", 0);
         return (-1);
     }
 

--- a/src/xmi2mid.c
+++ b/src/xmi2mid.c
@@ -469,7 +469,7 @@ int _WM_xmi2midi(const uint8_t *in, uint32_t insize,
     int ret = -1;
 
     if (convert_type > XMIDI_CONVERT_MT32_TO_GS) {
-        _WM_ERROR_NEW("%s:%i:  %d is an invalid conversion type.", __FUNCTION__, __LINE__, convert_type);
+        _WM_ERROR_NEW("%s:%i:  %d is an invalid conversion type.", __func__, __LINE__, convert_type);
         return (ret);
     }
 
@@ -914,7 +914,7 @@ static uint32_t ConvertListToMTrk(struct xmi_ctx *ctx, midi_event *mlist) {
 
         /* Never occur */
         default:
-            _WM_DEBUG_MSG("%s: unrecognized event", __FUNCTION__);
+            _WM_DEBUG_MSG("%s: unrecognized event", __func__);
             break;
         }
     }

--- a/src/xmi2mid.c
+++ b/src/xmi2mid.c
@@ -469,7 +469,7 @@ int _WM_xmi2midi(const uint8_t *in, uint32_t insize,
     int ret = -1;
 
     if (convert_type > XMIDI_CONVERT_MT32_TO_GS) {
-        _WM_ERROR_NEW("%s:%i:  %d is an invalid conversion type.", __func__, __LINE__, convert_type);
+        _WM_ERROR_NEW("%s:%i:  %d is an invalid conversion type.", __FILE__, __LINE__, convert_type);
         return (ret);
     }
 
@@ -914,7 +914,7 @@ static uint32_t ConvertListToMTrk(struct xmi_ctx *ctx, midi_event *mlist) {
 
         /* Never occur */
         default:
-            _WM_DEBUG_MSG("%s: unrecognized event", __func__);
+            _WM_DEBUG_MSG("%s: unrecognized event", __FILE__);
             break;
         }
     }


### PR DESCRIPTION
I've fixed #234, made the user-supplied input buffers `const`, added a standard C fallback to the file IO, and converted the codebase to C89 (which only required changing some comments and eliminating the use of `__FUNCTION__`/`__func__`, as the codebase was already mostly written in C89).