### PR TITLE
Silence warnings when compiling as ANSI C

### DIFF
--- a/include/wm_error.h
+++ b/include/wm_error.h
@@ -50,7 +50,14 @@ enum {
 extern char * _WM_Global_ErrorS;
 extern int _WM_Global_ErrorI;
 
-extern void _WM_GLOBAL_ERROR(const char *func, int lne, int wmerno, const char * wmfor, int error);
+#if (defined(__STDC_VERSION__) && __STDC_VERSION__ >= 199901L) || (defined(__cplusplus) && __cplusplus >= 201103L)
+#define _WM_FUNCTION __func__
+#else
+#define _WM_FUNCTION "<unknown>"
+#endif
+
+#define _WM_GLOBAL_ERROR(wmerno, wmfor, error) _WM_GLOBAL_ERROR_INTERNAL(_WM_FUNCTION, __LINE__, wmerno, wmfor, error)
+extern void _WM_GLOBAL_ERROR_INTERNAL(const char *func, int lne, int wmerno, const char * wmfor, int error);
 
 /* sets the global error string to a custom msg */
 extern void _WM_ERROR_NEW(const char * wmfmt, ...)

--- a/src/f_hmi.c
+++ b/src/f_hmi.c
@@ -77,12 +77,12 @@ _WM_ParseNewHmi(const uint8_t *hmi_data, uint32_t hmi_size) {
 
 
     if (hmi_size <= 370) {
-        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_CORUPT, "file too short", 0);
+        _WM_GLOBAL_ERROR(WM_ERR_CORUPT, "file too short", 0);
         return NULL;
     }
 
     if (memcmp(hmi_data, "HMI-MIDISONG061595", 18)) {
-        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_NOT_HMI, NULL, 0);
+        _WM_GLOBAL_ERROR(WM_ERR_NOT_HMI, NULL, 0);
         return NULL;
     }
 
@@ -94,16 +94,16 @@ _WM_ParseNewHmi(const uint8_t *hmi_data, uint32_t hmi_size) {
     hmi_track_cnt = hmi_data[228];
 
     if (!hmi_track_cnt) {
-        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_CORUPT, "(no tracks)", 0);
+        _WM_GLOBAL_ERROR(WM_ERR_CORUPT, "(no tracks)", 0);
         return NULL;
     }
     if (!hmi_bpm) {
-        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_INVALID, "(bad bpm)", 0);
+        _WM_GLOBAL_ERROR(WM_ERR_INVALID, "(bad bpm)", 0);
         return NULL;
     }
 
     if (hmi_size < (370 + (hmi_track_cnt * 17))) {
-        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_CORUPT, "file too short", 0);
+        _WM_GLOBAL_ERROR(WM_ERR_CORUPT, "file too short", 0);
         return NULL;
     }
 
@@ -136,7 +136,7 @@ _WM_ParseNewHmi(const uint8_t *hmi_data, uint32_t hmi_size) {
     for (i = 0; i < hmi_track_cnt; i++) {
         /* FIXME: better and/or more size checks??? */
         if (data_end - hmi_data < 4) {
-            _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_CORUPT, "file too short", 0);
+            _WM_GLOBAL_ERROR(WM_ERR_CORUPT, "file too short", 0);
             goto _hmi_end;
         }
 
@@ -146,14 +146,14 @@ _WM_ParseNewHmi(const uint8_t *hmi_data, uint32_t hmi_size) {
         hmi_track_offset[i] += (*hmi_data++ << 24);
 
         if (hmi_size < (hmi_track_offset[i] + 0x5a + 4)) {
-            _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_NOT_HMI, "file too short", 0);
+            _WM_GLOBAL_ERROR(WM_ERR_NOT_HMI, "file too short", 0);
             goto _hmi_end;
         }
 
         hmi_addr = hmi_base + hmi_track_offset[i];
 
         if (memcmp(hmi_addr, "HMI-MIDITRACK", 13)) {
-            _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_NOT_HMI, NULL, 0);
+            _WM_GLOBAL_ERROR(WM_ERR_NOT_HMI, NULL, 0);
             goto _hmi_end;
         }
 
@@ -196,7 +196,7 @@ _WM_ParseNewHmi(const uint8_t *hmi_data, uint32_t hmi_size) {
     if (smallest_delta >= 0x7fffffff) {
         /* DEBUG */
         /* fprintf(stderr,"CRAZY SMALLEST DELTA %u\n", smallest_delta); */
-        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_CORUPT, NULL, 0);
+        _WM_GLOBAL_ERROR(WM_ERR_CORUPT, NULL, 0);
         goto _hmi_end;
     }
 
@@ -204,7 +204,7 @@ _WM_ParseNewHmi(const uint8_t *hmi_data, uint32_t hmi_size) {
         /* DEBUG */
         /* fprintf(stderr,"INTEGER OVERFLOW (samples_per_delta: %f, smallest_delta: %u)\n", */
         /*        samples_per_delta_f, smallest_delta); */
-        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_CORUPT, NULL, 0);
+        _WM_GLOBAL_ERROR(WM_ERR_CORUPT, NULL, 0);
         goto _hmi_end;
     }
 
@@ -251,7 +251,7 @@ _WM_ParseNewHmi(const uint8_t *hmi_data, uint32_t hmi_size) {
                 hmi_data = hmi_base + hmi_track_offset[i];
                 hmi_delta[i] = 0;
                 if (hmi_track_offset[i] >= hmi_size) {
-                    _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_NOT_HMI, "file too short", 0);
+                    _WM_GLOBAL_ERROR(WM_ERR_NOT_HMI, "file too short", 0);
                     goto _hmi_end;
                 }
                 data_size = hmi_size - hmi_track_offset[i];
@@ -273,7 +273,7 @@ _WM_ParseNewHmi(const uint8_t *hmi_data, uint32_t hmi_size) {
                     hmi_data += 4;
                     hmi_track_offset[i] += 4;
                     if (hmi_tmp > data_size) {
-                        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_NOT_HMI, "file too short", 0);
+                        _WM_GLOBAL_ERROR(WM_ERR_NOT_HMI, "file too short", 0);
                         goto _hmi_end;
                     }
                     data_size -= hmi_tmp;
@@ -330,7 +330,7 @@ _WM_ParseNewHmi(const uint8_t *hmi_data, uint32_t hmi_size) {
                             } while (*hmi_data > 0x7F);
                         }
                         if (!data_size) {
-                            _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_NOT_HMI, "file too short", 0);
+                            _WM_GLOBAL_ERROR(WM_ERR_NOT_HMI, "file too short", 0);
                             goto _hmi_end;
                         }
                         note[hmi_tmp].length = (note[hmi_tmp].length << 7) | (*hmi_data & 0x7F);
@@ -365,7 +365,7 @@ _WM_ParseNewHmi(const uint8_t *hmi_data, uint32_t hmi_size) {
                     } while (*hmi_data > 0x7F);
                 }
                 if (!data_size) {
-                    _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_NOT_HMI, "file too short", 0);
+                    _WM_GLOBAL_ERROR(WM_ERR_NOT_HMI, "file too short", 0);
                     goto _hmi_end;
                 }
                 hmi_delta[i] = (hmi_delta[i] << 7) | (*hmi_data & 0x7F);
@@ -387,7 +387,7 @@ _WM_ParseNewHmi(const uint8_t *hmi_data, uint32_t hmi_size) {
             /* DEBUG */
             /* fprintf(stderr,"INTEGER OVERFLOW (samples_per_delta: %f, smallest_delta: %u)\n", */
             /*        samples_per_delta_f, smallest_delta); */
-            _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_CORUPT, NULL, 0);
+            _WM_GLOBAL_ERROR(WM_ERR_CORUPT, NULL, 0);
             goto _hmi_end;
         }
         subtract_delta = smallest_delta;
@@ -401,7 +401,7 @@ _WM_ParseNewHmi(const uint8_t *hmi_data, uint32_t hmi_size) {
     }
 
     if ((hmi_mdi->reverb = _WM_init_reverb(_WM_SampleRate, _WM_reverb_room_width, _WM_reverb_room_length, _WM_reverb_listen_posx, _WM_reverb_listen_posy)) == NULL) {
-        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_MEM, NULL, 0);
+        _WM_GLOBAL_ERROR(WM_ERR_MEM, NULL, 0);
         goto _hmi_end;
     }
 

--- a/src/f_hmp.c
+++ b/src/f_hmp.c
@@ -70,12 +70,12 @@ _WM_ParseNewHmp(const uint8_t *hmp_data, uint32_t hmp_size) {
     float sample_remainder = 0;
 
     if (hmp_size < 776) {
-        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_CORUPT, "file too short", 0);
+        _WM_GLOBAL_ERROR(WM_ERR_CORUPT, "file too short", 0);
         return NULL;
     }
 
     if (memcmp(hmp_data, "HMIMIDIP", 8)) {
-        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_NOT_HMP, NULL, 0);
+        _WM_GLOBAL_ERROR(WM_ERR_NOT_HMP, NULL, 0);
         return NULL;
     }
     hmp_data += 8;
@@ -83,7 +83,7 @@ _WM_ParseNewHmp(const uint8_t *hmp_data, uint32_t hmp_size) {
 
     if (!memcmp(hmp_data, "013195", 6)) {
         if (hmp_size < 896) {
-            _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_CORUPT, "file too short", 0);
+            _WM_GLOBAL_ERROR(WM_ERR_CORUPT, "file too short", 0);
             return NULL;
         }
         hmp_data += 6;
@@ -99,7 +99,7 @@ _WM_ParseNewHmp(const uint8_t *hmp_data, uint32_t hmp_size) {
     }
     for (i = 0; i < zero_cnt; i++) {
         if (hmp_data[i] != 0) {
-            _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_NOT_HMP, NULL, 0);
+            _WM_GLOBAL_ERROR(WM_ERR_NOT_HMP, NULL, 0);
             return NULL;
         }
     }
@@ -125,7 +125,7 @@ _WM_ParseNewHmp(const uint8_t *hmp_data, uint32_t hmp_size) {
     hmp_size -= 4;
 
     if (!hmp_chunks) {
-        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_CORUPT, "(no tracks)", 0);
+        _WM_GLOBAL_ERROR(WM_ERR_CORUPT, "(no tracks)", 0);
         return NULL;
     }
 
@@ -149,7 +149,7 @@ _WM_ParseNewHmp(const uint8_t *hmp_data, uint32_t hmp_size) {
     hmp_size -= 4;
 
     if (!hmp_bpm) {
-        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_INVALID, "(bad bpm)", 0);
+        _WM_GLOBAL_ERROR(WM_ERR_INVALID, "(bad bpm)", 0);
         return NULL;
     }
 
@@ -218,7 +218,7 @@ _WM_ParseNewHmp(const uint8_t *hmp_data, uint32_t hmp_size) {
         chunk_ofs[i] += 4;
 
         if (chunk_length[i] > hmp_size) {
-            _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_NOT_HMP, "file too short", 0);
+            _WM_GLOBAL_ERROR(WM_ERR_NOT_HMP, "file too short", 0);
             goto _hmp_end;
         }
         hmp_size -= chunk_length[i];
@@ -258,7 +258,7 @@ _WM_ParseNewHmp(const uint8_t *hmp_data, uint32_t hmp_size) {
     if (smallest_delta >= 0x7fffffff) {
         /* DEBUG */
         /* fprintf(stderr,"CRAZY SMALLEST DELTA %u\n", smallest_delta); */
-        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_CORUPT, NULL, 0);
+        _WM_GLOBAL_ERROR(WM_ERR_CORUPT, NULL, 0);
         goto _hmp_end;
     }
 
@@ -266,7 +266,7 @@ _WM_ParseNewHmp(const uint8_t *hmp_data, uint32_t hmp_size) {
         /* DEBUG */
         /* fprintf(stderr,"INTEGER OVERFLOW (samples_per_delta: %f, smallest_delta: %u)\n", */
         /*        samples_per_delta_f, smallest_delta); */
-        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_CORUPT, NULL, 0);
+        _WM_GLOBAL_ERROR(WM_ERR_CORUPT, NULL, 0);
         goto _hmp_end;
     }
 
@@ -343,7 +343,7 @@ _WM_ParseNewHmp(const uint8_t *hmp_data, uint32_t hmp_size) {
                     } while (*hmp_chunk[i] < 0x80);
                 }
                 if (! chunk_length[i]) {
-                    _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_NOT_HMP, "file too short", 0);
+                    _WM_GLOBAL_ERROR(WM_ERR_NOT_HMP, "file too short", 0);
                     goto _hmp_end;
                 }
                 chunk_delta[i] = chunk_delta[i] + ((*hmp_chunk[i] & 0x7F) << var_len_shift);
@@ -361,7 +361,7 @@ _WM_ParseNewHmp(const uint8_t *hmp_data, uint32_t hmp_size) {
             /* DEBUG */
             /* fprintf(stderr,"INTEGER OVERFLOW (samples_per_delta: %f, smallest_delta: %u)\n", */
             /*        samples_per_delta_f, smallest_delta); */
-            _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_CORUPT, NULL, 0);
+            _WM_GLOBAL_ERROR(WM_ERR_CORUPT, NULL, 0);
             goto _hmp_end;
         }
 
@@ -379,7 +379,7 @@ _WM_ParseNewHmp(const uint8_t *hmp_data, uint32_t hmp_size) {
     }
 
     if ((hmp_mdi->reverb = _WM_init_reverb(_WM_SampleRate, _WM_reverb_room_width, _WM_reverb_room_length, _WM_reverb_listen_posx, _WM_reverb_listen_posy)) == NULL) {
-        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_MEM, NULL, 0);
+        _WM_GLOBAL_ERROR(WM_ERR_MEM, NULL, 0);
         goto _hmp_end;
     }
 

--- a/src/f_midi.c
+++ b/src/f_midi.c
@@ -65,13 +65,13 @@ _WM_ParseNewMidi(const uint8_t *midi_data, uint32_t midi_size) {
     uint32_t setup_ret = 0;
 
     if (midi_size < 14) {
-        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_CORUPT, "(too short)", 0);
+        _WM_GLOBAL_ERROR(WM_ERR_CORUPT, "(too short)", 0);
         return (NULL);
     }
 
     if (!memcmp(midi_data, "RIFF", 4)) {
         if (midi_size < 34) {
-            _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_CORUPT, "(too short)", 0);
+            _WM_GLOBAL_ERROR(WM_ERR_CORUPT, "(too short)", 0);
             return (NULL);
         }
         midi_data += 20;
@@ -79,7 +79,7 @@ _WM_ParseNewMidi(const uint8_t *midi_data, uint32_t midi_size) {
     }
 
     if (memcmp(midi_data, "MThd", 4)) {
-        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_NOT_MIDI, NULL, 0);
+        _WM_GLOBAL_ERROR(WM_ERR_NOT_MIDI, NULL, 0);
         return (NULL);
     }
     midi_data += 4;
@@ -94,7 +94,7 @@ _WM_ParseNewMidi(const uint8_t *midi_data, uint32_t midi_size) {
     tmp_val |= *midi_data++;
     midi_size -= 4;
     if (tmp_val != 6) {
-        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_CORUPT, NULL, 0);
+        _WM_GLOBAL_ERROR(WM_ERR_CORUPT, NULL, 0);
         return (NULL);
     }
 
@@ -105,7 +105,7 @@ _WM_ParseNewMidi(const uint8_t *midi_data, uint32_t midi_size) {
     tmp_val |= *midi_data++;
     midi_size -= 2;
     if (tmp_val > 2) {
-        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_INVALID, NULL, 0);
+        _WM_GLOBAL_ERROR(WM_ERR_INVALID, NULL, 0);
         return (NULL);
     }
     midi_type = tmp_val;
@@ -117,7 +117,7 @@ _WM_ParseNewMidi(const uint8_t *midi_data, uint32_t midi_size) {
     tmp_val |= *midi_data++;
     midi_size -= 2;
     if (tmp_val < 1) {
-        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_CORUPT, "(no tracks)", 0);
+        _WM_GLOBAL_ERROR(WM_ERR_CORUPT, "(no tracks)", 0);
         return (NULL);
     }
     no_tracks = tmp_val;
