### PR TITLE
Add bounds checks to parser file-length handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ CHANGELOG
   errors instead of writing past the buffer.
 * Fix a possible double-free on library shutdown.
 * Fix player WAV writer not closing its output properly (0.4.6 bug)
+* Security hardening across the file parsers.
 * Assorted overflow guards.
 * Cmake build system fixes, other minor fixes/clean-ups.
 * The library is API/ABI compatible with 0.4.x versions.

--- a/src/f_hmi.c
+++ b/src/f_hmi.c
@@ -162,6 +162,15 @@ _WM_ParseNewHmi(const uint8_t *hmi_data, uint32_t hmi_size) {
         hmi_track_header_length[i] += (hmi_addr[0x59] << 16);
         hmi_track_header_length[i] += (hmi_addr[0x5a] << 24);
 
+        /* GHSA-f2xg-2rq9-xvhm: header length is file-controlled; bound it
+         * against the remaining buffer so the pointer advance below cannot
+         * walk off the file, and leave at least one byte for the VLQ read
+         * that follows. */
+        if (hmi_track_header_length[i] >= hmi_size - hmi_track_offset[i]) {
+            _WM_GLOBAL_ERROR(WM_ERR_NOT_HMI, "file too short", 0);
+            goto _hmi_end;
+        }
+
         hmi_addr += hmi_track_header_length[i];
         hmi_track_offset[i] += hmi_track_header_length[i];
 
@@ -307,7 +316,10 @@ _WM_ParseNewHmi(const uint8_t *hmi_data, uint32_t hmi_size) {
                     if ((hmi_running_event[i] & 0xf0) == 0x90) {
                         /* note on has extra data to specify how long the note is. */
                         if (*hmi_data > 127) {
-                            hmi_tmp = hmi_data[1];
+                            /* GHSA-f2xg-2rq9-xvhm: mask to the valid MIDI
+                             * note range so the note[] index below stays
+                             * inside the 128-per-track allocation. */
+                            hmi_tmp = hmi_data[1] & 0x7f;
                         } else {
                             hmi_tmp = *hmi_data;
                         }

--- a/src/f_hmi.c
+++ b/src/f_hmi.c
@@ -181,6 +181,12 @@ _WM_ParseNewHmi(const uint8_t *hmi_data, uint32_t hmi_size) {
                 hmi_delta[i] = (hmi_delta[i] << 7) + (*hmi_addr & 0x7f);
                 hmi_addr++;
                 hmi_track_offset[i]++;
+                /* GHSA-f2xg-2rq9-xvhm: a header ending in VLQ continuation
+                 * bytes could otherwise walk past the buffer. */
+                if (hmi_track_offset[i] >= hmi_size) {
+                    _WM_GLOBAL_ERROR(WM_ERR_NOT_HMI, "file too short", 0);
+                    goto _hmi_end;
+                }
             } while (*hmi_addr > 0x7f);
         }
         hmi_delta[i] = (hmi_delta[i] << 7) + (*hmi_addr & 0x7f);

--- a/src/f_mus.c
+++ b/src/f_mus.c
@@ -105,6 +105,14 @@ _WM_ParseNewMus(const uint8_t *mus_data, uint32_t mus_size) {
         return NULL;
     }
 
+    /* GHSA-v6gx-9vh4-c8qx: mus_song_ofs is a file-controlled uint16 used as
+     * a raw index into mus_data. Bound it against mus_size with room for
+     * the 3-byte first event read below. */
+    if (mus_song_ofs > mus_size - 3) {
+        _WM_GLOBAL_ERROR(WM_ERR_CORUPT, "file too short", 0);
+        return NULL;
+    }
+
     /* Instrument definition */
     mus_mid_instr = (uint16_t *) malloc(mus_no_instr * sizeof(uint16_t));
     for (mus_instr_cnt = 0; mus_instr_cnt < mus_no_instr; mus_instr_cnt++) {

--- a/src/f_xmidi.c
+++ b/src/f_xmidi.c
@@ -149,6 +149,13 @@ struct _mdi *_WM_ParseNewXmi(const uint8_t *xmi_data, uint32_t xmi_size) {
     memset(xmi_notelen, 0, (sizeof(uint32_t) * 16 * 128));
 
     for (i = 0; i < xmi_formcnt; i++) {
+        /* FORM header = 4-byte tag + 4-byte length + 4-byte XMID tag = 12
+         * bytes. Guard against a truncated file before we consume them, and
+         * against a xmi_subformlen < 4 that would underflow below. */
+        if (xmi_size < 12) {
+            _WM_GLOBAL_ERROR(WM_ERR_CORUPT, NULL, 0);
+            goto _xmi_end;
+        }
         if (memcmp(xmi_data,"FORM",4)) {
             _WM_GLOBAL_ERROR(WM_ERR_NOT_XMI, NULL, 0);
             goto _xmi_end;
@@ -164,6 +171,10 @@ struct _mdi *_WM_ParseNewXmi(const uint8_t *xmi_data, uint32_t xmi_size) {
 
         if (memcmp(xmi_data,"XMID",4)) {
             _WM_GLOBAL_ERROR(WM_ERR_NOT_XMI, NULL, 0);
+            goto _xmi_end;
+        }
+        if (xmi_subformlen < 4 || xmi_subformlen - 4 > xmi_size - 4) {
+            _WM_GLOBAL_ERROR(WM_ERR_CORUPT, NULL, 0);
             goto _xmi_end;
         }
         xmi_data += 4;

--- a/src/f_xmidi.c
+++ b/src/f_xmidi.c
@@ -104,6 +104,14 @@ struct _mdi *_WM_ParseNewXmi(const uint8_t *xmi_data, uint32_t xmi_size) {
      at this stage unsure if remaining data in
      this section means anything
      */
+    /* GHSA-w64x-crjj-cccf: XDIR chunk length is file-controlled; if it is
+     * smaller than the 13 sub-header bytes we already consumed, the uint32
+     * subtraction below would underflow and the pointer add would walk ~4 GB
+     * past the buffer. */
+    if (xmi_tmpdata < 13 || xmi_tmpdata - 13 > xmi_size) {
+        _WM_GLOBAL_ERROR(WM_ERR_NOT_XMI, NULL, 0);
+        return NULL;
+    }
     xmi_tmpdata -= 13;
     xmi_data += xmi_tmpdata;
     xmi_size -= xmi_tmpdata;
@@ -164,6 +172,12 @@ struct _mdi *_WM_ParseNewXmi(const uint8_t *xmi_data, uint32_t xmi_size) {
 
         /* Process Subform */
         do {
+            /* Each subform chunk is at least a 4-byte tag + 4-byte length. */
+            if (xmi_size < 8 || xmi_subformlen < 8) {
+                _WM_GLOBAL_ERROR(WM_ERR_CORUPT, NULL, 0);
+                goto _xmi_end;
+            }
+
             if (!memcmp(xmi_data,"TIMB",4)) {
                 /* Holds patch information */
                 /* FIXME: May not be needed for playback as EVNT seems to */
@@ -174,6 +188,13 @@ struct _mdi *_WM_ParseNewXmi(const uint8_t *xmi_data, uint32_t xmi_size) {
                 xmi_tmpdata |= *xmi_data++ << 16;
                 xmi_tmpdata |= *xmi_data++ << 8;
                 xmi_tmpdata |= *xmi_data++;
+                /* Bound the file-supplied length against the remaining buffer
+                 * and the enclosing subform, so the pointer add and the two
+                 * subtractions below cannot walk off / underflow. */
+                if (xmi_tmpdata > xmi_size - 8 || xmi_tmpdata > xmi_subformlen - 8) {
+                    _WM_GLOBAL_ERROR(WM_ERR_CORUPT, NULL, 0);
+                    goto _xmi_end;
+                }
                 xmi_data += xmi_tmpdata;
                 xmi_size -= (8 + xmi_tmpdata);
                 xmi_subformlen -= (8 + xmi_tmpdata);
@@ -187,6 +208,10 @@ struct _mdi *_WM_ParseNewXmi(const uint8_t *xmi_data, uint32_t xmi_size) {
                 xmi_tmpdata |= *xmi_data++ << 16;
                 xmi_tmpdata |= *xmi_data++ << 8;
                 xmi_tmpdata |= *xmi_data++;
+                if (xmi_tmpdata > xmi_size - 8 || xmi_tmpdata > xmi_subformlen - 8) {
+                    _WM_GLOBAL_ERROR(WM_ERR_CORUPT, NULL, 0);
+                    goto _xmi_end;
+                }
                 xmi_data += xmi_tmpdata;
                 xmi_size -= (8 + xmi_tmpdata);
                 xmi_subformlen -= (8 + xmi_tmpdata);
@@ -201,6 +226,12 @@ struct _mdi *_WM_ParseNewXmi(const uint8_t *xmi_data, uint32_t xmi_size) {
                 xmi_evntlen |= *xmi_data++ << 16;
                 xmi_evntlen |= *xmi_data++ << 8;
                 xmi_evntlen |= *xmi_data++;
+                /* EVNT payload must fit in the remaining buffer; otherwise
+                 * the inner event loop will read past the file. */
+                if (xmi_evntlen > xmi_size - 8 || xmi_evntlen > xmi_subformlen - 8) {
+                    _WM_GLOBAL_ERROR(WM_ERR_CORUPT, NULL, 0);
+                    goto _xmi_end;
+                }
                 xmi_size -= 8;
                 xmi_subformlen -= 8;
 
@@ -282,7 +313,10 @@ struct _mdi *_WM_ParseNewXmi(const uint8_t *xmi_data, uint32_t xmi_size) {
                         if ((*xmi_data & 0xf0) == 0x90) {
                             /* Note on has extra data stating note length */
                             xmi_ch = *xmi_data & 0x0f;
-                            xmi_note = xmi_data[1];
+                            /* GHSA-w64x-crjj-cccf: mask to the valid MIDI
+                             * note range so the xmi_notelen[128*ch+note]
+                             * index below stays inside the 16*128 allocation. */
+                            xmi_note = xmi_data[1] & 0x7f;
                             xmi_data += setup_ret;
                             xmi_size -= setup_ret;
                             xmi_evntlen -= setup_ret;

--- a/src/gus_pat.c
+++ b/src/gus_pat.c
@@ -773,6 +773,16 @@ struct _sample * _WM_load_gus_pat(const char *filename, int fix_release) {
         }
 
         gus_sample->next = NULL;
+
+        /* GHSA-c2fg-6v3f-77wq: guard the 96-byte sample header read below.
+         * no_of_samples (file byte 198) is untrusted, so gus_ptr may already
+         * be past the buffer on any iteration. */
+        if (gus_ptr > gus_size || gus_size - gus_ptr < 96) {
+            _WM_GLOBAL_ERROR(WM_ERR_CORUPT, filename, 0);
+            _WM_FreeBufferFile(gus_patch);
+            return NULL;
+        }
+
         gus_sample->loop_fraction = gus_patch[gus_ptr + 7];
         gus_sample->data_length = (gus_patch[gus_ptr + 11] << 24)
                                 | (gus_patch[gus_ptr + 10] << 16)
@@ -827,9 +837,9 @@ struct _sample * _WM_load_gus_pat(const char *filename, int fix_release) {
         /* GHSA-g5cc-5xv7-5f32: bounds-check header-supplied sizes so the sample
          * converters cannot integer-overflow their calloc size or read past the
          * source buffer. All 16 convert_* paths derive their allocation and
-         * write offsets from these three fields. */
+         * write offsets from these three fields. Header-range guard above
+         * already ensures gus_ptr + 96 <= gus_size. */
         if (gus_sample->data_length == 0
-            || gus_ptr + 96 > gus_size
             || gus_sample->data_length > gus_size - gus_ptr - 96
             || gus_sample->loop_end > gus_sample->data_length
             || gus_sample->data_length > (UINT32_MAX >> 10)) {

--- a/src/gus_pat.c
+++ b/src/gus_pat.c
@@ -23,6 +23,7 @@
 
 #include "config.h"
 
+#define __STDC_LIMIT_MACROS
 #include <stdint.h>
 #include <errno.h>
 #include <stdio.h>
@@ -821,6 +822,20 @@ struct _sample * _WM_load_gus_pat(const char *filename, int fix_release) {
             gus_sample->loop_fraction =
                     ((gus_sample->loop_fraction & 0x0f) << 4)
                             | ((gus_sample->loop_fraction & 0xf0) >> 4);
+        }
+
+        /* GHSA-g5cc-5xv7-5f32: bounds-check header-supplied sizes so the sample
+         * converters cannot integer-overflow their calloc size or read past the
+         * source buffer. All 16 convert_* paths derive their allocation and
+         * write offsets from these three fields. */
+        if (gus_sample->data_length == 0
+            || gus_ptr + 96 > gus_size
+            || gus_sample->data_length > gus_size - gus_ptr - 96
+            || gus_sample->loop_end > gus_sample->data_length
+            || gus_sample->data_length > (UINT32_MAX >> 10)) {
+            _WM_GLOBAL_ERROR(WM_ERR_CORUPT, filename, 0);
+            _WM_FreeBufferFile(gus_patch);
+            return NULL;
         }
 
         /* All sorts of annoying things happen with pat files.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened security and robustness of parsing for HMI, MUS, XMI, and GUS files with additional bounds validation for offsets, chunk sizes, VLQ/cursor advancement, and event/payload lengths.
  * Improved MIDI “note on” handling in HMI and XMI by masking to the 7-bit note range to prevent out-of-range indexing.
* **Documentation**
  * Updated the 0.5.0 changelog to mention security hardening across the file parsers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->