### PR TITLE
support spaces in config using quoted strings

### DIFF
--- a/.github/workflows/bsd.yml
+++ b/.github/workflows/bsd.yml
@@ -52,6 +52,7 @@ jobs:
             -DWANT_PLAYER=ON -DWANT_STATIC=ON \
             ${{ matrix.platform.cmake_opts }}
           cmake --build build --config Release
+          ctest --test-dir build --output-on-failure
           cmake --install build
 
     - uses: actions/upload-artifact@v4

--- a/.github/workflows/bsd.yml
+++ b/.github/workflows/bsd.yml
@@ -39,7 +39,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Build
-      uses: cross-platform-actions/action@v0.29.0
+      uses: cross-platform-actions/action@v1.3.0
       with:
         operating_system: ${{ matrix.platform.os }}
         architecture: ${{ matrix.platform.os-arch }}

--- a/.github/workflows/bsd.yml
+++ b/.github/workflows/bsd.yml
@@ -1,6 +1,9 @@
 name: bsd
 
-on: [push, pull_request]
+on:
+  push:
+    branches: [master]
+  pull_request:
 
 permissions:
   contents: read
@@ -20,7 +23,7 @@ jobs:
         platform:
           - { name: FreeBSD,  os: freebsd,  os-version: 14.3, os-arch: x86-64,
               cmake_opts: '-DWANT_OSS=ON',
-              setup_cmd: 'sudo pkg update',
+              setup_cmd: 'sudo env IGNORE_OSVERSION=yes pkg update',
               install_cmd: 'sudo pkg install -y cmake',
             }
           - { name: OpenBSD,  os: openbsd, os-version: 7.7,  os-arch: x86-64,

--- a/.github/workflows/bsd.yml
+++ b/.github/workflows/bsd.yml
@@ -21,12 +21,12 @@ jobs:
       fail-fast: false
       matrix:
         platform:
-          - { name: FreeBSD,  os: freebsd,  os-version: 14.3, os-arch: x86-64,
+          - { name: FreeBSD,  os: freebsd,  os-version: 14.4, os-arch: x86-64,
               cmake_opts: '-DWANT_OSS=ON',
-              setup_cmd: 'sudo env IGNORE_OSVERSION=yes pkg update',
+              setup_cmd: 'sudo pkg update',
               install_cmd: 'sudo pkg install -y cmake',
             }
-          - { name: OpenBSD,  os: openbsd, os-version: 7.7,  os-arch: x86-64,
+          - { name: OpenBSD,  os: openbsd, os-version: 7.9,  os-arch: x86-64,
               cmake_opts: '-DWANT_SNDIO=ON',
               setup_cmd: 'sudo pkg_add -u',
               install_cmd: 'sudo pkg_add cmake',
@@ -39,7 +39,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Build
-      uses: cross-platform-actions/action@v1.3.0
+      uses: cross-platform-actions/action@v1
       with:
         operating_system: ${{ matrix.platform.os }}
         architecture: ${{ matrix.platform.os-arch }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,9 @@
 name: build
 
-on: [push, pull_request]
+on:
+  push:
+    branches: [master]
+  pull_request:
 
 permissions:
   contents: read

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -48,6 +48,7 @@ jobs:
         run: |
           cmake -B build ${{ matrix.config.cmake_opts }} -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=build/out
           cmake --build build -j2 --config Release
+          ctest --test-dir build --output-on-failure -C Release
           cmake --install build
       - name: Upload artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/os2.yml
+++ b/.github/workflows/os2.yml
@@ -1,6 +1,9 @@
 name: Build (OS/2)
 
-on: [push, pull_request]
+on:
+  push:
+    branches: [master]
+  pull_request:
 
 permissions:
   contents: read

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,10 @@
 # build dirs
 build/
 
+# stray in-source cmake configure (should always use -B build)
+CMakeCache.txt
+CMakeFiles/
+
 # logs and other texts #
 *.log
 

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@
 *.a
 *.exe
 
+# build dirs
+build/
+
 # logs and other texts #
 *.log
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -303,3 +303,8 @@ ENDIF()
 CONFIGURE_FILE("${PROJECT_SOURCE_DIR}/include/config.h.cmake" "${PROJECT_BINARY_DIR}/include/config.h")
 
 ADD_SUBDIRECTORY(src)
+
+INCLUDE(CTest)
+IF (BUILD_TESTING)
+    ADD_SUBDIRECTORY(test)
+ENDIF()

--- a/src/wildmidi_lib.c
+++ b/src/wildmidi_lib.c
@@ -324,7 +324,22 @@ static char** WM_LC_Tokenize_Line(char *line_data) {
             /* double quotes toggle a "literal-whitespace" mode so paths like
              * `dir "/Users/foo/Application Support/patches"` parse as one
              * token. The quote characters themselves are stripped via the
-             * write_ofs compaction below. */
+             * write_ofs compaction below. Opening a quote also starts a
+             * token so an empty quoted string ("") still yields a token. */
+            if (!token_start) {
+                token_start = 1;
+                if (token_count >= token_data_length) {
+                    token_data_length += TOKEN_CNT_INC;
+                    token_data = (char **) realloc(token_data, token_data_length * sizeof(char *));
+                    if (token_data == NULL) {
+                        _WM_GLOBAL_ERROR(WM_ERR_MEM, NULL, errno);
+                        return (NULL);
+                    }
+                }
+
+                token_data[token_count] = &line_data[write_ofs];
+                token_count++;
+            }
             in_quotes = !in_quotes;
         } else if ((c == ' ' || c == '\t') && !in_quotes) {
             /* whitespace means we aren't in a token */
@@ -352,6 +367,10 @@ static char** WM_LC_Tokenize_Line(char *line_data) {
         }
         line_ofs++;
     } while (line_ofs != line_length);
+
+    if (in_quotes) {
+        _WM_DEBUG_MSG("config line has an unterminated quote: %s", line_data);
+    }
 
     /* terminate the final token when the line didn't end with whitespace */
     if (write_ofs < line_length) {

--- a/src/wildmidi_lib.c
+++ b/src/wildmidi_lib.c
@@ -304,23 +304,33 @@ static char** WM_LC_Tokenize_Line(char *line_data) {
     int line_length = (int) strlen(line_data);
     int token_data_length = 0;
     int line_ofs = 0;
+    int write_ofs = 0;
     int token_start = 0;
+    int in_quotes = 0;
     char **token_data = NULL;
     int token_count = 0;
 
     if (!line_length) return (NULL);
 
     do {
-        /* ignore everything after #  */
-        if (line_data[line_ofs] == '#') {
+        char c = line_data[line_ofs];
+
+        /* ignore everything after # (outside of quotes) */
+        if (c == '#' && !in_quotes) {
             break;
         }
 
-        if ((line_data[line_ofs] == ' ') || (line_data[line_ofs] == '\t')) {
+        if (c == '"') {
+            /* double quotes toggle a "literal-whitespace" mode so paths like
+             * `dir "/Users/foo/Application Support/patches"` parse as one
+             * token. The quote characters themselves are stripped via the
+             * write_ofs compaction below. */
+            in_quotes = !in_quotes;
+        } else if ((c == ' ' || c == '\t') && !in_quotes) {
             /* whitespace means we aren't in a token */
             if (token_start) {
                 token_start = 0;
-                line_data[line_ofs] = '\0';
+                line_data[write_ofs++] = '\0';
             }
         } else {
             if (!token_start) {
@@ -335,12 +345,18 @@ static char** WM_LC_Tokenize_Line(char *line_data) {
                     }
                 }
 
-                token_data[token_count] = &line_data[line_ofs];
+                token_data[token_count] = &line_data[write_ofs];
                 token_count++;
             }
+            line_data[write_ofs++] = c;
         }
         line_ofs++;
     } while (line_ofs != line_length);
+
+    /* terminate the final token when the line didn't end with whitespace */
+    if (write_ofs < line_length) {
+        line_data[write_ofs] = '\0';
+    }
 
     /* if we have found some tokens then add a null token to the end */
     if (token_count) {

--- a/src/wildmidi_lib.c
+++ b/src/wildmidi_lib.c
@@ -300,7 +300,8 @@ static int wm_strncasecmp(const char *s1, const char *s2, size_t n) {
 }
 
 #define TOKEN_CNT_INC 8
-static char** WM_LC_Tokenize_Line(char *line_data) {
+/* not static: exposed for test/test_tokenize.c */
+char** WM_LC_Tokenize_Line(char *line_data) {
     int line_length = (int) strlen(line_data);
     int token_data_length = 0;
     int line_ofs = 0;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,3 +1,3 @@
 ADD_EXECUTABLE(test_tokenize test_tokenize.c)
-TARGET_LINK_LIBRARIES(test_tokenize libwildmidi-static)
+TARGET_LINK_LIBRARIES(test_tokenize libwildmidi-static ${M_LIBRARY})
 ADD_TEST(NAME tokenize COMMAND test_tokenize)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,0 +1,3 @@
+ADD_EXECUTABLE(test_tokenize test_tokenize.c)
+TARGET_LINK_LIBRARIES(test_tokenize libwildmidi-static)
+ADD_TEST(NAME tokenize COMMAND test_tokenize)

--- a/test/test_tokenize.c
+++ b/test/test_tokenize.c
@@ -1,0 +1,50 @@
+/* assert-based smoke test for WM_LC_Tokenize_Line's config-line path handling */
+#include <assert.h>
+#include <string.h>
+#include <stdlib.h>
+
+extern char **WM_LC_Tokenize_Line(char *line_data);
+
+/* ponytail: leaks the strdup'd line buffer, tokens point into it and the
+ * process exits right after main(); not worth tracking for a smoke test. */
+static char **tokenize(const char *line) {
+    return WM_LC_Tokenize_Line(strdup(line));
+}
+
+int main(void) {
+    char **toks;
+
+    /* quoted path with embedded spaces stays one token */
+    toks = tokenize("dir \"/Users/foo/Application Support/patches\"");
+    assert(toks && !strcmp(toks[0], "dir"));
+    assert(!strcmp(toks[1], "/Users/foo/Application Support/patches"));
+    assert(toks[2] == NULL);
+    free(toks);
+
+    /* empty quoted string yields an empty token, not a dropped one */
+    toks = tokenize("dir \"\"");
+    assert(toks && !strcmp(toks[0], "dir"));
+    assert(toks[1] && toks[1][0] == '\0');
+    assert(toks[2] == NULL);
+    free(toks);
+
+    /* unterminated quote still parses what it can, doesn't crash */
+    toks = tokenize("dir \"unterminated");
+    assert(toks && !strcmp(toks[0], "dir"));
+    assert(!strcmp(toks[1], "unterminated"));
+    free(toks);
+
+    /* plain unquoted args are unaffected */
+    toks = tokenize("a b c");
+    assert(toks && !strcmp(toks[0], "a") && !strcmp(toks[1], "b") && !strcmp(toks[2], "c"));
+    assert(toks[3] == NULL);
+    free(toks);
+
+    /* comments outside quotes are stripped */
+    toks = tokenize("dir /patches # comment");
+    assert(toks && !strcmp(toks[0], "dir") && !strcmp(toks[1], "/patches"));
+    assert(toks[2] == NULL);
+    free(toks);
+
+    return 0;
+}


### PR DESCRIPTION
Need to be able to support the following:

`~/Library/Application Support/Mindwerks/Thirdeye/patches/wildmidi.cfg`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved config-line parsing for quoted values, preserving whitespace inside quotes.
  * `#` now starts comments only when outside quoted text.
  * Fixed end-of-line and empty-quote handling to ensure tokens are captured correctly.

* **Tests**
  * Added a new tokenizer smoke test and wired CTest so tests run automatically in CI.

* **Chores**
  * Updated CI triggers and run scope (push limited to `master`).
  * Refreshed CI steps and FreeBSD version, and expanded build artifacts ignored by git.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->