@@ -126,7 +126,7 @@ _WM_ParseNewMidi(const uint8_t *midi_data, uint32_t midi_size) {
      * Check that type 0 midi file has only 1 track
      */
     if ((midi_type == 0) && (no_tracks > 1)) {
-        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_INVALID, "(expected 1 track for type 0 midi file, found more)", 0);
+        _WM_GLOBAL_ERROR(WM_ERR_INVALID, "(expected 1 track for type 0 midi file, found more)", 0);
         return (NULL);
     }
 
@@ -137,7 +137,7 @@ _WM_ParseNewMidi(const uint8_t *midi_data, uint32_t midi_size) {
     divisions |= *midi_data++;
     midi_size -= 2;
     if (divisions & 0x00008000) {
-        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_INVALID, NULL, 0);
+        _WM_GLOBAL_ERROR(WM_ERR_INVALID, NULL, 0);
         return (NULL);
     }
 
@@ -155,11 +155,11 @@ _WM_ParseNewMidi(const uint8_t *midi_data, uint32_t midi_size) {
     smallest_delta = 0x7fffffff;
     for (i = 0; i < no_tracks; i++) {
         if (midi_size < 8) {
-            _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_CORUPT, "(too short)", 0);
+            _WM_GLOBAL_ERROR(WM_ERR_CORUPT, "(too short)", 0);
             goto _end;
         }
         if (memcmp(midi_data, "MTrk", 4) != 0) {
-            _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_CORUPT, "(missing track header)", 0);
+            _WM_GLOBAL_ERROR(WM_ERR_CORUPT, "(missing track header)", 0);
             goto _end;
         }
         midi_data += 4;
@@ -172,11 +172,11 @@ _WM_ParseNewMidi(const uint8_t *midi_data, uint32_t midi_size) {
         tmp_val |= *midi_data++;
         midi_size -= 4;
         if (midi_size < tmp_val) {
-            _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_CORUPT, "(too short)", 0);
+            _WM_GLOBAL_ERROR(WM_ERR_CORUPT, "(too short)", 0);
             goto _end;
         }
         if (tmp_val < 3) {
-            _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_CORUPT, "(bad track size)", 0);
+            _WM_GLOBAL_ERROR(WM_ERR_CORUPT, "(bad track size)", 0);
             goto _end;
         }
         if ((midi_data[tmp_val - 3] != 0xFF) ||
@@ -195,7 +195,7 @@ _WM_ParseNewMidi(const uint8_t *midi_data, uint32_t midi_size) {
                     (midi_data[tmp_val - 4] != 0xFF) ||
                     (midi_data[tmp_val - 3] != 0x2F) ||
                     (midi_data[tmp_val - 2] != 0x00)) {
-                    _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_CORUPT, "(missing EOT)", 0);
+                    _WM_GLOBAL_ERROR(WM_ERR_CORUPT, "(missing EOT)", 0);
                     goto _end;
                 }
             }
@@ -233,7 +233,7 @@ _WM_ParseNewMidi(const uint8_t *midi_data, uint32_t midi_size) {
     if (smallest_delta >= 0x7fffffff) {
         /* DEBUG */
         /* fprintf(stderr,"CRAZY SMALLEST DELTA %u\n", smallest_delta); */
-        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_CORUPT, NULL, 0);
+        _WM_GLOBAL_ERROR(WM_ERR_CORUPT, NULL, 0);
         goto _end;
     }
 
@@ -241,7 +241,7 @@ _WM_ParseNewMidi(const uint8_t *midi_data, uint32_t midi_size) {
         /* DEBUG */
         /* fprintf(stderr,"INTEGER OVERFLOW (samples_per_delta: %f, smallest_delta: %u)\n", */
         /*        samples_per_delta_f, smallest_delta); */
-        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_CORUPT, NULL, 0);
+        _WM_GLOBAL_ERROR(WM_ERR_CORUPT, NULL, 0);
         goto _end;
     }
 
@@ -312,7 +312,7 @@ _WM_ParseNewMidi(const uint8_t *midi_data, uint32_t midi_size) {
                         } while (*tracks[i] > 0x7f);
                     }
                     if (!track_size[i]) {
-                        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_CORUPT, "(too short)", 0);
+                        _WM_GLOBAL_ERROR(WM_ERR_CORUPT, "(too short)", 0);
                         goto _end;
                     }
                     track_delta[i] = (track_delta[i] << 7) + (*tracks[i] & 0x7F);
@@ -329,7 +329,7 @@ _WM_ParseNewMidi(const uint8_t *midi_data, uint32_t midi_size) {
                 /* DEBUG */
                 /* fprintf(stderr,"INTEGER OVERFLOW (samples_per_delta: %f, smallest_delta: %u)\n", */
                 /*        samples_per_delta_f, smallest_delta); */
-                _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_CORUPT, NULL, 0);
+                _WM_GLOBAL_ERROR(WM_ERR_CORUPT, NULL, 0);
                 goto _end;
             }
             subtract_delta = smallest_delta;
@@ -388,7 +388,7 @@ _WM_ParseNewMidi(const uint8_t *midi_data, uint32_t midi_size) {
                 }
                 if (!track_size[i]) {
                     if (midi_type != 0) {
-                        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_CORUPT, "(too short)", 0);
+                        _WM_GLOBAL_ERROR(WM_ERR_CORUPT, "(too short)", 0);
                         goto _end;
                     } else {
                         track_end[i] = 1;
@@ -403,7 +403,7 @@ _WM_ParseNewMidi(const uint8_t *midi_data, uint32_t midi_size) {
                     /* DEBUG */
                     /* fprintf(stderr,"INTEGER OVERFLOW (samples_per_delta: %f, smallest_delta: %u)\n", */
                     /*        samples_per_delta_f, smallest_delta); */
-                    _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_CORUPT, NULL, 0);
+                    _WM_GLOBAL_ERROR(WM_ERR_CORUPT, NULL, 0);
                     goto _end;
                 }
                 sample_count_f = (((float) track_delta[i] * samples_per_delta_f)
@@ -422,7 +422,7 @@ _WM_ParseNewMidi(const uint8_t *midi_data, uint32_t midi_size) {
     if ((mdi->reverb = _WM_init_reverb(_WM_SampleRate, _WM_reverb_room_width,
             _WM_reverb_room_length, _WM_reverb_listen_posx, _WM_reverb_listen_posy))
           == NULL) {
-        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_MEM, NULL, 0);
+        _WM_GLOBAL_ERROR(WM_ERR_MEM, NULL, 0);
         goto _end;
     }
 
@@ -476,7 +476,7 @@ _WM_Event2Midi(struct _mdi *mdi, uint8_t **out, uint32_t *outsize) {
     uint32_t track_count = 0;
 
     if (!mdi->event_count) {
-        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_CONVERT, "(No events to convert)", 0);
+        _WM_GLOBAL_ERROR(WM_ERR_CONVERT, "(No events to convert)", 0);
         return -1;
     }
 

--- a/src/f_mus.c
+++ b/src/f_mus.c
@@ -72,12 +72,12 @@ _WM_ParseNewMus(const uint8_t *mus_data, uint32_t mus_size) {
     uint16_t pitchbend_tmp = 0;
 
     if (mus_size < 18) {
-        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_CORUPT, "file too short", 0);
+        _WM_GLOBAL_ERROR(WM_ERR_CORUPT, "file too short", 0);
         return NULL;
     }
 
     if (memcmp(mus_data, mus_hdr, 4)) {
-        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_NOT_MUS, NULL, 0);
+        _WM_GLOBAL_ERROR(WM_ERR_NOT_MUS, NULL, 0);
         return NULL;
     }
 
@@ -101,7 +101,7 @@ _WM_ParseNewMus(const uint8_t *mus_data, uint32_t mus_size) {
 
     /* Check that we have enough data to check the rest */
     if (mus_size < (mus_data_ofs + (mus_no_instr << 1) + mus_song_len)) {
-        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_CORUPT, "file too short", 0);
+        _WM_GLOBAL_ERROR(WM_ERR_CORUPT, "file too short", 0);
         return NULL;
     }
 
@@ -356,7 +356,7 @@ _WM_ParseNewMus(const uint8_t *mus_data, uint32_t mus_size) {
 _mus_end_of_song:
     /* Finalise mdi structure */
     if ((mus_mdi->reverb = _WM_init_reverb(_WM_SampleRate, _WM_reverb_room_width, _WM_reverb_room_length, _WM_reverb_listen_posx, _WM_reverb_listen_posy)) == NULL) {
-        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_MEM, NULL, 0);
+        _WM_GLOBAL_ERROR(WM_ERR_MEM, NULL, 0);
         goto _mus_end;
     }
     _WM_midi_setup_endoftrack(mus_mdi);

--- a/src/f_xmidi.c
+++ b/src/f_xmidi.c
@@ -64,7 +64,7 @@ struct _mdi *_WM_ParseNewXmi(const uint8_t *xmi_data, uint32_t xmi_size) {
 
 
     if (memcmp(xmi_data,"FORM",4)) {
-        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_NOT_XMI, NULL, 0);
+        _WM_GLOBAL_ERROR(WM_ERR_NOT_XMI, NULL, 0);
         return NULL;
     }
 
@@ -79,7 +79,7 @@ struct _mdi *_WM_ParseNewXmi(const uint8_t *xmi_data, uint32_t xmi_size) {
     xmi_size -= 4;
 
     if (memcmp(xmi_data,"XDIRINFO",8)) {
-        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_NOT_XMI, NULL, 0);
+        _WM_GLOBAL_ERROR(WM_ERR_NOT_XMI, NULL, 0);
         return NULL;
     }
     xmi_data += 8;
@@ -95,7 +95,7 @@ struct _mdi *_WM_ParseNewXmi(const uint8_t *xmi_data, uint32_t xmi_size) {
     /* number of forms contained after this point */
     xmi_formcnt = *xmi_data++;
     if (xmi_formcnt == 0) {
-        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_NOT_XMI, NULL, 0);
+        _WM_GLOBAL_ERROR(WM_ERR_NOT_XMI, NULL, 0);
         return NULL;
     }
     xmi_size--;
@@ -110,7 +110,7 @@ struct _mdi *_WM_ParseNewXmi(const uint8_t *xmi_data, uint32_t xmi_size) {
 
     /* FIXME: Check: may not even need to process CAT information */
     if (memcmp(xmi_data,"CAT ",4)) {
-        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_NOT_XMI, NULL, 0);
+        _WM_GLOBAL_ERROR(WM_ERR_NOT_XMI, NULL, 0);
         return NULL;
     }
     xmi_data += 4;
@@ -125,7 +125,7 @@ struct _mdi *_WM_ParseNewXmi(const uint8_t *xmi_data, uint32_t xmi_size) {
     WMIDI_UNUSED(xmi_catlen);
 
     if (memcmp(xmi_data,"XMID",4)) {
-        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_NOT_XMI, NULL, 0);
+        _WM_GLOBAL_ERROR(WM_ERR_NOT_XMI, NULL, 0);
         return NULL;
     }
     xmi_data += 4;
@@ -142,7 +142,7 @@ struct _mdi *_WM_ParseNewXmi(const uint8_t *xmi_data, uint32_t xmi_size) {
 
     for (i = 0; i < xmi_formcnt; i++) {
         if (memcmp(xmi_data,"FORM",4)) {
-            _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_NOT_XMI, NULL, 0);
+            _WM_GLOBAL_ERROR(WM_ERR_NOT_XMI, NULL, 0);
             goto _xmi_end;
         }
         xmi_data += 4;
@@ -155,7 +155,7 @@ struct _mdi *_WM_ParseNewXmi(const uint8_t *xmi_data, uint32_t xmi_size) {
         xmi_size -= 4;
 
         if (memcmp(xmi_data,"XMID",4)) {
-            _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_NOT_XMI, NULL, 0);
+            _WM_GLOBAL_ERROR(WM_ERR_NOT_XMI, NULL, 0);
             goto _xmi_end;
         }
         xmi_data += 4;
@@ -232,7 +232,7 @@ struct _mdi *_WM_ParseNewXmi(const uint8_t *xmi_data, uint32_t xmi_size) {
                                 /* DEBUG */
                                 /* fprintf(stderr,"INTEGER OVERFLOW (samples_per_delta: %f, smallest_delta: %u)\n", */
                                 /*        xmi_samples_per_delta_f, xmi_tmpdata); */
-                                _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_CORUPT, NULL, 0);
+                                _WM_GLOBAL_ERROR(WM_ERR_CORUPT, NULL, 0);
                                 goto _xmi_end;
                             }
 
@@ -321,7 +321,7 @@ struct _mdi *_WM_ParseNewXmi(const uint8_t *xmi_data, uint32_t xmi_size) {
                 } while (xmi_evntlen);
 
             } else {
-                _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_NOT_XMI, NULL, 0);
+                _WM_GLOBAL_ERROR(WM_ERR_NOT_XMI, NULL, 0);
                 goto _xmi_end;
             }
 
@@ -330,7 +330,7 @@ struct _mdi *_WM_ParseNewXmi(const uint8_t *xmi_data, uint32_t xmi_size) {
 
     /* Finalise mdi structure */
     if ((xmi_mdi->reverb = _WM_init_reverb(_WM_SampleRate, _WM_reverb_room_width, _WM_reverb_room_length, _WM_reverb_listen_posx, _WM_reverb_listen_posy)) == NULL) {
-        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_MEM, NULL, 0);
+        _WM_GLOBAL_ERROR(WM_ERR_MEM, NULL, 0);
         goto _xmi_end;
     }
     xmi_mdi->extra_info.current_sample = 0;

--- a/src/file_io.c
+++ b/src/file_io.c
@@ -151,7 +151,7 @@ void *_WM_BufferFileImpl(const char *filename, uint32_t *size) {
         if (home) {
             buffer_file = (char *) malloc(strlen(filename) + strlen(home) + 1);
             if (buffer_file == NULL) {
-                _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_MEM, NULL, errno);
+                _WM_GLOBAL_ERROR(WM_ERR_MEM, NULL, errno);
                 return NULL;
             }
             strcpy(buffer_file, home);
@@ -162,7 +162,7 @@ void *_WM_BufferFileImpl(const char *filename, uint32_t *size) {
         if (cwdresult != NULL)
             buffer_file = (char *) malloc(strlen(filename) + strlen(buffer_dir) + 2);
         if (buffer_file == NULL || cwdresult == NULL) {
-            _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_MEM, NULL, errno);
+            _WM_GLOBAL_ERROR(WM_ERR_MEM, NULL, errno);
             return NULL;
         }
         strcpy(buffer_file, buffer_dir);
@@ -181,7 +181,7 @@ void *_WM_BufferFileImpl(const char *filename, uint32_t *size) {
     if (buffer_file == NULL) {
         buffer_file = (char *) malloc(strlen(filename) + 1);
         if (buffer_file == NULL) {
-            _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_MEM, NULL, errno);
+            _WM_GLOBAL_ERROR(WM_ERR_MEM, NULL, errno);
             return NULL;
         }
         strcpy(buffer_file, filename);
@@ -189,14 +189,14 @@ void *_WM_BufferFileImpl(const char *filename, uint32_t *size) {
 
 #ifdef __DJGPP__
     if (findfirst(buffer_file, &f, FA_ARCH | FA_RDONLY) != 0) {
-        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_STAT, filename, errno);
+        _WM_GLOBAL_ERROR(WM_ERR_STAT, filename, errno);
         free(buffer_file);
         return NULL;
     }
     *size = f.ff_fsize;
 #elif defined(_WIN32)
     if ((h = FindFirstFileA(buffer_file, &wfd)) == INVALID_HANDLE_VALUE) {
-        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_STAT, filename, ENOENT);
+        _WM_GLOBAL_ERROR(WM_ERR_STAT, filename, ENOENT);
         free(buffer_file);
         return NULL;
     }
@@ -206,7 +206,7 @@ void *_WM_BufferFileImpl(const char *filename, uint32_t *size) {
     else *size = wfd.nFileSizeLow;
 #elif defined(__OS2__) || defined(__EMX__)
     if (DosFindFirst(buffer_file, &h, FILE_NORMAL, &fb, sizeof(fb), &cnt, FIL_STANDARD) != NO_ERROR) {
-        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_STAT, filename, ENOENT);
+        _WM_GLOBAL_ERROR(WM_ERR_STAT, filename, ENOENT);
         free(buffer_file);
         return NULL;
     }
@@ -214,14 +214,14 @@ void *_WM_BufferFileImpl(const char *filename, uint32_t *size) {
     *size = fb.cbFile;
 #elif defined(WILDMIDI_AMIGA)
     if ((filsize = AMIGA_filesize(buffer_file)) < 0) {
-        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_STAT, filename, ENOENT /* do better!! */);
+        _WM_GLOBAL_ERROR(WM_ERR_STAT, filename, ENOENT /* do better!! */);
         free(buffer_file);
         return NULL;
     }
     *size = filsize;
 #elif defined(_3DS) || defined(GEKKO) || defined(__vita__) || defined(__SWITCH__) || defined(__riscos__) || defined(__unix) || defined(__unix__) || defined(__APPLE__)
     if (stat(buffer_file, &buffer_stat)) {
-        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_STAT, filename, errno);
+        _WM_GLOBAL_ERROR(WM_ERR_STAT, filename, errno);
         free(buffer_file);
         return NULL;
     }
