### PR TITLE
Fix various typos

### DIFF
--- a/cmake/Toolchain-MinGW32.cmake
+++ b/cmake/Toolchain-MinGW32.cmake
@@ -1,5 +1,5 @@
 # toolchain file I use to cross compile on Linux
-# targetting Windows (x86/mingw). running:
+# targeting Windows (x86/mingw). running:
 # cmake -DCMAKE_TOOLCHAIN_FILE=/path/to/Toolchain-MinGW32.cmake ....
 
 SET(CMAKE_SYSTEM_NAME Windows)

--- a/cmake/Toolchain-MinGW64.cmake
+++ b/cmake/Toolchain-MinGW64.cmake
@@ -1,5 +1,5 @@
 # toolchain file I use to cross compile on Linux
-# targetting Windows (x64/mingw-w64). running:
+# targeting Windows (x64/mingw-w64). running:
 # cmake -DCMAKE_TOOLCHAIN_FILE=/path/to/Toolchain-MinGW64.cmake ....
 
 SET(CMAKE_SYSTEM_NAME Windows)

--- a/cmake/Toolchain-OSX-ppc.cmake
+++ b/cmake/Toolchain-OSX-ppc.cmake
@@ -1,5 +1,5 @@
 # toolchain file I use to cross compile on Linux
-# targetting OSX/Darwin (powerpc). running:
+# targeting OSX/Darwin (powerpc). running:
 # cmake -DCMAKE_TOOLCHAIN_FILE=/path/to/Toolchain-OSX-ppc.cmake ....
 
 SET(CMAKE_SYSTEM_NAME Darwin)

--- a/cmake/Toolchain-OSX-x86.cmake
+++ b/cmake/Toolchain-OSX-x86.cmake
@@ -1,5 +1,5 @@
 # toolchain file I use to cross compile on Linux
-# targetting OSX/Darwin (x86). running:
+# targeting OSX/Darwin (x86). running:
 # cmake -DCMAKE_TOOLCHAIN_FILE=/path/to/Toolchain-OSX-x86.cmake ....
 
 SET(CMAKE_SYSTEM_NAME Darwin)

--- a/cmake/Toolchain-OSX-x86_64.cmake
+++ b/cmake/Toolchain-OSX-x86_64.cmake
@@ -1,5 +1,5 @@
 # toolchain file I use to cross compile on Linux
-# targetting OSX/Darwin (x86_64). running:
+# targeting OSX/Darwin (x86_64). running:
 # cmake -DCMAKE_TOOLCHAIN_FILE=/path/to/Toolchain-OSX-x86_64.cmake ....
 
 SET(CMAKE_SYSTEM_NAME Darwin)

--- a/include/internal_midi.h
+++ b/include/internal_midi.h
@@ -218,7 +218,7 @@ extern void _WM_do_meta_marker(struct _mdi *mdi, struct _event_data *data);
 extern void _WM_do_meta_cuepoint(struct _mdi *mdi, struct _event_data *data);
 
 /*
- * We need to expose these fuctions for use on some or the parsers due to some
+ * We need to expose these functions for use on some or the parsers due to some
  * formats not being able to trigger these events via _WM_Setup_Midi_Event.
  */
 extern int _WM_midi_setup_noteoff(struct _mdi *mdi, uint8_t channel, uint8_t note, uint8_t velocity);

--- a/include/wildmidi_lib.h
+++ b/include/wildmidi_lib.h
@@ -50,7 +50,7 @@
 /* for WildMidi_GetString */
 #define WM_GS_VERSION           0x0001
 
-/* set our symbol export visiblity */
+/* set our symbol export visibility */
 #if defined _WIN32 || defined __CYGWIN__
   /* ========== NOTE TO WINDOWS DEVELOPERS:
    * If you are compiling for Windows and will link to the static library
@@ -146,7 +146,7 @@ WM_SYMBOL void WildMidi_ClearError (void);
 
 /* NOTE: Not Yet Implemented Or Tested Properly */
 /* Due to delay in audio output in the player, this is not being developed
-   futher at the moment. Further Development will occur when output latency
+   further at the moment. Further Development will occur when output latency
    has been reduced enough to "appear" instant.
 WM_SYMBOL int WildMidi_Live (midi * handle, uint32_t midi_event);
  */

--- a/src/DevTest.c
+++ b/src/DevTest.c
@@ -267,7 +267,7 @@ static int check_midi_event (unsigned char *midi_data, unsigned long int midi_si
             printf("Expected MIDI event\n");
             return -1;
         }
