### PR TITLE
[#264] obey scale frequency and factor

### DIFF
--- a/include/sample.h
+++ b/include/sample.h
@@ -60,6 +60,8 @@ struct _sample {
     struct _sample *next;
 
     uint32_t note_off_decay;
+    uint16_t scale_frequency;
+    uint16_t scale_factor;
 };
 
 extern int _WM_fix_release;

--- a/include/stdint/stdint.h
+++ b/include/stdint/stdint.h
@@ -10,29 +10,51 @@ typedef unsigned short int uint16_t;
 
 #define INT8_MIN (-128)
 #define INT16_MIN (-32767-1)
-#define INT32_MIN (-2147483647-1)
 #define INT8_MAX (127)
 #define INT16_MAX (32767)
-#define INT32_MAX (2147483647)
 #define UINT8_MAX (255)
 #define UINT16_MAX (65535)
 
 #if (INT_MAX == 2147483647)
 typedef signed int int32_t;
 typedef unsigned int uint32_t;
+#define INT32_MIN (-2147483647-1)
+#define INT32_MAX ( 2147483647)
 #define UINT32_MAX (4294967295U)
 #elif (LONG_MAX == 2147483647)
 typedef signed long int int32_t;
 typedef unsigned long int uint32_t;
+#define INT32_MIN (-2147483647L-1L)
+#define INT32_MAX ( 2147483647L)
 #define UINT32_MAX (4294967295UL)
 #else
 #error define a 32bit integral type
 #endif /* int32_t */
 
+#ifdef _MSC_VER
+typedef unsigned __int64 uint64_t;
+typedef signed __int64 int64_t;
+#define INT64_MAX   9223372036854775807i64
+#define INT64_MIN (-9223372036854775807i64-1i64)
+#define UINT64_MAX 18446744073709551615ui64
+#elif defined(_LP64) || defined(__LP64__)
+typedef unsigned long uint64_t;
+typedef signed long int64_t;
+#define INT64_MAX   9223372036854775807L
+#define INT64_MIN (-9223372036854775807L-1L)
+#define UINT64_MAX 18446744073709551615UL
+#else
+typedef unsigned long long uint64_t;
+typedef signed long long int64_t;
+#define INT64_MAX 9223372036854775807LL
+#define INT64_MIN (-9223372036854775807LL-1LL)
+#define UINT64_MAX 18446744073709551615ULL
+#endif /* int64_t */
+
 /* make sure of type sizes */
 typedef int _wm_int8_test [(sizeof(int8_t ) == 1) * 2 - 1];
 typedef int _wm_int16_test[(sizeof(int16_t) == 2) * 2 - 1];
 typedef int _wm_int32_test[(sizeof(int32_t) == 4) * 2 - 1];
+typedef int _wm_int64_test[(sizeof(int64_t) == 8) * 2 - 1];
 
 #endif /* WM_STDINT_H */
-

--- a/src/gus_pat.c
+++ b/src/gus_pat.c
@@ -812,6 +812,15 @@ struct _sample * _WM_load_gus_pat(const char *filename, int fix_release) {
                 gus_patch[gus_ptr+52], gus_patch[gus_ptr+53], gus_patch[gus_ptr+54]);
 #endif
         gus_sample->modes = gus_patch[gus_ptr + 55];
+        gus_sample->scale_frequency = gus_patch[gus_ptr + 56]
+                                    | (gus_patch[gus_ptr + 57] << 8);
+        gus_sample->scale_factor    = gus_patch[gus_ptr + 58]
+                                    | (gus_patch[gus_ptr + 59] << 8);
+        /* ponytail: some pre-1.10 patches leave both zero; treat as identity. */
+        if (gus_sample->scale_factor == 0 && gus_sample->scale_frequency == 0) {
+            gus_sample->scale_frequency = 60;
+            gus_sample->scale_factor = 1024;
+        }
         GUSPAT_START_DEBUG(); GUSPAT_MODE_DEBUG(gus_patch[gus_ptr+55], SAMPLE_16BIT, "16bit "); GUSPAT_MODE_DEBUG(gus_patch[gus_ptr+55], SAMPLE_UNSIGNED, "Unsigned "); GUSPAT_MODE_DEBUG(gus_patch[gus_ptr+55], SAMPLE_LOOP, "Loop "); GUSPAT_MODE_DEBUG(gus_patch[gus_ptr+55], SAMPLE_PINGPONG, "PingPong "); GUSPAT_MODE_DEBUG(gus_patch[gus_ptr+55], SAMPLE_REVERSE, "Reverse "); GUSPAT_MODE_DEBUG(gus_patch[gus_ptr+55], SAMPLE_SUSTAIN, "Sustain "); GUSPAT_MODE_DEBUG(gus_patch[gus_ptr+55], SAMPLE_ENVELOPE, "Envelope "); GUSPAT_MODE_DEBUG(gus_patch[gus_ptr+55], SAMPLE_CLAMPED, "Clamped "); GUSPAT_END_DEBUG();
 
         if (gus_sample->loop_start > gus_sample->loop_end) {

--- a/src/internal_midi.c
+++ b/src/internal_midi.c
@@ -672,9 +672,12 @@ static inline uint32_t get_inc(struct _mdi *mdi, struct _note *nte) {
     }
     note_f += mdi->channel[ch].pitch_adjust;
     {
-        /* Apply GUS keyboard frequency scaling (Ultrasound SDK 13.4). */
+        /* Apply GUS keyboard frequency scaling (Ultrasound SDK 13.4).
+           int64 intermediate: guards against int32 overflow on corrupt
+           patch fields; the note_f clamp below then bounds the result. */
         int32_t pivot = (int32_t)nte->sample->scale_frequency * 100;
-        note_f = pivot + (note_f - pivot) * (int32_t)nte->sample->scale_factor / 1024;
+        int64_t scaled = (int64_t)(note_f - pivot) * (int32_t)nte->sample->scale_factor / 1024;
+        note_f = (int32_t)(pivot + scaled);
     }
     if (__builtin_expect((note_f < 0), 0)) {
         note_f = 0;

--- a/src/internal_midi.c
+++ b/src/internal_midi.c
@@ -671,6 +671,11 @@ static inline uint32_t get_inc(struct _mdi *mdi, struct _note *nte) {
         note_f = (nte->noteid & 0x7f) * 100;
     }
     note_f += mdi->channel[ch].pitch_adjust;
+    {
+        /* Apply GUS keyboard frequency scaling (Ultrasound SDK 13.4). */
+        int32_t pivot = (int32_t)nte->sample->scale_frequency * 100;
+        note_f = pivot + (note_f - pivot) * (int32_t)nte->sample->scale_factor / 1024;
+    }
     if (__builtin_expect((note_f < 0), 0)) {
         note_f = 0;
     } else if (__builtin_expect((note_f > 12700), 0)) {


### PR DESCRIPTION
Closes #264 

baseline test (do not break):
```
cd /Users/bret.curtis/Workspace/private/wildmidi/build
./wildmidi.app/Contents/MacOS/wildmidi \
  -c /Users/bret.curtis/Downloads/dgguspat/timidity.cfg \
  ~/Downloads/canyon.mid
```
I've attached the files I used to test this here: [test.zip](https://github.com/user-attachments/files/29847266/test.zip)
this includes applause.mid that repeats the applause in different frequency and scale factor

Attached the GUS lowleve toolkit pdf because one in ticket 404s
[UltraSound Lowlevel ToolKit v2.22 (21 December 1994).pdf](https://github.com/user-attachments/files/29847332/UltraSound.Lowlevel.ToolKit.v2.22.21.December.1994.pdf)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Sample playback now supports per-sample frequency scaling for more accurate instrument rendering.
* **Bug Fixes**
  * Improved handling of patch files that omit scaling data by applying identity scaling to preserve prior playback behavior.
  * Notes are now adjusted with the instrument’s scaling parameters for more accurate pitch and timing behavior during playback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->