@@ -233,20 +233,20 @@ void *_WM_BufferFileImpl(const char *filename, uint32_t *size) {
     /* Standard C fallback */
     file = fopen(buffer_file, "rb");
     if (file == NULL) {
-        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_STAT, filename, errno);
+        _WM_GLOBAL_ERROR(WM_ERR_STAT, filename, errno);
         free(buffer_file);
         return NULL;
     }
     /* Technically undefined behaviour, but any sane implementation will allow this without issue. */
     if (fseek(file, 0, SEEK_END) != 0) {
-        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_READ, filename, EIO);
+        _WM_GLOBAL_ERROR(WM_ERR_READ, filename, EIO);
         free(buffer_file);
         fclose(file);
         return NULL;
     }
     pos = ftell(file);
     if (pos < 0) {
-        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_READ, filename, EIO);
+        _WM_GLOBAL_ERROR(WM_ERR_READ, filename, EIO);
         free(buffer_file);
         fclose(file);
         return NULL;
@@ -257,7 +257,7 @@ void *_WM_BufferFileImpl(const char *filename, uint32_t *size) {
 
     if (__builtin_expect((*size > WM_MAXFILESIZE), 0)) {
         /* don't bother loading suspiciously long files */
-        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_LONGFIL, filename, 0);
+        _WM_GLOBAL_ERROR(WM_ERR_LONGFIL, filename, 0);
         free(buffer_file);
         return NULL;
     }
@@ -265,20 +265,20 @@ void *_WM_BufferFileImpl(const char *filename, uint32_t *size) {
     /* +1 needed for parsing text files without a newline at the end */
     data = (uint8_t *) malloc(*size + 1);
     if (data == NULL) {
-        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_MEM, NULL, errno);
+        _WM_GLOBAL_ERROR(WM_ERR_MEM, NULL, errno);
         free(buffer_file);
         return NULL;
     }
 
 #if defined(WILDMIDI_AMIGA)
     if (!(buffer_fd = AMIGA_open(buffer_file))) {
-        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_OPEN, filename, ENOENT /* do better!! */);
+        _WM_GLOBAL_ERROR(WM_ERR_OPEN, filename, ENOENT /* do better!! */);
         free(buffer_file);
         free(data);
         return NULL;
     }
     if (AMIGA_read(buffer_fd, data, filsize) != filsize) {
-        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_READ, filename, EIO /* do better!! */);
+        _WM_GLOBAL_ERROR(WM_ERR_READ, filename, EIO /* do better!! */);
         free(buffer_file);
         free(data);
         AMIGA_close(buffer_fd);
@@ -287,13 +287,13 @@ void *_WM_BufferFileImpl(const char *filename, uint32_t *size) {
     AMIGA_close(buffer_fd);
 #elif defined(__DJGPP__) || defined(_WIN32) || defined(__OS2__) || defined(__EMX__) || defined(_3DS) || defined(GEKKO) || defined(__vita__) || defined(__SWITCH__) || defined(__riscos__) || defined(__unix) || defined(__unix__) || defined(__APPLE__)
     if ((buffer_fd = open(buffer_file,(O_RDONLY | O_BINARY))) == -1) {
-        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_OPEN, filename, errno);
+        _WM_GLOBAL_ERROR(WM_ERR_OPEN, filename, errno);
         free(buffer_file);
         free(data);
         return NULL;
     }
     if (read(buffer_fd, data, *size) != (long) *size) {
-        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_READ, filename, errno);
+        _WM_GLOBAL_ERROR(WM_ERR_READ, filename, errno);
         free(buffer_file);
         free(data);
         close(buffer_fd);
@@ -302,7 +302,7 @@ void *_WM_BufferFileImpl(const char *filename, uint32_t *size) {
     close(buffer_fd);
 #else
     if (fread(data, 1, (size_t)*size, file) != (size_t)*size) {
-        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_READ, filename, EIO);
+        _WM_GLOBAL_ERROR(WM_ERR_READ, filename, EIO);
         free(buffer_file);
         fclose(file);
         free(data);

--- a/src/gus_pat.c
+++ b/src/gus_pat.c
@@ -63,7 +63,7 @@ static int convert_8s(uint8_t *data, struct _sample *gus_sample) {
     uint8_t *read_end = data + gus_sample->data_length;
     int16_t *write_data = NULL;
 
-    SAMPLE_CONVERT_DEBUG(__FUNCTION__);
+    SAMPLE_CONVERT_DEBUG(_WM_FUNCTION);
     gus_sample->data = (int16_t *) calloc((gus_sample->data_length + 2), sizeof(int16_t));
     if (__builtin_expect((gus_sample->data != NULL), 1)) {
         write_data = gus_sample->data;
@@ -73,7 +73,7 @@ static int convert_8s(uint8_t *data, struct _sample *gus_sample) {
         return 0;
     }
 
-    _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_MEM, NULL, errno);
+    _WM_GLOBAL_ERROR(WM_ERR_MEM, NULL, errno);
 
     return -1;
 }
@@ -90,7 +90,7 @@ static int convert_8sp(uint8_t *data, struct _sample *gus_sample) {
     int16_t *write_data_a = NULL;
     int16_t *write_data_b = NULL;
 
-    SAMPLE_CONVERT_DEBUG(__FUNCTION__);
+    SAMPLE_CONVERT_DEBUG(_WM_FUNCTION);
     gus_sample->data = (int16_t *) calloc((new_length + 2), sizeof(int16_t));
     if (__builtin_expect((gus_sample->data != NULL), 1)) {
         write_data = gus_sample->data;
@@ -124,7 +124,7 @@ static int convert_8sp(uint8_t *data, struct _sample *gus_sample) {
         return 0;
     }
 
-    _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_MEM, NULL, errno);
+    _WM_GLOBAL_ERROR(WM_ERR_MEM, NULL, errno);
     return -1;
 }
 
@@ -135,7 +135,7 @@ static int convert_8sr(uint8_t *data, struct _sample *gus_sample) {
     int16_t *write_data = NULL;
     uint32_t tmp_loop = 0;
 
-    SAMPLE_CONVERT_DEBUG(__FUNCTION__);
+    SAMPLE_CONVERT_DEBUG(_WM_FUNCTION);
     gus_sample->data = (int16_t *) calloc((gus_sample->data_length + 2), sizeof(int16_t));
     if (__builtin_expect((gus_sample->data != NULL), 1)) {
         write_data = gus_sample->data + gus_sample->data_length - 1;
@@ -150,7 +150,7 @@ static int convert_8sr(uint8_t *data, struct _sample *gus_sample) {
         gus_sample->modes ^= SAMPLE_REVERSE;
         return 0;
     }
-    _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_MEM, NULL, errno);
+    _WM_GLOBAL_ERROR(WM_ERR_MEM, NULL, errno);
     return -1;
 }
 
@@ -166,7 +166,7 @@ static int convert_8srp(uint8_t *data, struct _sample *gus_sample) {
     int16_t *write_data_a = NULL;
     int16_t *write_data_b = NULL;
 
-    SAMPLE_CONVERT_DEBUG(__FUNCTION__);
+    SAMPLE_CONVERT_DEBUG(_WM_FUNCTION);
     gus_sample->data = (int16_t *) calloc((new_length + 2), sizeof(int16_t));
     if (__builtin_expect((gus_sample->data != NULL), 1)) {
         write_data = gus_sample->data;
@@ -201,7 +201,7 @@ static int convert_8srp(uint8_t *data, struct _sample *gus_sample) {
         return 0;
     }
 
-    _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_MEM, NULL, errno);
+    _WM_GLOBAL_ERROR(WM_ERR_MEM, NULL, errno);
     return -1;
 }
 
@@ -211,7 +211,7 @@ static int convert_8u(uint8_t *data, struct _sample *gus_sample) {
     uint8_t *read_end = data + gus_sample->data_length;
     int16_t *write_data = NULL;
 
-    SAMPLE_CONVERT_DEBUG(__FUNCTION__);
+    SAMPLE_CONVERT_DEBUG(_WM_FUNCTION);
     gus_sample->data = (int16_t *) calloc((gus_sample->data_length + 2), sizeof(int16_t));
     if (__builtin_expect((gus_sample->data != NULL), 1)) {
         write_data = gus_sample->data;
@@ -221,7 +221,7 @@ static int convert_8u(uint8_t *data, struct _sample *gus_sample) {
         gus_sample->modes ^= SAMPLE_UNSIGNED;
         return 0;
     }
-    _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_MEM, NULL, errno);
+    _WM_GLOBAL_ERROR(WM_ERR_MEM, NULL, errno);
     return -1;
 }
 
@@ -237,7 +237,7 @@ static int convert_8up(uint8_t *data, struct _sample *gus_sample) {
     int16_t *write_data_a = NULL;
     int16_t *write_data_b = NULL;
 
-    SAMPLE_CONVERT_DEBUG(__FUNCTION__);
+    SAMPLE_CONVERT_DEBUG(_WM_FUNCTION);
     gus_sample->data = (int16_t *) calloc((new_length + 2), sizeof(int16_t));
     if (__builtin_expect((gus_sample->data != NULL), 1)) {
         write_data = gus_sample->data;
@@ -272,7 +272,7 @@ static int convert_8up(uint8_t *data, struct _sample *gus_sample) {
         return 0;
     }
 
-    _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_MEM, NULL, errno);
+    _WM_GLOBAL_ERROR(WM_ERR_MEM, NULL, errno);
     return -1;
 }
 
@@ -283,7 +283,7 @@ static int convert_8ur(uint8_t *data, struct _sample *gus_sample) {
     int16_t *write_data = NULL;
     uint32_t tmp_loop = 0;
 
-    SAMPLE_CONVERT_DEBUG(__FUNCTION__);
+    SAMPLE_CONVERT_DEBUG(_WM_FUNCTION);
     gus_sample->data = (int16_t *) calloc((gus_sample->data_length + 2), sizeof(int16_t));
     if (__builtin_expect((gus_sample->data != NULL), 1)) {
         write_data = gus_sample->data + gus_sample->data_length - 1;
@@ -298,7 +298,7 @@ static int convert_8ur(uint8_t *data, struct _sample *gus_sample) {
         gus_sample->modes ^= SAMPLE_REVERSE | SAMPLE_UNSIGNED;
         return 0;
     }
-    _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_MEM, NULL, errno);
+    _WM_GLOBAL_ERROR(WM_ERR_MEM, NULL, errno);
     return -1;
 }
 
@@ -314,7 +314,7 @@ static int convert_8urp(uint8_t *data, struct _sample *gus_sample) {
     int16_t *write_data_a = NULL;
     int16_t *write_data_b = NULL;
 
-    SAMPLE_CONVERT_DEBUG(__FUNCTION__);
+    SAMPLE_CONVERT_DEBUG(_WM_FUNCTION);
     gus_sample->data = (int16_t *) calloc((new_length + 2), sizeof(int16_t));
     if (__builtin_expect((gus_sample->data != NULL), 1)) {
         write_data = gus_sample->data;
@@ -348,7 +348,7 @@ static int convert_8urp(uint8_t *data, struct _sample *gus_sample) {
         return 0;
     }
 
-    _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_MEM, NULL, errno);
+    _WM_GLOBAL_ERROR(WM_ERR_MEM, NULL, errno);
     return -1;
 }
 
@@ -358,7 +358,7 @@ static int convert_16s(uint8_t *data, struct _sample *gus_sample) {
     uint8_t *read_end = data + gus_sample->data_length;
     int16_t *write_data = NULL;
 
-    SAMPLE_CONVERT_DEBUG(__FUNCTION__);
+    SAMPLE_CONVERT_DEBUG(_WM_FUNCTION);
     gus_sample->data = (int16_t *) calloc(((gus_sample->data_length >> 1) + 2), sizeof(int16_t));
     if (__builtin_expect((gus_sample->data != NULL), 1)) {
         write_data = gus_sample->data;
@@ -372,7 +372,7 @@ static int convert_16s(uint8_t *data, struct _sample *gus_sample) {
         gus_sample->data_length >>= 1;
         return 0;
     }
-    _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_MEM, NULL, errno);
+    _WM_GLOBAL_ERROR(WM_ERR_MEM, NULL, errno);
     return -1;
 }
 
@@ -388,7 +388,7 @@ static int convert_16sp(uint8_t *data, struct _sample *gus_sample) {
     int16_t *write_data_a = NULL;
     int16_t *write_data_b = NULL;
 
-    SAMPLE_CONVERT_DEBUG(__FUNCTION__);
+    SAMPLE_CONVERT_DEBUG(_WM_FUNCTION);
     gus_sample->data = (int16_t *) calloc(((new_length >> 1) + 2), sizeof(int16_t));
     if (__builtin_expect((gus_sample->data != NULL), 1)) {
         write_data = gus_sample->data;
@@ -432,7 +432,7 @@ static int convert_16sp(uint8_t *data, struct _sample *gus_sample) {
         return 0;
     }
 
-    _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_MEM, NULL, errno);
+    _WM_GLOBAL_ERROR(WM_ERR_MEM, NULL, errno);
     return -1;
 }
 
@@ -443,7 +443,7 @@ static int convert_16sr(uint8_t *data, struct _sample *gus_sample) {
     int16_t *write_data = NULL;
     uint32_t tmp_loop = 0;
 
-    SAMPLE_CONVERT_DEBUG(__FUNCTION__);
+    SAMPLE_CONVERT_DEBUG(_WM_FUNCTION);
     gus_sample->data = (int16_t *) calloc(((gus_sample->data_length >> 1) + 2), sizeof(int16_t));
     if (__builtin_expect((gus_sample->data != NULL), 1)) {
         write_data = gus_sample->data + (gus_sample->data_length >> 1) - 1;
@@ -462,7 +462,7 @@ static int convert_16sr(uint8_t *data, struct _sample *gus_sample) {
         gus_sample->modes ^= SAMPLE_REVERSE;
         return 0;
     }
-    _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_MEM, NULL, errno);
+    _WM_GLOBAL_ERROR(WM_ERR_MEM, NULL, errno);
     return -1;
 }
 
@@ -478,7 +478,7 @@ static int convert_16srp(uint8_t *data, struct _sample *gus_sample) {
     int16_t *write_data_a = NULL;
     int16_t *write_data_b = NULL;
 
-    SAMPLE_CONVERT_DEBUG(__FUNCTION__);
+    SAMPLE_CONVERT_DEBUG(_WM_FUNCTION);
     gus_sample->data = (int16_t *) calloc(((new_length >> 1) + 2), sizeof(int16_t));
     if (__builtin_expect((gus_sample->data != NULL), 1)) {
         write_data = gus_sample->data;
@@ -517,7 +517,7 @@ static int convert_16srp(uint8_t *data, struct _sample *gus_sample) {
         return 0;
     }
 
-    _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_MEM, NULL, errno);
+    _WM_GLOBAL_ERROR(WM_ERR_MEM, NULL, errno);
     return -1;
 }
 
@@ -527,7 +527,7 @@ static int convert_16u(uint8_t *data, struct _sample *gus_sample) {
     uint8_t *read_end = data + gus_sample->data_length;
     int16_t *write_data = NULL;
 
-    SAMPLE_CONVERT_DEBUG(__FUNCTION__);
+    SAMPLE_CONVERT_DEBUG(_WM_FUNCTION);
     gus_sample->data = (int16_t *) calloc(((gus_sample->data_length >> 1) + 2), sizeof(int16_t));
     if (__builtin_expect((gus_sample->data != NULL), 1)) {
         write_data = gus_sample->data;
@@ -541,7 +541,7 @@ static int convert_16u(uint8_t *data, struct _sample *gus_sample) {
         gus_sample->modes ^= SAMPLE_UNSIGNED;
         return 0;
     }
-    _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_MEM, NULL, errno);
+    _WM_GLOBAL_ERROR(WM_ERR_MEM, NULL, errno);
     return -1;
 }
 
@@ -557,7 +557,7 @@ static int convert_16up(uint8_t *data, struct _sample *gus_sample) {
     int16_t *write_data_a = NULL;
     int16_t *write_data_b = NULL;
 
-    SAMPLE_CONVERT_DEBUG(__FUNCTION__);
+    SAMPLE_CONVERT_DEBUG(_WM_FUNCTION);
     gus_sample->data = (int16_t *) calloc(((new_length >> 1) + 2), sizeof(int16_t));
     if (__builtin_expect((gus_sample->data != NULL), 1)) {
         write_data = gus_sample->data;
@@ -601,7 +601,7 @@ static int convert_16up(uint8_t *data, struct _sample *gus_sample) {
         return 0;
     }
 
-    _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_MEM, NULL, errno);
+    _WM_GLOBAL_ERROR(WM_ERR_MEM, NULL, errno);
     return -1;
 }
 
@@ -612,7 +612,7 @@ static int convert_16ur(uint8_t *data, struct _sample *gus_sample) {
     int16_t *write_data = NULL;
     uint32_t tmp_loop = 0;
 
-    SAMPLE_CONVERT_DEBUG(__FUNCTION__);
+    SAMPLE_CONVERT_DEBUG(_WM_FUNCTION);
     gus_sample->data = (int16_t *) calloc(((gus_sample->data_length >> 1) + 2), sizeof(int16_t));
     if (__builtin_expect((gus_sample->data != NULL), 1)) {
         write_data = gus_sample->data + (gus_sample->data_length >> 1) - 1;
@@ -631,7 +631,7 @@ static int convert_16ur(uint8_t *data, struct _sample *gus_sample) {
         gus_sample->modes ^= SAMPLE_REVERSE | SAMPLE_UNSIGNED;
         return 0;
     }
-    _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_MEM, NULL, errno);
+    _WM_GLOBAL_ERROR(WM_ERR_MEM, NULL, errno);
     return -1;
 }
 
@@ -647,7 +647,7 @@ static int convert_16urp(uint8_t *data, struct _sample *gus_sample) {
     int16_t *write_data_a = NULL;
     int16_t *write_data_b = NULL;
 
-    SAMPLE_CONVERT_DEBUG(__FUNCTION__);
+    SAMPLE_CONVERT_DEBUG(_WM_FUNCTION);
     gus_sample->data = (int16_t *) calloc(((new_length >> 1) + 2), sizeof(int16_t));
     if (__builtin_expect((gus_sample->data != NULL), 1)) {
         write_data = gus_sample->data;
@@ -686,7 +686,7 @@ static int convert_16urp(uint8_t *data, struct _sample *gus_sample) {
         return 0;
     }
 
-    _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_MEM, NULL, errno);
+    _WM_GLOBAL_ERROR(WM_ERR_MEM, NULL, errno);
     return -1;
 }
 
@@ -724,29 +724,29 @@ struct _sample * _WM_load_gus_pat(const char *filename, int fix_release) {
 
     WMIDI_UNUSED(fix_release);
 
-    SAMPLE_CONVERT_DEBUG(__FUNCTION__); SAMPLE_CONVERT_DEBUG(filename);
+    SAMPLE_CONVERT_DEBUG(_WM_FUNCTION); SAMPLE_CONVERT_DEBUG(filename);
 
     if ((gus_patch = (uint8_t *) _WM_BufferFile(filename, &gus_size)) == NULL) {
         return NULL;
     }
     if (gus_size < 239) {
-        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_CORUPT, filename, 0);
+        _WM_GLOBAL_ERROR(WM_ERR_CORUPT, filename, 0);
         _WM_FreeBufferFile(gus_patch);
         return NULL;
     }
     if (memcmp(gus_patch, "GF1PATCH110\0ID#000002", 22)
             && memcmp(gus_patch, "GF1PATCH100\0ID#000002", 22)) {
-        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_INVALID, filename, 0);
+        _WM_GLOBAL_ERROR(WM_ERR_INVALID, filename, 0);
         _WM_FreeBufferFile(gus_patch);
         return NULL;
     }
     if (gus_patch[82] > 1) {
-        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_INVALID, filename, 0);
+        _WM_GLOBAL_ERROR(WM_ERR_INVALID, filename, 0);
         _WM_FreeBufferFile(gus_patch);
         return NULL;
     }
     if (gus_patch[151] > 1) {
-        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_INVALID, filename, 0);
+        _WM_GLOBAL_ERROR(WM_ERR_INVALID, filename, 0);
         _WM_FreeBufferFile(gus_patch);
         return NULL;
     }
