### PR TITLE
Fix build failures with MSVC.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,16 +19,6 @@ INCLUDE(CheckIncludeFile)
 INCLUDE(GNUInstallDirs)
 INCLUDE(TestBigEndian)
 
-# Set a default build type if none was specified
-IF (NOT DEFINED CMAKE_BUILD_TYPE OR CMAKE_BUILD_TYPE STREQUAL "")
-    MESSAGE(STATUS "Setting build type to 'Debug' as none was specified.")
-    SET(CMAKE_BUILD_TYPE Debug CACHE STRING "Choose the type of build." FORCE)
-    # Set the possible values of build type for cmake-gui
-    SET_PROPERTY(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS "Debug" "Release" "MinSizeRel" "RelWithDebInfo")
-ENDIF ()
-SET(CMAKE_CONFIGURATION_TYPES "${CMAKE_BUILD_TYPE}")
-MESSAGE(STATUS "Build Type: ${CMAKE_BUILD_TYPE}")
-
 # Set our options
 OPTION(BUILD_SHARED_LIBS "Build a dynamic wildmidi library" ON)
 OPTION(WANT_PLAYER "Build WildMIDI player in addition to the libraries" ON)
@@ -270,8 +260,6 @@ ENDIF (APPLE)
 
 IF (APPLE)
     SET(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${APP_BUNDLE_DIR}/Contents/MacOS")
-ELSE (APPLE)
-    SET(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${wildmidi_BINARY_DIR}")
 ENDIF (APPLE)
 
 # Setup up our config file

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -268,12 +268,6 @@ IF (WIN32 AND MSVC)
         SET(MT_BUILD "/MP")
     ENDIF ()
 
-    foreach (OUTPUTCONFIG ${CMAKE_CONFIGURATION_TYPES})
-        STRING(TOUPPER ${OUTPUTCONFIG} OUTPUTCONFIG)
-        SET(CMAKE_RUNTIME_OUTPUT_DIRECTORY_${OUTPUTCONFIG} "$(SolutionDir)$(Configuration)")
-        SET(CMAKE_LIBRARY_OUTPUT_DIRECTORY_${OUTPUTCONFIG} "$(ProjectDir)$(Configuration)")
-    endforeach (OUTPUTCONFIG)
-
     IF (WANT_PLAYER)
         # Release builds use the debug console
         SET_TARGET_PROPERTIES(wildmidi PROPERTIES LINK_FLAGS_RELEASE "/SUBSYSTEM:CONSOLE")


### PR DESCRIPTION
In my Doom source-port, I use WildMIDI as a CMake subproject. When running CMake for the first time, targetting MSVC, I do not set `CMAKE_BUILD_TYPE` as MSVC uses a multi-configuration generator, meaning that it should have no effect. However, if I make MSVC attempt to compile a Release build, it will fail, claiming that the WildMIDI binary could not be found. This seems to be caused by an odd combination of things:

WildMIDI detects that `CMAKE_BUILD_TYPE` is not set, forcefully sets it to 'Debug', and then sets `CMAKE_CONFIGURATION_TYPES` to match it, which presumably disables every other build type for multi-configuration generators.

This state-mutilation should be unnecessary, as the setting (or lack thereof) of `CMAKE_BUILD_TYPE` should have no effect on multi-configuration generators in the first place. Likewise, forcing `CMAKE_BUILD_TYPE` to 'Debug' in the absense of an explicit value is overbearing, as it is desirable to build software with no particular build type, as it causes the minimum amount of compiler flags to be automatically added by CMake. Notably, Arch Linux relies on this, opting instead to manually provide its own compiler flags for optimisations and hardening.

https://wiki.archlinux.org/title/CMake_package_guidelines#CMake_can_automatically_override_the_default_compiler_optimization_flag

Later on, `CMAKE_RUNTIME_OUTPUT_DIRECTORY` is redundantly set to the `wildmidi_BINARY_DIR` variable. This causes the
automatically-generated per-configuration `CMAKE_RUNTIME_OUTPUT_DIRECTORY_[CONFIG]` variables to become undefined.

Finally, in an apparent attempt to counteract the above bug, the per-configuration `CMAKE_RUNTIME_OUTPUT_DIRECTORY_[CONFIG]` variables are manually redefined, using `CMAKE_CONFIGURATION_TYPES`. Because `CMAKE_CONFIGURATION_TYPES` was forcefully set earlier, however, it only contains 'Debug', causing only the Debug configuration to have a valid output directory set. This causes all other configurations to fail to produce a binary, resulting in a build failure as the binary cannot be linked.

Personally, my rule-of-thumb is to keep CMake scripts as simple as possible and trust that CMake has sane defaults. Seeing redundant logic like this strikes me as a code smell, and this bug seems to validate that.