-/*      printf("Unsing running event 0x%2x\n", running_event); */
+/*      printf("Using running event 0x%2x\n", running_event); */
     } else {
         event = *midi_data++;
         midi_size--;
@@ -851,10 +851,10 @@ static int8_t test_mus(unsigned char * mus_data, unsigned long mus_size, uint32_
                         case 11:
                             printf("All Notes Off\n");
                             break;
-                        case 12: /* Not supported by WildMidi. Parsed for compatability */
+                        case 12: /* Not supported by WildMidi. Parsed for compatibility */
                             printf("Mono\n");
                             break;
-                        case 13:  /* Not supported by WildMidi. Parsed for compatability */
+                        case 13:  /* Not supported by WildMidi. Parsed for compatibility */
                             printf("Poly\n");
                             break;
                         case 14:
@@ -1744,7 +1744,7 @@ static int test_midi(unsigned char * midi_data, unsigned long int midi_size,
                 if ((midi_type == 1) && (i != 0)) {
                     /*
                      * since type 1 midi's store tempo info on first track
-                     * we only need to do this check for subsiquent tracks.
+                     * we only need to do this check for subsequent tracks.
                      */
                     if ((changeTempoOfs == 0) || changeTempoAtTick[changeTempoOfs][0] > 0) {
                         if (changeTempoAtTick[changeTempoOfs][0] <= delta_accum) {
@@ -1770,7 +1770,7 @@ static int test_midi(unsigned char * midi_data, unsigned long int midi_size,
 
             if (*midi_data < 0x80) {
                 if (running_event == 0) {
-                    printf("Currupt Midi: expected event, got data\n");
+                    printf("Corrupt Midi: expected event, got data\n");
                     printf("%.4x %.2x %.2x %.2x %.2x\n", total_count, midi_data[0], midi_data[1], midi_data[2], midi_data[3]);
                     return -1;
                 }
@@ -1833,7 +1833,7 @@ static int test_midi(unsigned char * midi_data, unsigned long int midi_size,
                 unsigned char *tmp_ptr = midi_data + check_ret;
 
                 if (tmp_ptr > next_track) {
-                    printf("Corrupt Midi, Track Data went beyond track boundries.\n");
+                    printf("Corrupt Midi, Track Data went beyond track boundaries.\n");
                     return -1;
                 }
 
@@ -1847,7 +1847,7 @@ static int test_midi(unsigned char * midi_data, unsigned long int midi_size,
                      */
                     midi_data = next_track;
                 } else if (midi_size == 0) {
-                    printf("Corrupt Midi, Track Data went beyond track boundries.\n");
+                    printf("Corrupt Midi, Track Data went beyond track boundaries.\n");
                     return -1;
                 } else {
                     midi_data += check_ret;

--- a/src/f_midi.c
+++ b/src/f_midi.c
@@ -457,7 +457,7 @@ _end:   free(sysex_store);
  NOTE: This will only write out events that we do support.
 
  *** CAUTION ***
- This will output type 0 midi file reguardless of the original file type.
+ This will output type 0 midi file regardless of the original file type.
  Type 2 midi files will have each original track play on the same track one
  after the other in the type 0 file.
  */

--- a/src/gus_pat.c
+++ b/src/gus_pat.c
@@ -801,7 +801,7 @@ struct _sample * _WM_load_gus_pat(const char *filename, int fix_release) {
                                 |  gus_patch[gus_ptr + 30];
 
         /* This is done this way instead of ((freq * 1024) / rate) to avoid 32bit overflow. */
-        /* Result is 0.001% inacurate */
+        /* Result is 0.001% inaccurate */
         gus_sample->inc_div = ((gus_sample->freq_root * 512) / gus_sample->rate) * 2;
 
 #if 0

--- a/src/wildmidi_lib.c
+++ b/src/wildmidi_lib.c
@@ -1769,7 +1769,7 @@ WM_SYMBOL int WildMidi_FastSeek(midi * handle, unsigned long int *sample_pos) {
     _WM_Lock(&mdi->lock);
     event = mdi->current_event;
 
-    /* make sure we havent asked for a positions beyond the end of the song. */
+    /* make sure we haven't asked for a positions beyond the end of the song. */
     if (*sample_pos > mdi->extra_info.approx_total_samples) {
         /* if so set the position to the end of the song */
         *sample_pos = mdi->extra_info.approx_total_samples;
@@ -2142,7 +2142,7 @@ WM_SYMBOL int WildMidi_Shutdown(void) {
     Cleanup is done by the lib.
 
     Once WildMidi_GetLyric is called it will return NULL
-    on subsiquent calls until the next lyric event is processed
+    on subsequent calls until the next lyric event is processed
     during a WildMidi_GetOutput call.
  */
 WM_SYMBOL char * WildMidi_GetLyric (midi * handle) {


### PR DESCRIPTION
Found via `codespell -q 3 -L nam,pres,siz`