### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,6 +2,9 @@ name: build
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     strategy:


### PR DESCRIPTION
Potential fix for [https://github.com/Mindwerks/wildmidi/security/code-scanning/3](https://github.com/Mindwerks/wildmidi/security/code-scanning/3)

Add an explicit `permissions` block to `.github/workflows/main.yml` at the workflow root so it applies to all jobs.  
For this workflow, the minimal safe setting is:

- `contents: read`

This preserves current functionality (`actions/checkout` and artifact upload continue to work) while ensuring the token cannot write unless explicitly granted later. The best single change is to insert this block after the `on:` declaration and before `jobs:`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build workflow permissions to use read-only repository access. This improves security without changing app behavior or user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->