@@ -766,7 +766,7 @@ struct _sample * _WM_load_gus_pat(const char *filename, int fix_release) {
             gus_sample = gus_sample->next;
         }
         if (gus_sample == NULL) {
-            _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_MEM, NULL, 0);
+            _WM_GLOBAL_ERROR(WM_ERR_MEM, NULL, 0);
             _WM_FreeBufferFile(gus_patch);
             return NULL;
         }
@@ -852,7 +852,7 @@ struct _sample * _WM_load_gus_pat(const char *filename, int fix_release) {
                 GUSPAT_INT_DEBUG("Envelope Rate",gus_sample->env_rate[i]); GUSPAT_INT_DEBUG("GUSPAT Rate",env_rate);
                 if (gus_sample->env_rate[i] == 0) {
                     _WM_DEBUG_MSG("%s: Warning: found invalid envelope(%u) rate setting in %s. Using %f instead.",
-                                  __FUNCTION__, i, filename, env_time_table[63]);
+                                  _WM_FUNCTION, i, filename, env_time_table[63]);
                     gus_sample->env_rate[i] = (int32_t) (4194303.0f
                             / ((float) _WM_SampleRate * env_time_table[63]));
                     GUSPAT_FLOAT_DEBUG("Envelope Time",env_time_table[63]);

--- a/src/internal_midi.c
+++ b/src/internal_midi.c
@@ -486,7 +486,7 @@ void _WM_AdjustNoteVolumes(struct _mdi *mdi, uint8_t ch, struct _note *nte) {
 #define VOL_DIVISOR 4.0
     volume_adj = ((double)_WM_MasterVolume / 1024.0) / VOL_DIVISOR;
 
-    MIDI_EVENT_DEBUG(__FUNCTION__,ch, 0);
+    MIDI_EVENT_DEBUG(_WM_FUNCTION,ch, 0);
 
     if (pan_ofs > 127) pan_ofs = 127;
     premix_dBm_left = dBm_pan_volume[(127-pan_ofs)];
@@ -555,7 +555,7 @@ static void _WM_CheckEventMemoryPool(struct _mdi *mdi) {
 
 void _WM_do_note_off_extra(struct _note *nte) {
 
-    MIDI_EVENT_DEBUG(__FUNCTION__,0, 0);
+    MIDI_EVENT_DEBUG(_WM_FUNCTION,0, 0);
     nte->is_off = 0;
 
     if (!(nte->modes & SAMPLE_ENVELOPE)) {
@@ -609,7 +609,7 @@ void _WM_do_note_off(struct _mdi *mdi, struct _event_data *data) {
     struct _note *nte;
     uint8_t ch = data->channel;
 
-    MIDI_EVENT_DEBUG(__FUNCTION__,ch, data->data.value);
+    MIDI_EVENT_DEBUG(_WM_FUNCTION,ch, data->data.value);
 
     nte = &mdi->note_table[0][ch][(data->data.value >> 8)];
     if (!nte->active) {
@@ -670,7 +670,7 @@ void _WM_do_note_on(struct _mdi *mdi, struct _event_data *data) {
         return;
     }
 
-    MIDI_EVENT_DEBUG(__FUNCTION__,ch, data->data.value);
+    MIDI_EVENT_DEBUG(_WM_FUNCTION,ch, data->data.value);
 
     if (!mdi->channel[ch].isdrum) {
         patch = mdi->channel[ch].patch;
@@ -752,7 +752,7 @@ void _WM_do_aftertouch(struct _mdi *mdi, struct _event_data *data) {
     struct _note *nte;
     uint8_t ch = data->channel;
 
-    MIDI_EVENT_DEBUG(__FUNCTION__,ch, data->data.value);
+    MIDI_EVENT_DEBUG(_WM_FUNCTION,ch, data->data.value);
 
     nte = &mdi->note_table[0][ch][(data->data.value >> 8)];
     if (!nte->active) {
@@ -772,7 +772,7 @@ void _WM_do_aftertouch(struct _mdi *mdi, struct _event_data *data) {
 
 void _WM_do_control_bank_select(struct _mdi *mdi, struct _event_data *data) {
     uint8_t ch = data->channel;
-    MIDI_EVENT_DEBUG(__FUNCTION__,ch, data->data.value);
+    MIDI_EVENT_DEBUG(_WM_FUNCTION,ch, data->data.value);
     mdi->channel[ch].bank = data->data.value;
 }
 
@@ -780,7 +780,7 @@ void _WM_do_control_data_entry_course(struct _mdi *mdi,
                                          struct _event_data *data) {
     uint8_t ch = data->channel;
     int data_tmp;
-    MIDI_EVENT_DEBUG(__FUNCTION__,ch, data->data.value);
+    MIDI_EVENT_DEBUG(_WM_FUNCTION,ch, data->data.value);
 
     if ((mdi->channel[ch].reg_non == 0)
         && (mdi->channel[ch].reg_data == 0x0000)) { /* Pitch Bend Range */
@@ -794,7 +794,7 @@ void _WM_do_control_data_entry_course(struct _mdi *mdi,
 void _WM_do_control_channel_volume(struct _mdi *mdi,
                                       struct _event_data *data) {
     uint8_t ch = data->channel;
-    MIDI_EVENT_DEBUG(__FUNCTION__,ch, data->data.value);
+    MIDI_EVENT_DEBUG(_WM_FUNCTION,ch, data->data.value);
 
     mdi->channel[ch].volume = data->data.value;
     _WM_AdjustChannelVolumes(mdi, ch);
@@ -803,7 +803,7 @@ void _WM_do_control_channel_volume(struct _mdi *mdi,
 void _WM_do_control_channel_balance(struct _mdi *mdi,
                                        struct _event_data *data) {
     uint8_t ch = data->channel;
-    MIDI_EVENT_DEBUG(__FUNCTION__,ch, data->data.value);
+    MIDI_EVENT_DEBUG(_WM_FUNCTION,ch, data->data.value);
 
     mdi->channel[ch].balance = data->data.value;
     _WM_AdjustChannelVolumes(mdi, ch);
@@ -811,7 +811,7 @@ void _WM_do_control_channel_balance(struct _mdi *mdi,
 
 void _WM_do_control_channel_pan(struct _mdi *mdi, struct _event_data *data) {
     uint8_t ch = data->channel;
-    MIDI_EVENT_DEBUG(__FUNCTION__,ch, data->data.value);
+    MIDI_EVENT_DEBUG(_WM_FUNCTION,ch, data->data.value);
 
     mdi->channel[ch].pan = data->data.value;
     _WM_AdjustChannelVolumes(mdi, ch);
@@ -820,7 +820,7 @@ void _WM_do_control_channel_pan(struct _mdi *mdi, struct _event_data *data) {
 void _WM_do_control_channel_expression(struct _mdi *mdi,
                                           struct _event_data *data) {
     uint8_t ch = data->channel;
-    MIDI_EVENT_DEBUG(__FUNCTION__,ch, data->data.value);
+    MIDI_EVENT_DEBUG(_WM_FUNCTION,ch, data->data.value);
 
     mdi->channel[ch].expression = data->data.value;
     _WM_AdjustChannelVolumes(mdi, ch);
@@ -830,7 +830,7 @@ void _WM_do_control_data_entry_fine(struct _mdi *mdi,
                                        struct _event_data *data) {
     uint8_t ch = data->channel;
     int data_tmp;
-    MIDI_EVENT_DEBUG(__FUNCTION__,ch, data->data.value);
+    MIDI_EVENT_DEBUG(_WM_FUNCTION,ch, data->data.value);
 
     if ((mdi->channel[ch].reg_non == 0)
       && (mdi->channel[ch].reg_data == 0x0000)) { /* Pitch Bend Range */
@@ -844,7 +844,7 @@ void _WM_do_control_data_entry_fine(struct _mdi *mdi,
 void _WM_do_control_channel_hold(struct _mdi *mdi, struct _event_data *data) {
     struct _note *note_data = mdi->note;
     uint8_t ch = data->channel;
-    MIDI_EVENT_DEBUG(__FUNCTION__,ch, data->data.value);
+    MIDI_EVENT_DEBUG(_WM_FUNCTION,ch, data->data.value);
 
     if (data->data.value > 63) {
         mdi->channel[ch].hold = 1;
@@ -910,7 +910,7 @@ void _WM_do_control_channel_hold(struct _mdi *mdi, struct _event_data *data) {
 void _WM_do_control_data_increment(struct _mdi *mdi,
                                       struct _event_data *data) {
     uint8_t ch = data->channel;
-    MIDI_EVENT_DEBUG(__FUNCTION__,ch, data->data.value);
+    MIDI_EVENT_DEBUG(_WM_FUNCTION,ch, data->data.value);
 
     if ((mdi->channel[ch].reg_non == 0)
         && (mdi->channel[ch].reg_data == 0x0000)) { /* Pitch Bend Range */
@@ -922,7 +922,7 @@ void _WM_do_control_data_increment(struct _mdi *mdi,
 void _WM_do_control_data_decrement(struct _mdi *mdi,
                                       struct _event_data *data) {
     uint8_t ch = data->channel;
-    MIDI_EVENT_DEBUG(__FUNCTION__,ch, data->data.value);
+    MIDI_EVENT_DEBUG(_WM_FUNCTION,ch, data->data.value);
 
     if ((mdi->channel[ch].reg_non == 0)
         && (mdi->channel[ch].reg_data == 0x0000)) { /* Pitch Bend Range */
@@ -933,7 +933,7 @@ void _WM_do_control_data_decrement(struct _mdi *mdi,
 void _WM_do_control_non_registered_param_fine(struct _mdi *mdi,
                                             struct _event_data *data) {
     uint8_t ch = data->channel;
-    MIDI_EVENT_DEBUG(__FUNCTION__,ch, data->data.value);
+    MIDI_EVENT_DEBUG(_WM_FUNCTION,ch, data->data.value);
     mdi->channel[ch].reg_data = (mdi->channel[ch].reg_data & 0x3F80)
                                 | data->data.value;
     mdi->channel[ch].reg_non = 1;
@@ -942,7 +942,7 @@ void _WM_do_control_non_registered_param_fine(struct _mdi *mdi,
 void _WM_do_control_non_registered_param_course(struct _mdi *mdi,
                                      struct _event_data *data) {
     uint8_t ch = data->channel;
-    MIDI_EVENT_DEBUG(__FUNCTION__,ch, data->data.value);
+    MIDI_EVENT_DEBUG(_WM_FUNCTION,ch, data->data.value);
     mdi->channel[ch].reg_data = (mdi->channel[ch].reg_data & 0x7F)
                                 | (data->data.value << 7);
     mdi->channel[ch].reg_non = 1;
@@ -951,7 +951,7 @@ void _WM_do_control_non_registered_param_course(struct _mdi *mdi,
 void _WM_do_control_registered_param_fine(struct _mdi *mdi,
                                           struct _event_data *data) {
     uint8_t ch = data->channel;
-    MIDI_EVENT_DEBUG(__FUNCTION__,ch, data->data.value);
+    MIDI_EVENT_DEBUG(_WM_FUNCTION,ch, data->data.value);
     mdi->channel[ch].reg_data = (mdi->channel[ch].reg_data & 0x3F80)
                                 | data->data.value;
     mdi->channel[ch].reg_non = 0;
@@ -960,7 +960,7 @@ void _WM_do_control_registered_param_fine(struct _mdi *mdi,
 void _WM_do_control_registered_param_course(struct _mdi *mdi,
                                             struct _event_data *data) {
     uint8_t ch = data->channel;
-    MIDI_EVENT_DEBUG(__FUNCTION__,ch, data->data.value);
+    MIDI_EVENT_DEBUG(_WM_FUNCTION,ch, data->data.value);
     mdi->channel[ch].reg_data = (mdi->channel[ch].reg_data & 0x7F)
                                 | (data->data.value << 7);
     mdi->channel[ch].reg_non = 0;
@@ -970,7 +970,7 @@ void _WM_do_control_channel_sound_off(struct _mdi *mdi,
                                       struct _event_data *data) {
     struct _note *note_data = mdi->note;
     uint8_t ch = data->channel;
-    MIDI_EVENT_DEBUG(__FUNCTION__,ch, data->data.value);
+    MIDI_EVENT_DEBUG(_WM_FUNCTION,ch, data->data.value);
 
     if (note_data) {
         do {
@@ -988,7 +988,7 @@ void _WM_do_control_channel_sound_off(struct _mdi *mdi,
 void _WM_do_control_channel_controllers_off(struct _mdi *mdi,
                                             struct _event_data *data) {
     uint8_t ch = data->channel;
-    MIDI_EVENT_DEBUG(__FUNCTION__,ch, data->data.value);
+    MIDI_EVENT_DEBUG(_WM_FUNCTION,ch, data->data.value);
 
     mdi->channel[ch].expression = 127;
     mdi->channel[ch].pressure = 127;
@@ -1005,7 +1005,7 @@ void _WM_do_control_channel_notes_off(struct _mdi *mdi,
                                       struct _event_data *data) {
     struct _note *note_data = mdi->note;
     uint8_t ch = data->channel;
-    MIDI_EVENT_DEBUG(__FUNCTION__,ch, data->data.value);
+    MIDI_EVENT_DEBUG(_WM_FUNCTION,ch, data->data.value);
 
     if (mdi->channel[ch].isdrum)
         return;
@@ -1038,7 +1038,7 @@ void _WM_do_control_channel_notes_off(struct _mdi *mdi,
 void _WM_do_control_dummy(struct _mdi *mdi, struct _event_data *data) {
 #ifdef DEBUG_MIDI
     uint8_t ch = data->channel;
-    MIDI_EVENT_DEBUG(__FUNCTION__, ch, data->data.value);
+    MIDI_EVENT_DEBUG(_WM_FUNCTION, ch, data->data.value);
 #else
     WMIDI_UNUSED(data);
 #endif
@@ -1047,7 +1047,7 @@ void _WM_do_control_dummy(struct _mdi *mdi, struct _event_data *data) {
 
 void _WM_do_patch(struct _mdi *mdi, struct _event_data *data) {
     uint8_t ch = data->channel;
-    MIDI_EVENT_DEBUG(__FUNCTION__,ch, data->data.value);
+    MIDI_EVENT_DEBUG(_WM_FUNCTION,ch, data->data.value);
     if (!mdi->channel[ch].isdrum) {
         mdi->channel[ch].patch = _WM_get_patch_data(mdi,
                                                 ((mdi->channel[ch].bank << 8) | data->data.value));
@@ -1059,7 +1059,7 @@ void _WM_do_patch(struct _mdi *mdi, struct _event_data *data) {
 void _WM_do_channel_pressure(struct _mdi *mdi, struct _event_data *data) {
     uint8_t ch = data->channel;
     struct _note *note_data = mdi->note;
-    MIDI_EVENT_DEBUG(__FUNCTION__,ch, data->data.value);
+    MIDI_EVENT_DEBUG(_WM_FUNCTION,ch, data->data.value);
 
     mdi->channel[ch].pressure = data->data.value;
 
@@ -1082,7 +1082,7 @@ void _WM_do_pitch(struct _mdi *mdi, struct _event_data *data) {
     struct _note *note_data = mdi->note;
     uint8_t ch = data->channel;
 
-    MIDI_EVENT_DEBUG(__FUNCTION__,ch, data->data.value);
+    MIDI_EVENT_DEBUG(_WM_FUNCTION,ch, data->data.value);
     mdi->channel[ch].pitch = data->data.value - 0x2000;
 
     if (mdi->channel[ch].pitch < 0) {
@@ -1106,7 +1106,7 @@ void _WM_do_pitch(struct _mdi *mdi, struct _event_data *data) {
 void _WM_do_sysex_roland_drum_track(struct _mdi *mdi, struct _event_data *data) {
     uint8_t ch = data->channel;
 
-    MIDI_EVENT_DEBUG(__FUNCTION__,ch, data->data.value);
+    MIDI_EVENT_DEBUG(_WM_FUNCTION,ch, data->data.value);
 
     if (data->data.value > 0) {
         mdi->channel[ch].isdrum = 1;
@@ -1121,9 +1121,9 @@ void _WM_do_sysex_gm_reset(struct _mdi *mdi, struct _event_data *data) {
     int i;
 
     if (data != NULL) {
-        MIDI_EVENT_DEBUG(__FUNCTION__,data->channel, data->data.value);
+        MIDI_EVENT_DEBUG(_WM_FUNCTION,data->channel, data->data.value);
     } else {
-        MIDI_EVENT_DEBUG(__FUNCTION__,0, 0);
+        MIDI_EVENT_DEBUG(_WM_FUNCTION,0, 0);
     }
 
     for (i = 0; i < 16; i++) {
@@ -1154,7 +1154,7 @@ void _WM_do_sysex_gm_reset(struct _mdi *mdi, struct _event_data *data) {
 void _WM_do_sysex_roland_reset(struct _mdi *mdi, struct _event_data *data) {
 #ifdef DEBUG_MIDI
     uint8_t ch = data->channel;
-    MIDI_EVENT_DEBUG(__FUNCTION__, ch, data->data.value);
+    MIDI_EVENT_DEBUG(_WM_FUNCTION, ch, data->data.value);
 #else
     WMIDI_UNUSED(data);
 #endif
@@ -1164,7 +1164,7 @@ void _WM_do_sysex_roland_reset(struct _mdi *mdi, struct _event_data *data) {
 void _WM_do_sysex_yamaha_reset(struct _mdi *mdi, struct _event_data *data) {
 #ifdef DEBUG_MIDI
     uint8_t ch = data->channel;
-    MIDI_EVENT_DEBUG(__FUNCTION__, ch, data->data.value);
+    MIDI_EVENT_DEBUG(_WM_FUNCTION, ch, data->data.value);
 #else
     WMIDI_UNUSED(data);
 #endif
@@ -1212,7 +1212,7 @@ void _WM_do_meta_endoftrack(struct _mdi *mdi, struct _event_data *data) {
  * for conversion function _WM_Event2Midi */
 #ifdef DEBUG_MIDI
     uint8_t ch = data->channel;
-    MIDI_EVENT_DEBUG(__FUNCTION__, ch, data->data.value);
+    MIDI_EVENT_DEBUG(_WM_FUNCTION, ch, data->data.value);
 #else
     WMIDI_UNUSED(data);
 #endif
@@ -1226,7 +1226,7 @@ void _WM_do_meta_tempo(struct _mdi *mdi, struct _event_data *data) {
  * for conversion function _WM_Event2Midi */
 #ifdef DEBUG_MIDI
     uint8_t ch = data->channel;
-    MIDI_EVENT_DEBUG(__FUNCTION__, ch, data->data.value);
+    MIDI_EVENT_DEBUG(_WM_FUNCTION, ch, data->data.value);
 #else
     WMIDI_UNUSED(data);
 #endif
@@ -1239,7 +1239,7 @@ void _WM_do_meta_timesignature(struct _mdi *mdi, struct _event_data *data) {
  * for conversion function _WM_Event2Midi */
 #ifdef DEBUG_MIDI
     uint8_t ch = data->channel;
-    MIDI_EVENT_DEBUG(__FUNCTION__, ch, data->data.value);
+    MIDI_EVENT_DEBUG(_WM_FUNCTION, ch, data->data.value);
 #else
     WMIDI_UNUSED(data);
 #endif
@@ -1252,7 +1252,7 @@ void _WM_do_meta_keysignature(struct _mdi *mdi, struct _event_data *data) {
  * for conversion function _WM_Event2Midi */
 #ifdef DEBUG_MIDI
     uint8_t ch = data->channel;
-    MIDI_EVENT_DEBUG(__FUNCTION__, ch, data->data.value);
+    MIDI_EVENT_DEBUG(_WM_FUNCTION, ch, data->data.value);
 #else
     WMIDI_UNUSED(data);
 #endif
@@ -1265,7 +1265,7 @@ void _WM_do_meta_sequenceno(struct _mdi *mdi, struct _event_data *data) {
  * for conversion function _WM_Event2Midi */
 #ifdef DEBUG_MIDI
     uint8_t ch = data->channel;
-    MIDI_EVENT_DEBUG(__FUNCTION__, ch, data->data.value);
+    MIDI_EVENT_DEBUG(_WM_FUNCTION, ch, data->data.value);
 #else
     WMIDI_UNUSED(data);
 #endif
@@ -1278,7 +1278,7 @@ void _WM_do_meta_channelprefix(struct _mdi *mdi, struct _event_data *data) {
  * for conversion function _WM_Event2Midi */
 #ifdef DEBUG_MIDI
     uint8_t ch = data->channel;
-    MIDI_EVENT_DEBUG(__FUNCTION__, ch, data->data.value);
+    MIDI_EVENT_DEBUG(_WM_FUNCTION, ch, data->data.value);
 #else
     WMIDI_UNUSED(data);
 #endif
@@ -1291,7 +1291,7 @@ void _WM_do_meta_portprefix(struct _mdi *mdi, struct _event_data *data) {
  * for conversion function _WM_Event2Midi */
 #ifdef DEBUG_MIDI
     uint8_t ch = data->channel;
-    MIDI_EVENT_DEBUG(__FUNCTION__, ch, data->data.value);
+    MIDI_EVENT_DEBUG(_WM_FUNCTION, ch, data->data.value);
 #else
     WMIDI_UNUSED(data);
 #endif
@@ -1304,7 +1304,7 @@ void _WM_do_meta_smpteoffset(struct _mdi *mdi, struct _event_data *data) {
  * for conversion function _WM_Event2Midi */
 #ifdef DEBUG_MIDI
     uint8_t ch = data->channel;
-    MIDI_EVENT_DEBUG(__FUNCTION__, ch, data->data.value);
+    MIDI_EVENT_DEBUG(_WM_FUNCTION, ch, data->data.value);
 #else
     WMIDI_UNUSED(data);
 #endif
@@ -1317,7 +1317,7 @@ void _WM_do_meta_text(struct _mdi *mdi, struct _event_data *data) {
  * for conversion function _WM_Event2Midi */
 #ifdef DEBUG_MIDI
     uint8_t ch = data->channel;
-    MIDI_EVENT_SDEBUG(__FUNCTION__, ch, data->data.string);
+    MIDI_EVENT_SDEBUG(_WM_FUNCTION, ch, data->data.string);
 #endif
     if (mdi->extra_info.mixer_options & WM_MO_TEXTASLYRIC) {
         mdi->lyric = data->data.string;
@@ -1331,7 +1331,7 @@ void _WM_do_meta_copyright(struct _mdi *mdi, struct _event_data *data) {
  * for conversion function _WM_Event2Midi */
 #ifdef DEBUG_MIDI
     uint8_t ch = data->channel;
-    MIDI_EVENT_SDEBUG(__FUNCTION__, ch, data->data.string);
+    MIDI_EVENT_SDEBUG(_WM_FUNCTION, ch, data->data.string);
 #else
     WMIDI_UNUSED(data);
 #endif
@@ -1344,7 +1344,7 @@ void _WM_do_meta_trackname(struct _mdi *mdi, struct _event_data *data) {
  * for conversion function _WM_Event2Midi */
 #ifdef DEBUG_MIDI
     uint8_t ch = data->channel;
-    MIDI_EVENT_SDEBUG(__FUNCTION__, ch, data->data.string);
+    MIDI_EVENT_SDEBUG(_WM_FUNCTION, ch, data->data.string);
 #else
     WMIDI_UNUSED(data);
 #endif
@@ -1357,7 +1357,7 @@ void _WM_do_meta_instrumentname(struct _mdi *mdi, struct _event_data *data) {
  * for conversion function _WM_Event2Midi */
 #ifdef DEBUG_MIDI
     uint8_t ch = data->channel;
-    MIDI_EVENT_SDEBUG(__FUNCTION__, ch, data->data.string);
+    MIDI_EVENT_SDEBUG(_WM_FUNCTION, ch, data->data.string);
 #else
     WMIDI_UNUSED(data);
 #endif
@@ -1370,7 +1370,7 @@ void _WM_do_meta_lyric(struct _mdi *mdi, struct _event_data *data) {
  * for conversion function _WM_Event2Midi */
 #ifdef DEBUG_MIDI
     uint8_t ch = data->channel;
-    MIDI_EVENT_SDEBUG(__FUNCTION__, ch, data->data.string);
+    MIDI_EVENT_SDEBUG(_WM_FUNCTION, ch, data->data.string);
 #endif
     if (!(mdi->extra_info.mixer_options & WM_MO_TEXTASLYRIC)) {
         mdi->lyric = data->data.string;
@@ -1383,7 +1383,7 @@ void _WM_do_meta_marker(struct _mdi *mdi, struct _event_data *data) {
  * for conversion function _WM_Event2Midi */
 #ifdef DEBUG_MIDI
     uint8_t ch = data->channel;
-    MIDI_EVENT_SDEBUG(__FUNCTION__, ch, data->data.string);
+    MIDI_EVENT_SDEBUG(_WM_FUNCTION, ch, data->data.string);
 #else
     WMIDI_UNUSED(data);
 #endif
@@ -1396,7 +1396,7 @@ void _WM_do_meta_cuepoint(struct _mdi *mdi, struct _event_data *data) {
  * for conversion function _WM_Event2Midi */
 #ifdef DEBUG_MIDI
     uint8_t ch = data->channel;
-    MIDI_EVENT_SDEBUG(__FUNCTION__, ch, data->data.string);
+    MIDI_EVENT_SDEBUG(_WM_FUNCTION, ch, data->data.string);
 #else
     WMIDI_UNUSED(data);
 #endif
@@ -1451,7 +1451,7 @@ void _WM_ResetToStart(struct _mdi *mdi) {
 }
 
 int _WM_midi_setup_divisions(struct _mdi *mdi, uint32_t divisions) {
-    MIDI_EVENT_DEBUG(__FUNCTION__,0,0);
+    MIDI_EVENT_DEBUG(_WM_FUNCTION,0,0);
     _WM_CheckEventMemoryPool(mdi);
     mdi->events[mdi->event_count].evtype = ev_midi_divisions;
     mdi->events[mdi->event_count].do_event = _WM_do_midi_divisions;
@@ -1464,7 +1464,7 @@ int _WM_midi_setup_divisions(struct _mdi *mdi, uint32_t divisions) {
 
 int _WM_midi_setup_noteoff(struct _mdi *mdi, uint8_t channel,
                            uint8_t note, uint8_t velocity) {
-    MIDI_EVENT_DEBUG(__FUNCTION__,channel, note);
+    MIDI_EVENT_DEBUG(_WM_FUNCTION,channel, note);
     _WM_CheckEventMemoryPool(mdi);
     note &= 0x7f; /* silently bound note to 0..127 (github bug #180) */
     mdi->events[mdi->event_count].evtype = ev_note_off;
@@ -1478,7 +1478,7 @@ int _WM_midi_setup_noteoff(struct _mdi *mdi, uint8_t channel,
 
 static int midi_setup_noteon(struct _mdi *mdi, uint8_t channel,
                              uint8_t note, uint8_t velocity) {
-    MIDI_EVENT_DEBUG(__FUNCTION__,channel, note);
+    MIDI_EVENT_DEBUG(_WM_FUNCTION,channel, note);
     _WM_CheckEventMemoryPool(mdi);
     note &= 0x7f; /* silently bound note to 0..127 (github bug #180) */
     mdi->events[mdi->event_count].evtype = ev_note_on;
@@ -1495,7 +1495,7 @@ static int midi_setup_noteon(struct _mdi *mdi, uint8_t channel,
 
 static int midi_setup_aftertouch(struct _mdi *mdi, uint8_t channel,
                                  uint8_t note, uint8_t pressure) {
-    MIDI_EVENT_DEBUG(__FUNCTION__,channel, note);
+    MIDI_EVENT_DEBUG(_WM_FUNCTION,channel, note);
     _WM_CheckEventMemoryPool(mdi);
     note &= 0x7f; /* silently bound note to 0..127 (github bug #180) */
     mdi->events[mdi->event_count].evtype = ev_aftertouch;
@@ -1512,7 +1512,7 @@ static int midi_setup_control(struct _mdi *mdi, uint8_t channel,
     void (*tmp_event)(struct _mdi *mdi, struct _event_data *data);
     enum _event_type ev;
 
-    MIDI_EVENT_DEBUG(__FUNCTION__,channel, controller);
+    MIDI_EVENT_DEBUG(_WM_FUNCTION,channel, controller);
 
     switch (controller) {
         /*
@@ -1613,7 +1613,7 @@ static int midi_setup_control(struct _mdi *mdi, uint8_t channel,
 }
 
 static int midi_setup_patch(struct _mdi *mdi, uint8_t channel, uint8_t patch) {
-    MIDI_EVENT_DEBUG(__FUNCTION__,channel, patch);
+    MIDI_EVENT_DEBUG(_WM_FUNCTION,channel, patch);
     _WM_CheckEventMemoryPool(mdi);
     mdi->events[mdi->event_count].evtype = ev_patch;
     mdi->events[mdi->event_count].do_event = _WM_do_patch;
@@ -1634,7 +1634,7 @@ static int midi_setup_patch(struct _mdi *mdi, uint8_t channel, uint8_t patch) {
 
 static int midi_setup_channel_pressure(struct _mdi *mdi, uint8_t channel,
                                        uint8_t pressure) {
-    MIDI_EVENT_DEBUG(__FUNCTION__,channel, pressure);
+    MIDI_EVENT_DEBUG(_WM_FUNCTION,channel, pressure);
     _WM_CheckEventMemoryPool(mdi);
     mdi->events[mdi->event_count].evtype = ev_channel_pressure;
     mdi->events[mdi->event_count].do_event = _WM_do_channel_pressure;
@@ -1646,7 +1646,7 @@ static int midi_setup_channel_pressure(struct _mdi *mdi, uint8_t channel,
 }
 
 static int midi_setup_pitch(struct _mdi *mdi, uint8_t channel, uint16_t pitch) {
-    MIDI_EVENT_DEBUG(__FUNCTION__,channel, pitch);
+    MIDI_EVENT_DEBUG(_WM_FUNCTION,channel, pitch);
     _WM_CheckEventMemoryPool(mdi);
     mdi->events[mdi->event_count].evtype = ev_pitch;
     mdi->events[mdi->event_count].do_event = _WM_do_pitch;
@@ -1659,7 +1659,7 @@ static int midi_setup_pitch(struct _mdi *mdi, uint8_t channel, uint16_t pitch) {
 
 static int midi_setup_sysex_roland_drum_track(struct _mdi *mdi,
                                               uint8_t channel, uint16_t setting) {
-    MIDI_EVENT_DEBUG(__FUNCTION__,channel, setting);
+    MIDI_EVENT_DEBUG(_WM_FUNCTION,channel, setting);
     _WM_CheckEventMemoryPool(mdi);
     mdi->events[mdi->event_count].evtype = ev_sysex_roland_drum_track;
     mdi->events[mdi->event_count].do_event = _WM_do_sysex_roland_drum_track;
@@ -1677,7 +1677,7 @@ static int midi_setup_sysex_roland_drum_track(struct _mdi *mdi,
 }
 
 static int midi_setup_sysex_gm_reset(struct _mdi *mdi) {
-    MIDI_EVENT_DEBUG(__FUNCTION__,0,0);
+    MIDI_EVENT_DEBUG(_WM_FUNCTION,0,0);
 
     _WM_CheckEventMemoryPool(mdi);
     mdi->events[mdi->event_count].evtype = ev_sysex_roland_reset;
@@ -1690,7 +1690,7 @@ static int midi_setup_sysex_gm_reset(struct _mdi *mdi) {
 }
 
 static int midi_setup_sysex_roland_reset(struct _mdi *mdi) {
-    MIDI_EVENT_DEBUG(__FUNCTION__,0,0);
+    MIDI_EVENT_DEBUG(_WM_FUNCTION,0,0);
     _WM_CheckEventMemoryPool(mdi);
     mdi->events[mdi->event_count].evtype = ev_sysex_roland_reset;
     mdi->events[mdi->event_count].do_event = _WM_do_sysex_roland_reset;
@@ -1702,7 +1702,7 @@ static int midi_setup_sysex_roland_reset(struct _mdi *mdi) {
 }
 
 static int midi_setup_sysex_yamaha_reset(struct _mdi *mdi) {
-    MIDI_EVENT_DEBUG(__FUNCTION__,0,0);
+    MIDI_EVENT_DEBUG(_WM_FUNCTION,0,0);
     _WM_CheckEventMemoryPool(mdi);
     mdi->events[mdi->event_count].evtype = ev_sysex_roland_reset;
     mdi->events[mdi->event_count].do_event = _WM_do_sysex_roland_reset;
@@ -1714,7 +1714,7 @@ static int midi_setup_sysex_yamaha_reset(struct _mdi *mdi) {
 }
 
 int _WM_midi_setup_endoftrack(struct _mdi *mdi) {
-    MIDI_EVENT_DEBUG(__FUNCTION__,0,0);
+    MIDI_EVENT_DEBUG(_WM_FUNCTION,0,0);
     _WM_CheckEventMemoryPool(mdi);
     mdi->events[mdi->event_count].evtype = ev_meta_endoftrack;
     mdi->events[mdi->event_count].do_event = _WM_do_meta_endoftrack;
@@ -1726,7 +1726,7 @@ int _WM_midi_setup_endoftrack(struct _mdi *mdi) {
 }
 
 int _WM_midi_setup_tempo(struct _mdi *mdi, uint32_t setting) {
-    MIDI_EVENT_DEBUG(__FUNCTION__,0,setting);
+    MIDI_EVENT_DEBUG(_WM_FUNCTION,0,setting);
     _WM_CheckEventMemoryPool(mdi);
     mdi->events[mdi->event_count].evtype = ev_meta_tempo;
     mdi->events[mdi->event_count].do_event = _WM_do_meta_tempo;
@@ -1738,7 +1738,7 @@ int _WM_midi_setup_tempo(struct _mdi *mdi, uint32_t setting) {
 }
 
 static int midi_setup_timesignature(struct _mdi *mdi, uint32_t setting) {
-    MIDI_EVENT_DEBUG(__FUNCTION__,0, setting);
+    MIDI_EVENT_DEBUG(_WM_FUNCTION,0, setting);
     _WM_CheckEventMemoryPool(mdi);
     mdi->events[mdi->event_count].evtype = ev_meta_timesignature;
     mdi->events[mdi->event_count].do_event = _WM_do_meta_timesignature;
@@ -1750,7 +1750,7 @@ static int midi_setup_timesignature(struct _mdi *mdi, uint32_t setting) {
 }
 
 static int midi_setup_keysignature(struct _mdi *mdi, uint32_t setting) {
-    MIDI_EVENT_DEBUG(__FUNCTION__,0, setting);
+    MIDI_EVENT_DEBUG(_WM_FUNCTION,0, setting);
     _WM_CheckEventMemoryPool(mdi);
     mdi->events[mdi->event_count].evtype = ev_meta_keysignature;
     mdi->events[mdi->event_count].do_event = _WM_do_meta_keysignature;
@@ -1762,7 +1762,7 @@ static int midi_setup_keysignature(struct _mdi *mdi, uint32_t setting) {
 }
 
 static int midi_setup_sequenceno(struct _mdi *mdi, uint32_t setting) {
-    MIDI_EVENT_DEBUG(__FUNCTION__,0, setting);
+    MIDI_EVENT_DEBUG(_WM_FUNCTION,0, setting);
     _WM_CheckEventMemoryPool(mdi);
     mdi->events[mdi->event_count].evtype = ev_meta_sequenceno;
     mdi->events[mdi->event_count].do_event = _WM_do_meta_sequenceno;
@@ -1774,7 +1774,7 @@ static int midi_setup_sequenceno(struct _mdi *mdi, uint32_t setting) {
 }
 
 static int midi_setup_channelprefix(struct _mdi *mdi, uint32_t setting) {
-    MIDI_EVENT_DEBUG(__FUNCTION__,0, setting);
+    MIDI_EVENT_DEBUG(_WM_FUNCTION,0, setting);
     _WM_CheckEventMemoryPool(mdi);
     mdi->events[mdi->event_count].evtype = ev_meta_channelprefix;
     mdi->events[mdi->event_count].do_event = _WM_do_meta_channelprefix;
@@ -1786,7 +1786,7 @@ static int midi_setup_channelprefix(struct _mdi *mdi, uint32_t setting) {
 }
 
 static int midi_setup_portprefix(struct _mdi *mdi, uint32_t setting) {
-    MIDI_EVENT_DEBUG(__FUNCTION__,0, setting);
+    MIDI_EVENT_DEBUG(_WM_FUNCTION,0, setting);
     _WM_CheckEventMemoryPool(mdi);
     mdi->events[mdi->event_count].evtype = ev_meta_portprefix;
     mdi->events[mdi->event_count].do_event = _WM_do_meta_portprefix;
@@ -1798,7 +1798,7 @@ static int midi_setup_portprefix(struct _mdi *mdi, uint32_t setting) {
 }
 
 static int midi_setup_smpteoffset(struct _mdi *mdi, uint32_t setting) {
-    MIDI_EVENT_DEBUG(__FUNCTION__,0, setting);
+    MIDI_EVENT_DEBUG(_WM_FUNCTION,0, setting);
     _WM_CheckEventMemoryPool(mdi);
     mdi->events[mdi->event_count].evtype = ev_meta_smpteoffset;
     mdi->events[mdi->event_count].do_event = _WM_do_meta_smpteoffset;
@@ -1825,7 +1825,7 @@ static void strip_text(char * text) {
 }
 
 static int midi_setup_text(struct _mdi *mdi, char * text) {
-    MIDI_EVENT_SDEBUG(__FUNCTION__,0, text);
+    MIDI_EVENT_SDEBUG(_WM_FUNCTION,0, text);
     strip_text(text);
     _WM_CheckEventMemoryPool(mdi);
     mdi->events[mdi->event_count].evtype = ev_meta_text;
@@ -1838,7 +1838,7 @@ static int midi_setup_text(struct _mdi *mdi, char * text) {
 }
 
 static int midi_setup_copyright(struct _mdi *mdi, char * text) {
-    MIDI_EVENT_SDEBUG(__FUNCTION__,0, text);
+    MIDI_EVENT_SDEBUG(_WM_FUNCTION,0, text);
     strip_text(text);
     _WM_CheckEventMemoryPool(mdi);
     mdi->events[mdi->event_count].evtype = ev_meta_copyright;
@@ -1851,7 +1851,7 @@ static int midi_setup_copyright(struct _mdi *mdi, char * text) {
 }
 
 static int midi_setup_trackname(struct _mdi *mdi, char * text) {
-    MIDI_EVENT_SDEBUG(__FUNCTION__,0, text);
+    MIDI_EVENT_SDEBUG(_WM_FUNCTION,0, text);
     strip_text(text);
     _WM_CheckEventMemoryPool(mdi);
     mdi->events[mdi->event_count].evtype = ev_meta_trackname;
@@ -1864,7 +1864,7 @@ static int midi_setup_trackname(struct _mdi *mdi, char * text) {
 }
 
 static int midi_setup_instrumentname(struct _mdi *mdi, char * text) {
-    MIDI_EVENT_SDEBUG(__FUNCTION__,0, text);
+    MIDI_EVENT_SDEBUG(_WM_FUNCTION,0, text);
     strip_text(text);
     _WM_CheckEventMemoryPool(mdi);
     mdi->events[mdi->event_count].evtype = ev_meta_instrumentname;
@@ -1877,7 +1877,7 @@ static int midi_setup_instrumentname(struct _mdi *mdi, char * text) {
 }
 
 static int midi_setup_lyric(struct _mdi *mdi, char * text) {
-    MIDI_EVENT_SDEBUG(__FUNCTION__,0, text);
+    MIDI_EVENT_SDEBUG(_WM_FUNCTION,0, text);
     strip_text(text);
     _WM_CheckEventMemoryPool(mdi);
     mdi->events[mdi->event_count].evtype = ev_meta_lyric;
@@ -1890,7 +1890,7 @@ static int midi_setup_lyric(struct _mdi *mdi, char * text) {
 }
 
 static int midi_setup_marker(struct _mdi *mdi, char * text) {
-    MIDI_EVENT_SDEBUG(__FUNCTION__,0, text);
+    MIDI_EVENT_SDEBUG(_WM_FUNCTION,0, text);
     strip_text(text);
     _WM_CheckEventMemoryPool(mdi);
     mdi->events[mdi->event_count].evtype = ev_meta_marker;
@@ -1903,7 +1903,7 @@ static int midi_setup_marker(struct _mdi *mdi, char * text) {
 }
 
 static int midi_setup_cuepoint(struct _mdi *mdi, char * text) {
-    MIDI_EVENT_SDEBUG(__FUNCTION__,0, text);
+    MIDI_EVENT_SDEBUG(_WM_FUNCTION,0, text);
     strip_text(text);
     _WM_CheckEventMemoryPool(mdi);
     mdi->events[mdi->event_count].evtype = ev_meta_cuepoint;
@@ -2471,7 +2471,7 @@ uint32_t _WM_SetupMidiEvent(struct _mdi *mdi, const uint8_t * event_data, uint32
                 */
                 ret_cnt += sysex_len;
             } else {
-                _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_CORUPT, "(unrecognized meta type event)", 0);
+                _WM_GLOBAL_ERROR(WM_ERR_CORUPT, "(unrecognized meta type event)", 0);
                 return 0;
             }
             break;
@@ -2481,11 +2481,11 @@ uint32_t _WM_SetupMidiEvent(struct _mdi *mdi, const uint8_t * event_data, uint32
             break;
     }
     if (ret_cnt == 0)
-        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_CORUPT, "(missing event)", 0);
+        _WM_GLOBAL_ERROR(WM_ERR_CORUPT, "(missing event)", 0);
     return ret_cnt;
 
 shortbuf:
-    _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_CORUPT, "(input too short)", 0);
+    _WM_GLOBAL_ERROR(WM_ERR_CORUPT, "(input too short)", 0);
     return 0;
 }
 

--- a/src/mus2mid.c
+++ b/src/mus2mid.c
@@ -227,7 +227,7 @@ int _WM_mus2midi(const uint8_t *in, uint32_t insize,
     int currentChannel;
 
     if (insize < MUS_HEADERSIZE) {
-        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_CORUPT, "(too short)", 0);
+        _WM_GLOBAL_ERROR(WM_ERR_CORUPT, "(too short)", 0);
         return (-1);
     }
 
@@ -243,16 +243,16 @@ int _WM_mus2midi(const uint8_t *in, uint32_t insize,
     header.instrCnt = READ_INT16(&in[12]);
 
     if (memcmp(header.ID, MUS_ID, 4)) {
-        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_NOT_MUS, NULL, 0);
+        _WM_GLOBAL_ERROR(WM_ERR_NOT_MUS, NULL, 0);
         return (-1);
     }
     if (insize < (uint32_t)header.scoreLen + (uint32_t)header.scoreStart) {
-        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_CORUPT, "(too short)", 0);
+        _WM_GLOBAL_ERROR(WM_ERR_CORUPT, "(too short)", 0);
         return (-1);
     }
     /* channel #15 should be excluded in the numchannels field: */
     if (header.channels > MIDI_MAXCHANNELS - 1) {
-        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_INVALID, NULL, 0);
+        _WM_GLOBAL_ERROR(WM_ERR_INVALID, NULL, 0);
         return (-1);
     }
 
@@ -371,7 +371,7 @@ int _WM_mus2midi(const uint8_t *in, uint32_t insize,
                 status |= 0xB0;
                 if (*cur >= sizeof(midimap) / sizeof(midimap[0])) {
                     _WM_ERROR_NEW("%s:%i: can't map %u to midi",
-                                  __FUNCTION__, __LINE__, *cur);
+                                  _WM_FUNCTION, __LINE__, *cur);
                     goto _end;
                 }
                 bit1 = midimap[*cur++];
@@ -388,7 +388,7 @@ int _WM_mus2midi(const uint8_t *in, uint32_t insize,
                     status |= 0xB0;
                     if (*cur >= sizeof(midimap) / sizeof(midimap[0])) {
                         _WM_ERROR_NEW("%s:%i: can't map %u to midi",
-                                      __FUNCTION__, __LINE__, *cur);
+                                      _WM_FUNCTION, __LINE__, *cur);
                         goto _end;
                     }
                     bit1 = midimap[*cur++];
@@ -406,14 +406,14 @@ int _WM_mus2midi(const uint8_t *in, uint32_t insize,
                 bit2 = 0x00;
                 if (cur != end) { /* should we error here or report-only? */
                     _WM_DEBUG_MSG("%s:%i: MUS buffer off by %ld bytes",
-                                  __FUNCTION__, __LINE__, (long)(cur - end));
+                                  _WM_FUNCTION, __LINE__, (long)(cur - end));
                 }
                 break;
             case 5:/* Unknown */
             case 7:/* Unknown */
             default:/* shouldn't happen */
                 _WM_ERROR_NEW("%s:%i: unrecognized event (%u)",
-                              __FUNCTION__, __LINE__, event);
+                              _WM_FUNCTION, __LINE__, event);
                 goto _end;
         }
 

--- a/src/wildmidi_lib.c
+++ b/src/wildmidi_lib.c
@@ -330,7 +330,7 @@ static char** WM_LC_Tokenize_Line(char *line_data) {
                     token_data_length += TOKEN_CNT_INC;
                     token_data = (char **) realloc(token_data, token_data_length * sizeof(char *));
                     if (token_data == NULL) {
-                        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_MEM, NULL, errno);
+                        _WM_GLOBAL_ERROR(WM_ERR_MEM, NULL, errno);
                         return (NULL);
                     }
                 }
@@ -374,7 +374,7 @@ static int load_config(const char *config_file, const char *conf_dir) {
 
     if (conf_dir) {
         if (!(config_dir = wm_strdup(conf_dir))) {
-            _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_MEM, NULL, errno);
+            _WM_GLOBAL_ERROR(WM_ERR_MEM, NULL, errno);
             WM_FreePatches();
             _WM_FreeBufferFile(config_buffer);
             return (-1);
@@ -384,7 +384,7 @@ static int load_config(const char *config_file, const char *conf_dir) {
         if (dir_end) {
             config_dir = (char *) malloc((dir_end - config_file + 2));
             if (config_dir == NULL) {
-                _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_MEM, NULL, errno);
+                _WM_GLOBAL_ERROR(WM_ERR_MEM, NULL, errno);
                 WM_FreePatches();
                 free(config_buffer);
                 return (-1);
@@ -414,13 +414,13 @@ static int load_config(const char *config_file, const char *conf_dir) {
                     if (wm_strcasecmp(line_tokens[0], "dir") == 0) {
                         free(config_dir);
                         if (!line_tokens[1]) {
-                            _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_INVALID_ARG, "(missing name in dir line)", 0);
+                            _WM_GLOBAL_ERROR(WM_ERR_INVALID_ARG, "(missing name in dir line)", 0);
                             WM_FreePatches();
                             free(line_tokens);
                             _WM_FreeBufferFile(config_buffer);
                             return (-1);
                         } else if (!(config_dir = wm_strdup(line_tokens[1]))) {
-                            _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_MEM, NULL, errno);
+                            _WM_GLOBAL_ERROR(WM_ERR_MEM, NULL, errno);
                             WM_FreePatches();
                             free(line_tokens);
                             _WM_FreeBufferFile(config_buffer);
@@ -433,7 +433,7 @@ static int load_config(const char *config_file, const char *conf_dir) {
                     } else if (wm_strcasecmp(line_tokens[0], "source") == 0) {
                         char *new_config = NULL;
                         if (!line_tokens[1]) {
-                            _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_INVALID_ARG, "(missing name in source line)", 0);
+                            _WM_GLOBAL_ERROR(WM_ERR_INVALID_ARG, "(missing name in source line)", 0);
                             WM_FreePatches();
                             free(line_tokens);
                             _WM_FreeBufferFile(config_buffer);
@@ -441,7 +441,7 @@ static int load_config(const char *config_file, const char *conf_dir) {
                         } else if (!IS_ABSOLUTE_PATH(line_tokens[1]) && config_dir) {
                             new_config = (char *) malloc(strlen(config_dir) + strlen(line_tokens[1]) + 1);
                             if (new_config == NULL) {
-                                _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_MEM, NULL, errno);
+                                _WM_GLOBAL_ERROR(WM_ERR_MEM, NULL, errno);
                                 WM_FreePatches();
                                 free(config_dir);
                                 free(line_tokens);
@@ -452,7 +452,7 @@ static int load_config(const char *config_file, const char *conf_dir) {
                             strcpy(&new_config[strlen(config_dir)], line_tokens[1]);
                         } else {
                             if (!(new_config = wm_strdup(line_tokens[1]))) {
-                                _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_MEM, NULL, errno);
+                                _WM_GLOBAL_ERROR(WM_ERR_MEM, NULL, errno);
                                 WM_FreePatches();
                                 free(line_tokens);
                                 _WM_FreeBufferFile(config_buffer);
@@ -469,7 +469,7 @@ static int load_config(const char *config_file, const char *conf_dir) {
                         free(new_config);
                     } else if (wm_strcasecmp(line_tokens[0], "bank") == 0) {
                         if (!line_tokens[1] || !wm_isdigit(line_tokens[1][0])) {
-                            _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_INVALID_ARG, "(syntax error in bank line)", 0);
+                            _WM_GLOBAL_ERROR(WM_ERR_INVALID_ARG, "(syntax error in bank line)", 0);
                             WM_FreePatches();
                             free(config_dir);
                             free(line_tokens);
@@ -479,7 +479,7 @@ static int load_config(const char *config_file, const char *conf_dir) {
                         patchid = (atoi(line_tokens[1]) & 0xFF) << 8;
                     } else if (wm_strcasecmp(line_tokens[0], "drumset") == 0) {
                         if (!line_tokens[1] || !wm_isdigit(line_tokens[1][0])) {
-                            _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_INVALID_ARG, "(syntax error in drumset line)", 0);
+                            _WM_GLOBAL_ERROR(WM_ERR_INVALID_ARG, "(syntax error in drumset line)", 0);
                             WM_FreePatches();
                             free(config_dir);
                             free(line_tokens);
@@ -489,7 +489,7 @@ static int load_config(const char *config_file, const char *conf_dir) {
                         patchid = ((atoi(line_tokens[1]) & 0xFF) << 8) | 0x80;
                     } else if (wm_strcasecmp(line_tokens[0], "reverb_room_width") == 0) {
                         if (!line_tokens[1] || !wm_isdigit(line_tokens[1][0])) {
-                            _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_INVALID_ARG, "(syntax error in reverb_room_width line)", 0);
+                            _WM_GLOBAL_ERROR(WM_ERR_INVALID_ARG, "(syntax error in reverb_room_width line)", 0);
                             WM_FreePatches();
                             free(config_dir);
                             free(line_tokens);
@@ -506,7 +506,7 @@ static int load_config(const char *config_file, const char *conf_dir) {
                         }
                     } else if (wm_strcasecmp(line_tokens[0], "reverb_room_length") == 0) {
                         if (!line_tokens[1] || !wm_isdigit(line_tokens[1][0])) {
-                            _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_INVALID_ARG, "(syntax error in reverb_room_length line)", 0);
+                            _WM_GLOBAL_ERROR(WM_ERR_INVALID_ARG, "(syntax error in reverb_room_length line)", 0);
                             WM_FreePatches();
                             free(config_dir);
                             free(line_tokens);
@@ -523,7 +523,7 @@ static int load_config(const char *config_file, const char *conf_dir) {
                         }
                     } else if (wm_strcasecmp(line_tokens[0], "reverb_listener_posx") == 0) {
                         if (!line_tokens[1] || !wm_isdigit(line_tokens[1][0])) {
-                            _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_INVALID_ARG, "(syntax error in reverb_listen_posx line)", 0);
+                            _WM_GLOBAL_ERROR(WM_ERR_INVALID_ARG, "(syntax error in reverb_listen_posx line)", 0);
                             WM_FreePatches();
                             free(config_dir);
                             free(line_tokens);
@@ -539,7 +539,7 @@ static int load_config(const char *config_file, const char *conf_dir) {
                     } else if (wm_strcasecmp(line_tokens[0],
                             "reverb_listener_posy") == 0) {
                         if (!line_tokens[1] || !wm_isdigit(line_tokens[1][0])) {
-                            _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_INVALID_ARG, "(syntax error in reverb_listen_posy line)", 0);
+                            _WM_GLOBAL_ERROR(WM_ERR_INVALID_ARG, "(syntax error in reverb_listen_posy line)", 0);
                             WM_FreePatches();
                             free(config_dir);
                             free(line_tokens);
@@ -565,7 +565,7 @@ static int load_config(const char *config_file, const char *conf_dir) {
                         if (_WM_patch[(patchid & 0x7F)] == NULL) {
                             _WM_patch[(patchid & 0x7F)] = (struct _patch *) malloc(sizeof(struct _patch));
                             if (_WM_patch[(patchid & 0x7F)] == NULL) {
-                                _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_MEM, NULL, errno);
+                                _WM_GLOBAL_ERROR(WM_ERR_MEM, NULL, errno);
                                 WM_FreePatches();
                                 free(config_dir);
                                 free(line_tokens);
@@ -597,7 +597,7 @@ static int load_config(const char *config_file, const char *conf_dir) {
                                     }
                                     if (tmp_patch->next == NULL) {
                                         if ((tmp_patch->next = (struct _patch *) malloc(sizeof(struct _patch))) == NULL) {
-                                            _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_MEM, NULL, 0);
+                                            _WM_GLOBAL_ERROR(WM_ERR_MEM, NULL, 0);
                                             WM_FreePatches();
                                             free(config_dir);
                                             free(line_tokens);
@@ -623,7 +623,7 @@ static int load_config(const char *config_file, const char *conf_dir) {
                                 } else {
                                     tmp_patch->next = (struct _patch *) malloc(sizeof(struct _patch));
                                     if (tmp_patch->next == NULL) {
-                                        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_MEM, NULL, errno);
+                                        _WM_GLOBAL_ERROR(WM_ERR_MEM, NULL, errno);
                                         WM_FreePatches();
                                         free(config_dir);
                                         free(line_tokens);
@@ -643,7 +643,7 @@ static int load_config(const char *config_file, const char *conf_dir) {
                             }
                         }
                         if (!line_tokens[1]) {
-                            _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_INVALID_ARG, "(missing name in patch line)", 0);
+                            _WM_GLOBAL_ERROR(WM_ERR_INVALID_ARG, "(missing name in patch line)", 0);
                             WM_FreePatches();
                             free(config_dir);
                             free(line_tokens);
@@ -652,7 +652,7 @@ static int load_config(const char *config_file, const char *conf_dir) {
                         } else if (!IS_ABSOLUTE_PATH(line_tokens[1]) && config_dir) {
                             tmp_patch->filename = (char *) malloc(strlen(config_dir) + strlen(line_tokens[1]) + 5);
                             if (tmp_patch->filename == NULL) {
-                                _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_MEM, NULL, 0);
+                                _WM_GLOBAL_ERROR(WM_ERR_MEM, NULL, 0);
                                 WM_FreePatches();
                                 free(config_dir);
                                 free(line_tokens);
@@ -663,7 +663,7 @@ static int load_config(const char *config_file, const char *conf_dir) {
                             strcat(tmp_patch->filename, line_tokens[1]);
                         } else {
                             if (!(tmp_patch->filename = wm_strdup(line_tokens[1]))) {
-                                _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_MEM, NULL, 0);
+                                _WM_GLOBAL_ERROR(WM_ERR_MEM, NULL, 0);
                                 WM_FreePatches();
                                 free(config_dir);
                                 free(line_tokens);
@@ -781,7 +781,7 @@ static int add_handle(void * handle) {
     if (first_handle == NULL) {
         first_handle = (struct _hndl *) malloc(sizeof(struct _hndl));
         if (first_handle == NULL) {
-            _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_MEM, NULL, errno);
+            _WM_GLOBAL_ERROR(WM_ERR_MEM, NULL, errno);
             return (-1);
         }
         first_handle->handle = handle;
@@ -795,7 +795,7 @@ static int add_handle(void * handle) {
         }
         tmp_handle->next = (struct _hndl *) malloc(sizeof(struct _hndl));
         if (tmp_handle->next == NULL) {
-            _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_MEM, NULL, errno);
+            _WM_GLOBAL_ERROR(WM_ERR_MEM, NULL, errno);
             return (-1);
         }
         tmp_handle->next->prev = tmp_handle;
@@ -1481,7 +1481,7 @@ WM_SYMBOL int WildMidi_ConvertToMidi (const char *file, uint8_t **out, uint32_t 
     int ret;
 
     if (!file) {
-        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_INVALID_ARG, "(NULL filename)", 0);
+        _WM_GLOBAL_ERROR(WM_ERR_INVALID_ARG, "(NULL filename)", 0);
         return (-1);
     }
     if ((buf = (uint8_t *) _WM_BufferFile(file, size)) == NULL) {
@@ -1496,7 +1496,7 @@ WM_SYMBOL int WildMidi_ConvertToMidi (const char *file, uint8_t **out, uint32_t 
 WM_SYMBOL int WildMidi_ConvertBufferToMidi (const uint8_t *in, uint32_t insize,
                                             uint8_t **out, uint32_t *outsize) {
     if (!in || !out || !outsize) {
-        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_INVALID_ARG, "(NULL params)", 0);
+        _WM_GLOBAL_ERROR(WM_ERR_INVALID_ARG, "(NULL params)", 0);
         return (-1);
     }
 
@@ -1513,11 +1513,11 @@ WM_SYMBOL int WildMidi_ConvertBufferToMidi (const uint8_t *in, uint32_t insize,
         }
     }
     else if (!memcmp(in, "MThd", 4)) {
-        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, 0, "Already a midi file", 0);
+        _WM_GLOBAL_ERROR(0, "Already a midi file", 0);
         return (-1);
     }
     else {
-        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_INVALID, NULL, 0);
+        _WM_GLOBAL_ERROR(WM_ERR_INVALID, NULL, 0);
         return (-1);
     }
 
@@ -1540,12 +1540,12 @@ WM_SYMBOL long WildMidi_GetVersion (void) {
 static int _WM_Init(const struct _WM_VIO *callbacks,
                     const char *config_file, uint16_t rate, uint16_t mixer_options) {
     if (WM_Initialized) {
-        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_ALR_INIT, NULL, 0);
+        _WM_GLOBAL_ERROR(WM_ERR_ALR_INIT, NULL, 0);
         return (-1);
     }
 
     if (config_file == NULL) {
-        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_INVALID_ARG,
+        _WM_GLOBAL_ERROR(WM_ERR_INVALID_ARG,
                 "(NULL config file pointer)", 0);
         return (-1);
     }
@@ -1559,7 +1559,7 @@ static int _WM_Init(const struct _WM_VIO *callbacks,
     }
 
     if (mixer_options & 0x0FF0) {
-        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_INVALID_ARG, "(invalid option)",
+        _WM_GLOBAL_ERROR(WM_ERR_INVALID_ARG, "(invalid option)",
                 0);
         WM_FreePatches();
         return (-1);
@@ -1567,7 +1567,7 @@ static int _WM_Init(const struct _WM_VIO *callbacks,
     _WM_MixerOptions = mixer_options;
 
     if (rate < 11025) {
-        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_INVALID_ARG,
+        _WM_GLOBAL_ERROR(WM_ERR_INVALID_ARG,
                 "(rate out of bounds, range is 11025 - 65535)", 0);
         WM_FreePatches();
         return (-1);
@@ -1589,7 +1589,7 @@ WM_SYMBOL int WildMidi_Init(const char *config_file, uint16_t rate, uint16_t mix
 
 WM_SYMBOL int WildMidi_InitVIO(struct _WM_VIO *callbacks, const char *config_file, uint16_t rate, uint16_t mixer_options) {
     if (!callbacks || !callbacks->allocate_file || !callbacks->free_file) {
-        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_INVALID_ARG, "(NULL VIO callbacks)", 0);
+        _WM_GLOBAL_ERROR(WM_ERR_INVALID_ARG, "(NULL VIO callbacks)", 0);
         return (-1);
     }
 
@@ -1598,11 +1598,11 @@ WM_SYMBOL int WildMidi_InitVIO(struct _WM_VIO *callbacks, const char *config_fil
 
 WM_SYMBOL int WildMidi_MasterVolume(uint8_t master_volume) {
     if (!WM_Initialized) {
-        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_NOT_INIT, NULL, 0);
+        _WM_GLOBAL_ERROR(WM_ERR_NOT_INIT, NULL, 0);
         return (-1);
     }
     if (master_volume > 127) {
-        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_INVALID_ARG,
+        _WM_GLOBAL_ERROR(WM_ERR_INVALID_ARG,
                 "(master volume out of range, range is 0-127)", 0);
         return (-1);
     }
@@ -1617,15 +1617,15 @@ WM_SYMBOL int WildMidi_Close(midi * handle) {
     struct _hndl * tmp_handle;
 
     if (!WM_Initialized) {
-        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_NOT_INIT, NULL, 0);
+        _WM_GLOBAL_ERROR(WM_ERR_NOT_INIT, NULL, 0);
         return (-1);
     }
     if (handle == NULL) {
-        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_INVALID_ARG, "(NULL handle)", 0);
+        _WM_GLOBAL_ERROR(WM_ERR_INVALID_ARG, "(NULL handle)", 0);
         return (-1);
     }
     if (first_handle == NULL) {
-        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_INVALID_ARG, "(no midi's open)", 0);
+        _WM_GLOBAL_ERROR(WM_ERR_INVALID_ARG, "(no midi's open)", 0);
         return (-1);
     }
     _WM_Lock(&mdi->lock);
@@ -1665,11 +1665,11 @@ WM_SYMBOL midi *WildMidi_Open(const char *midifile) {
     midi * ret = NULL;
 
     if (!WM_Initialized) {
-        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_NOT_INIT, NULL, 0);
+        _WM_GLOBAL_ERROR(WM_ERR_NOT_INIT, NULL, 0);
         return (NULL);
     }
     if (midifile == NULL) {
-        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_INVALID_ARG, "(NULL filename)", 0);
+        _WM_GLOBAL_ERROR(WM_ERR_INVALID_ARG, "(NULL filename)", 0);
         return (NULL);
     }
 
@@ -1677,7 +1677,7 @@ WM_SYMBOL midi *WildMidi_Open(const char *midifile) {
         return (NULL);
     }
     if (midisize < 18) {
-        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_CORUPT, "(too short)", 0);
+        _WM_GLOBAL_ERROR(WM_ERR_CORUPT, "(too short)", 0);
         return (NULL);
     }
     if (memcmp(mididata,"HMIMIDIP", 8) == 0) {
@@ -1709,20 +1709,20 @@ WM_SYMBOL midi *WildMidi_OpenBuffer(const uint8_t *midibuffer, uint32_t size) {
     midi * ret = NULL;
 
     if (!WM_Initialized) {
-        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_NOT_INIT, NULL, 0);
+        _WM_GLOBAL_ERROR(WM_ERR_NOT_INIT, NULL, 0);
         return (NULL);
     }
     if (midibuffer == NULL) {
-        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_INVALID_ARG, "(NULL midi data buffer)", 0);
+        _WM_GLOBAL_ERROR(WM_ERR_INVALID_ARG, "(NULL midi data buffer)", 0);
         return (NULL);
     }
     if (size > WM_MAXFILESIZE) {
         /* don't bother loading suspiciously long files */
-        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_LONGFIL, NULL, 0);
+        _WM_GLOBAL_ERROR(WM_ERR_LONGFIL, NULL, 0);
         return (NULL);
     }
     if (size < 18) {
-        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_CORUPT, "(too short)", 0);
+        _WM_GLOBAL_ERROR(WM_ERR_CORUPT, "(too short)", 0);
         return (NULL);
     }
     if (memcmp(midibuffer,"HMIMIDIP", 8) == 0) {
@@ -1753,15 +1753,15 @@ WM_SYMBOL int WildMidi_FastSeek(midi * handle, unsigned long int *sample_pos) {
     struct _note *note_data;
 
     if (!WM_Initialized) {
-        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_NOT_INIT, NULL, 0);
+        _WM_GLOBAL_ERROR(WM_ERR_NOT_INIT, NULL, 0);
         return (-1);
     }
     if (handle == NULL) {
-        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_INVALID_ARG, "(NULL handle)", 0);
+        _WM_GLOBAL_ERROR(WM_ERR_INVALID_ARG, "(NULL handle)", 0);
         return (-1);
     }
     if (sample_pos == NULL) {
-        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_INVALID_ARG, "(NULL seek position pointer)", 0);
+        _WM_GLOBAL_ERROR(WM_ERR_INVALID_ARG, "(NULL seek position pointer)", 0);
         return (-1);
     }
 
@@ -1846,23 +1846,23 @@ WM_SYMBOL int WildMidi_SongSeek (midi * handle, int8_t nextsong) {
     struct _note *note_data;
 
     if (!WM_Initialized) {
-        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_NOT_INIT, NULL, 0);
+        _WM_GLOBAL_ERROR(WM_ERR_NOT_INIT, NULL, 0);
         return (-1);
     }
     if (handle == NULL) {
-        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_INVALID_ARG, "(NULL handle)", 0);
+        _WM_GLOBAL_ERROR(WM_ERR_INVALID_ARG, "(NULL handle)", 0);
         return (-1);
     }
     mdi = (struct _mdi *) handle;
     _WM_Lock(&mdi->lock);
 
     if ((!mdi->is_type2) && (nextsong != 0)) {
-        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_INVALID_ARG, "(Illegal use. Only usable with files detected to be type 2 compatible.", 0);
+        _WM_GLOBAL_ERROR(WM_ERR_INVALID_ARG, "(Illegal use. Only usable with files detected to be type 2 compatible.", 0);
         _WM_Unlock(&mdi->lock);
         return (-1);
     }
     if ((nextsong > 1) || (nextsong < -1)) {
-        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_INVALID_ARG, "(Invalid nextsong: -1 is previous song, 0 is start of current song, 1 is next song)", 0);
+        _WM_GLOBAL_ERROR(WM_ERR_INVALID_ARG, "(Invalid nextsong: -1 is previous song, 0 is start of current song, 1 is next song)", 0);
         _WM_Unlock(&mdi->lock);
         return (-1);
     }
@@ -1950,22 +1950,22 @@ WM_SYMBOL int WildMidi_SongSeek (midi * handle, int8_t nextsong) {
 
 WM_SYMBOL int WildMidi_GetOutput(midi * handle, int8_t *buffer, uint32_t size) {
     if (__builtin_expect((!WM_Initialized), 0)) {
-        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_NOT_INIT, NULL, 0);
+        _WM_GLOBAL_ERROR(WM_ERR_NOT_INIT, NULL, 0);
         return (-1);
     }
     if (__builtin_expect((handle == NULL), 0)) {
-        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_INVALID_ARG, "(NULL handle)", 0);
+        _WM_GLOBAL_ERROR(WM_ERR_INVALID_ARG, "(NULL handle)", 0);
         return (-1);
     }
     if (__builtin_expect((buffer == NULL), 0)) {
-        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_INVALID_ARG, "(NULL buffer pointer)", 0);
+        _WM_GLOBAL_ERROR(WM_ERR_INVALID_ARG, "(NULL buffer pointer)", 0);
         return (-1);
     }
     if (__builtin_expect((size == 0), 0)) {
         return (0);
     }
     if (__builtin_expect((!!(size % 4)), 0)) {
-        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_INVALID_ARG, "(size not a multiple of 4)", 0);
+        _WM_GLOBAL_ERROR(WM_ERR_INVALID_ARG, "(size not a multiple of 4)", 0);
         return (-1);
     }
 
@@ -1978,15 +1978,15 @@ WM_SYMBOL int WildMidi_GetOutput(midi * handle, int8_t *buffer, uint32_t size) {
 
 WM_SYMBOL int WildMidi_GetMidiOutput(midi * handle, int8_t **buffer, uint32_t *size) {
     if (__builtin_expect((!WM_Initialized), 0)) {
-        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_NOT_INIT, NULL, 0);
+        _WM_GLOBAL_ERROR(WM_ERR_NOT_INIT, NULL, 0);
         return (-1);
     }
     if (__builtin_expect((handle == NULL), 0)) {
-        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_INVALID_ARG, "(NULL handle)", 0);
+        _WM_GLOBAL_ERROR(WM_ERR_INVALID_ARG, "(NULL handle)", 0);
         return (-1);
     }
     if (__builtin_expect((buffer == NULL), 0)) {
-        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_INVALID_ARG, "(NULL buffer pointer)", 0);
+        _WM_GLOBAL_ERROR(WM_ERR_INVALID_ARG, "(NULL buffer pointer)", 0);
         return (-1);
     }
     return _WM_Event2Midi((struct _mdi *)handle, (uint8_t **)buffer, size);
@@ -1997,23 +1997,23 @@ WM_SYMBOL int WildMidi_SetOption(midi * handle, uint16_t options, uint16_t setti
     struct _mdi *mdi;
 
     if (!WM_Initialized) {
-        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_NOT_INIT, NULL, 0);
+        _WM_GLOBAL_ERROR(WM_ERR_NOT_INIT, NULL, 0);
         return (-1);
     }
     if (handle == NULL) {
-        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_INVALID_ARG, "(NULL handle)", 0);
+        _WM_GLOBAL_ERROR(WM_ERR_INVALID_ARG, "(NULL handle)", 0);
         return (-1);
     }
 
     mdi = (struct _mdi *) handle;
     _WM_Lock(&mdi->lock);
     if ((!(options & 0x800F)) || (options & 0x7FF0)) {
-        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_INVALID_ARG, "(invalid option)", 0);
+        _WM_GLOBAL_ERROR(WM_ERR_INVALID_ARG, "(invalid option)", 0);
         _WM_Unlock(&mdi->lock);
         return (-1);
     }
     if (setting & 0x7FF0) {
-        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_INVALID_ARG, "(invalid setting)", 0);
+        _WM_GLOBAL_ERROR(WM_ERR_INVALID_ARG, "(invalid setting)", 0);
         _WM_Unlock(&mdi->lock);
         return (-1);
     }
@@ -2042,7 +2042,7 @@ WM_SYMBOL int WildMidi_SetCvtOption(uint16_t tag, uint16_t setting) {
         WM_ConvertOptions.frequency = setting;
         break;
     default:
-        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_INVALID_ARG, "(invalid setting)", 0);
+        _WM_GLOBAL_ERROR(WM_ERR_INVALID_ARG, "(invalid setting)", 0);
         _WM_Unlock(&WM_ConvertOptions.lock);
         return (-1);
     }
@@ -2054,18 +2054,18 @@ WM_SYMBOL struct _WM_Info *
 WildMidi_GetInfo(midi * handle) {
     struct _mdi *mdi = (struct _mdi *) handle;
     if (!WM_Initialized) {
-        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_NOT_INIT, NULL, 0);
+        _WM_GLOBAL_ERROR(WM_ERR_NOT_INIT, NULL, 0);
         return (NULL);
     }
     if (handle == NULL) {
-        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_INVALID_ARG, "(NULL handle)", 0);
+        _WM_GLOBAL_ERROR(WM_ERR_INVALID_ARG, "(NULL handle)", 0);
         return (NULL);
     }
     _WM_Lock(&mdi->lock);
     if (mdi->tmp_info == NULL) {
         mdi->tmp_info = (struct _WM_Info *) malloc(sizeof(struct _WM_Info));
         if (mdi->tmp_info == NULL) {
-            _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_MEM, NULL, 0);
+            _WM_GLOBAL_ERROR(WM_ERR_MEM, NULL, 0);
             _WM_Unlock(&mdi->lock);
             return (NULL);
         }
@@ -2081,7 +2081,7 @@ WildMidi_GetInfo(midi * handle) {
         if (mdi->tmp_info->copyright == NULL) {
             free(mdi->tmp_info);
             mdi->tmp_info = NULL;
-            _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_MEM, NULL, 0);
+            _WM_GLOBAL_ERROR(WM_ERR_MEM, NULL, 0);
             _WM_Unlock(&mdi->lock);
             return (NULL);
         } else {
@@ -2096,7 +2096,7 @@ WildMidi_GetInfo(midi * handle) {
 
 WM_SYMBOL int WildMidi_Shutdown(void) {
     if (!WM_Initialized) {
-        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_NOT_INIT, NULL, 0);
+        _WM_GLOBAL_ERROR(WM_ERR_NOT_INIT, NULL, 0);
         return (-1);
     }
     while (first_handle) {
@@ -2150,11 +2150,11 @@ WM_SYMBOL char * WildMidi_GetLyric (midi * handle) {
     char * lyric = NULL;
 
     if (!WM_Initialized) {
-        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_NOT_INIT, NULL, 0);
+        _WM_GLOBAL_ERROR(WM_ERR_NOT_INIT, NULL, 0);
         return (NULL);
     }
     if (handle == NULL) {
-        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_INVALID_ARG, "(NULL handle)", 0);
+        _WM_GLOBAL_ERROR(WM_ERR_INVALID_ARG, "(NULL handle)", 0);
         return (NULL);
     }
     _WM_Lock(&mdi->lock);

--- a/src/wm_error.c
+++ b/src/wm_error.c
@@ -67,7 +67,7 @@ static const char *errors[WM_ERR_MAX+1] = {
 char * _WM_Global_ErrorS = NULL;
 int _WM_Global_ErrorI = 0;
 
-void _WM_GLOBAL_ERROR(const char *func, int lne, int wmerno, const char *wmfor, int error) {
+void _WM_GLOBAL_ERROR_INTERNAL(const char *func, int lne, int wmerno, const char *wmfor, int error) {
 
     char *errorstring;
 

--- a/src/xmi2mid.c
+++ b/src/xmi2mid.c
@@ -469,7 +469,7 @@ int _WM_xmi2midi(const uint8_t *in, uint32_t insize,
     int ret = -1;
 
     if (convert_type > XMIDI_CONVERT_MT32_TO_GS) {
-        _WM_ERROR_NEW("%s:%i:  %d is an invalid conversion type.", __FUNCTION__, __LINE__, convert_type);
+        _WM_ERROR_NEW("%s:%i:  %d is an invalid conversion type.", _WM_FUNCTION, __LINE__, convert_type);
         return (ret);
     }
 
@@ -479,12 +479,12 @@ int _WM_xmi2midi(const uint8_t *in, uint32_t insize,
     ctx.convert_type = convert_type;
 
     if (ParseXMI(&ctx) < 0) {
-        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_NOT_XMI, NULL, 0);
+        _WM_GLOBAL_ERROR(WM_ERR_NOT_XMI, NULL, 0);
         goto _end;
     }
 
     if (ExtractTracks(&ctx) < 0) {
-        _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_NOT_MIDI, NULL, 0);
+        _WM_GLOBAL_ERROR(WM_ERR_NOT_MIDI, NULL, 0);
         goto _end;
     }
 
@@ -914,7 +914,7 @@ static uint32_t ConvertListToMTrk(struct xmi_ctx *ctx, midi_event *mlist) {
 
         /* Never occur */
         default:
-            _WM_DEBUG_MSG("%s: unrecognized event", __FUNCTION__);
+            _WM_DEBUG_MSG("%s: unrecognized event", _WM_FUNCTION);
             break;
         }
     }
@@ -957,7 +957,7 @@ static uint32_t ExtractTracksFromXmi(struct xmi_ctx *ctx) {
 
         /* Convert it */
         if (!(ppqn = ConvertFiletoList(ctx))) {
-            _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_CORUPT, NULL, 0);
+            _WM_GLOBAL_ERROR(WM_ERR_CORUPT, NULL, 0);
             break;
         }
         ctx->timing[num] = ppqn;
@@ -984,7 +984,7 @@ static int ParseXMI(struct xmi_ctx *ctx) {
 
     file_size = getsrcsize(ctx);
     if (getsrcpos(ctx) + 8 > file_size) {
-badfile:    _WM_GLOBAL_ERROR(__FUNCTION__, __LINE__, WM_ERR_CORUPT, "(too short)", 0);
+badfile:    _WM_GLOBAL_ERROR(WM_ERR_CORUPT, "(too short)", 0);
         return (-1);
     }
 


### PR DESCRIPTION
Compiling WildMIDI as ANSI C with GCC and with warnings enabled causes many warning messages to be printed which complain about `__FUNCTION__` not existing in C89. This commit works around the issue by only using it when compiling as C99 or newer. In C89, the function string is simply dummied-out instead.

While I was at it, I used some macro magic to hide most uses of `__FUNCTION__` and `__LINE__`.