### PR TITLE
Potential fix for code scanning alert no. 5: Time-of-check time-of-use filesystem race condition

### DIFF
--- a/src/DevTest.c
+++ b/src/DevTest.c
@@ -188,18 +188,6 @@ DT_BufferFile(const char *filename, unsigned long int *size) {
         strcpy(buffer_file, filename);
     }
 
-    if (stat(buffer_file, &buffer_stat)) {
-        printf("Unable to stat %s: %s\n", filename, strerror(errno));
-        free(buffer_file);
-        return NULL;
-    }
-    *size = buffer_stat.st_size;
-    data = malloc(*size);
-    if (data == NULL) {
-        printf("Unable to get ram for %s: %s\n", filename, strerror(errno));
-        free(buffer_file);
-        return NULL;
-    }
 #ifdef _WIN32
     if ((buffer_fd = open(buffer_file,(O_RDONLY | O_BINARY))) == -1) {
 #else
@@ -207,7 +195,20 @@ DT_BufferFile(const char *filename, unsigned long int *size) {
 #endif
         printf("Unable to open %s: %s\n", filename, strerror(errno));
         free(buffer_file);
-        free(data);
+        return NULL;
+    }
+    if (fstat(buffer_fd, &buffer_stat)) {
+        printf("Unable to stat %s: %s\n", filename, strerror(errno));
+        free(buffer_file);
+        close(buffer_fd);
+        return NULL;
+    }
+    *size = buffer_stat.st_size;
+    data = malloc(*size);
+    if (data == NULL) {
+        printf("Unable to get ram for %s: %s\n", filename, strerror(errno));
+        free(buffer_file);
+        close(buffer_fd);
         return NULL;
     }
     if (read(buffer_fd, data, *size) != buffer_stat.st_size) {


### PR DESCRIPTION
Potential fix for [https://github.com/Mindwerks/wildmidi/security/code-scanning/5](https://github.com/Mindwerks/wildmidi/security/code-scanning/5)

General fix: avoid path-based check-then-use flows. Open the file first, then perform metadata checks (`fstat`) and reads via the same file descriptor so all operations apply to the same object.

Best targeted fix in `src/DevTest.c` (in the shown function region around lines 191–214):
- Remove the pre-open `stat(buffer_file, &buffer_stat)` block.
- Open `buffer_file` first (existing `open` code already there).
- Immediately call `fstat(buffer_fd, &buffer_stat)` and use that result for `*size` and allocation.
- Keep existing behavior otherwise (same errors, memory cleanup style, and read logic).

No new dependencies are needed. `fstat` is already available via existing headers on both Unix and Windows CRT mappings used here.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
