### PR TITLE
add support for dumping hmi and hmp files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 
 # build dirs
 build/
+cmake-build*/
 
 # stray in-source cmake configure (should always use -B build)
 CMakeCache.txt

--- a/README.md
+++ b/README.md
@@ -42,6 +42,11 @@ CHANGELOG
 * SoundFont2 (SF2) rendering support via TinySoundFont, vendored under
   `src/tsf/`. Enabled by default (`WANT_SF2=ON`); pass either an `.sf2`
   file or a config with a `soundfont` directive to `WildMidi_Init`.
+* HMP and HMI to MIDI converters: WildMidi_ConvertToMidi and the player's
+  `-x/--tomidi` switch now convert HMP and HMI files in addition to XMI
+  and MUS (bug #181).  
+* Support for playing and converting compressed ("mangled") HMP files as
+  shipped by Gremlin Interactive games such as Fatal Racing / Whiplash.
 * Find and use a GUS patch with neareset patchid in case of missing patches:
   https://www.cpdl.org/wiki/images/f/f8/349_Jesu_meiner_Freuden_Freude.mid,
   for example, now plays well with alternative patches instead of producing

--- a/amiga/Makefile
+++ b/amiga/Makefile
@@ -55,7 +55,7 @@ endif
 	$(CC) -c $(CFLAGS) -o $@ $<
 
 # Objects
-LIB_OBJ= wm_error.o file_io.o lock.o wildmidi_lib.o reverb.o gus_pat.o f_xmidi.o f_mus.o f_hmp.o f_midi.o f_hmi.o mus2mid.o xmi2mid.o internal_midi.o patches.o sample.o sf2.o
+LIB_OBJ= wm_error.o file_io.o lock.o wildmidi_lib.o reverb.o gus_pat.o f_xmidi.o f_mus.o f_hmp.o f_midi.o f_hmi.o mus2mid.o xmi2mid.o hmp2mid.o hmi2mid.o internal_midi.o patches.o sample.o sf2.o
 PLAYER_OBJ= amiga.o wm_tty.o msleep.o getopt_long.o out_none.o out_wave.o out_ahi.o wildmidi.o
 
 # Build targets

--- a/amiga/Makefile.vbcc
+++ b/amiga/Makefile.vbcc
@@ -34,7 +34,7 @@ endif
 	$(CC) -c $(CFLAGS) -o $@ $<
 
 # Objects
-LIB_OBJ= wm_error.o file_io.o lock.o wildmidi_lib.o reverb.o gus_pat.o f_xmidi.o f_mus.o f_hmp.o f_midi.o f_hmi.o mus2mid.o xmi2mid.o internal_midi.o patches.o sample.o sf2.o
+LIB_OBJ= wm_error.o file_io.o lock.o wildmidi_lib.o reverb.o gus_pat.o f_xmidi.o f_mus.o f_hmp.o f_midi.o f_hmi.o mus2mid.o xmi2mid.o hmp2mid.o hmi2mid.o internal_midi.o patches.o sample.o sf2.o
 PLAYER_OBJ= amiga.o wm_tty.o msleep.o getopt_long.o out_none.o out_wave.o out_ahi.o wildmidi.o
 
 # Build targets

--- a/android/jni/Android.mk
+++ b/android/jni/Android.mk
@@ -24,6 +24,8 @@ LOCAL_SRC_FILES := \
 	src/sf2.c \
 	src/wildmidi_lib.c \
 	src/wm_error.c \
-	src/xmi2mid.c
+	src/xmi2mid.c \
+	src/hmp2mid.c \
+	src/hmi2mid.c
 
 include $(BUILD_SHARED_LIBRARY)

--- a/djgpp/Makefile
+++ b/djgpp/Makefile
@@ -57,7 +57,7 @@ endif
 
 
 # Objects
-LIB_OBJ= wm_error.o file_io.o lock.o wildmidi_lib.o reverb.o gus_pat.o f_xmidi.o f_mus.o f_hmp.o f_midi.o f_hmi.o mus2mid.o xmi2mid.o internal_midi.o patches.o sample.o sf2.o
+LIB_OBJ= wm_error.o file_io.o lock.o wildmidi_lib.o reverb.o gus_pat.o f_xmidi.o f_mus.o f_hmp.o f_midi.o f_hmi.o mus2mid.o xmi2mid.o hmp2mid.o hmi2mid.o internal_midi.o patches.o sample.o sf2.o
 PLAYER_OBJ= wm_tty.o msleep.o getopt_long.o out_none.o dosirq.o dosdma.o dossb.o out_dossb.o out_wave.o wildmidi.o
 
 # Build targets

--- a/docs/man/man1/wildmidi.1
+++ b/docs/man/man1/wildmidi.1
@@ -68,7 +68,7 @@ Skips any silence at the start of playback.
 Display version and copyright information.
 .PP
 .IP "\fB\-x\fP | \fB\-\-tomidi\fP"
-Convert a MUS or an XMI file to midi and save to file.
+Convert a MUS, XMI, HMP or HMI file to midi and save to file.
 .PP
 .SH TEST OPTIONS
 These options are not designed for general use. Instead these options are designed to make it easier to listen to specific sound samples.

--- a/docs/man/man3/WildMidi_ConvertBufferToMidi.3
+++ b/docs/man/man3/WildMidi_ConvertBufferToMidi.3
@@ -14,7 +14,7 @@ WildMidi_ConvertBufferToMidi \- Convert a MIDI-like buffer into a new MIDI buffe
 Takes a MIDI-like memory buffer as input and tries to detect, convert and write to a memory buffer in MIDI format.
 .PP
 .IP \fIin\fP
-The input buffer that contains MIDI-like content: XMI or MUS.
+The input buffer that contains MIDI-like content: XMI, MUS, HMP or HMI.
 .PP
 .IP \fIinsize\fP
 The size of the input buffer.

--- a/docs/man/man3/WildMidi_ConvertToMidi.3
+++ b/docs/man/man3/WildMidi_ConvertToMidi.3
@@ -14,7 +14,7 @@ WildMidi_ConvertToMidi \- Convert a MIDI-like file into a new MIDI file.
 Takes a MIDI-like file as input and tries to detect, convert and write to a memory buffer in MIDI format.
 .PP
 .IP \fIfile\fP
-The input file that contains MIDI-like content: XMI or MUS.
+The input file that contains MIDI-like content: XMI, MUS, HMP or HMI.
 .PP
 .IP \fIout\fP
 The output buffer. It will be allocated with \fBmalloc\fP() and must be \fBfree\fP()d by the caller when it is no longer needed.

--- a/include/hmi2mid.h
+++ b/include/hmi2mid.h
@@ -1,0 +1,30 @@
+/*
+ * HMI2MIDI: HMI Sound Operating System HMI to MIDI Library Header
+ *
+ * Copyright (C) WildMIDI Developers 2026
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public
+ * License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+ * Boston, MA  02110-1301, USA.
+ */
+
+#ifndef HMILIB_H
+#define HMILIB_H
+
+#include <stdint.h>
+
+int _WM_hmi2midi(const uint8_t *in, uint32_t insize,
+                 uint8_t **out, uint32_t *outsize);
+
+#endif /* HMILIB_H */

--- a/include/hmp2mid.h
+++ b/include/hmp2mid.h
@@ -1,0 +1,36 @@
+/*
+ * HMP2MIDI: HMI Sound Operating System HMP to MIDI Library Header
+ *
+ * Copyright (C) WildMIDI Developers 2026
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public
+ * License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+ * Boston, MA  02110-1301, USA.
+ */
+
+#ifndef HMPLIB_H
+#define HMPLIB_H
+
+#include <stdint.h>
+
+int _WM_hmp2midi(const uint8_t *in, uint32_t insize,
+                 uint8_t **out, uint32_t *outsize);
+
+/* Gremlin Interactive "mangled" (compressed) HMP/HMI files,
+ * as shipped by Fatal Racing / Whiplash */
+int _WM_IsMangled(const uint8_t *in, uint32_t insize);
+int _WM_Unmangle(const uint8_t *in, uint32_t insize,
+                 uint8_t **out, uint32_t *outsize);
+
+#endif /* HMPLIB_H */

--- a/macosx/Makefile
+++ b/macosx/Makefile
@@ -68,7 +68,7 @@ LDLIBS_EXE+=-L. -l$(LIBNAME)
 
 # Objects
 LIB_OBJ = wm_error.o file_io.o lock.o wildmidi_lib.o reverb.o gus_pat.o
-LIB_OBJ+= f_xmidi.o f_mus.o f_hmp.o f_midi.o f_hmi.o mus2mid.o xmi2mid.o internal_midi.o patches.o sample.o sf2.o
+LIB_OBJ+= f_xmidi.o f_mus.o f_hmp.o f_midi.o f_hmi.o mus2mid.o xmi2mid.o hmp2mid.o hmi2mid.o internal_midi.o patches.o sample.o sf2.o
 PLAYER_OBJ = wm_tty.o msleep.o out_none.o out_wave.o out_coreaudio.o wildmidi.o
 # out_openal.o
 

--- a/mingw/Makefile
+++ b/mingw/Makefile
@@ -52,7 +52,7 @@ LDLIBS_EXE+=-L. -l$(LIBNAME)
 
 # Objects
 LIB_OBJ = wm_error.o file_io.o lock.o wildmidi_lib.o reverb.o gus_pat.o
-LIB_OBJ+= f_xmidi.o f_mus.o f_hmp.o f_midi.o f_hmi.o mus2mid.o xmi2mid.o internal_midi.o patches.o sample.o sf2.o
+LIB_OBJ+= f_xmidi.o f_mus.o f_hmp.o f_midi.o f_hmi.o mus2mid.o xmi2mid.o hmp2mid.o hmi2mid.o internal_midi.o patches.o sample.o sf2.o
 PLAYER_OBJ = wm_tty.o msleep.o getopt_long.o out_none.o out_wave.o out_win32mm.o wildmidi.o
 # out_openal.o
 

--- a/msvc/common.mak
+++ b/msvc/common.mak
@@ -11,7 +11,7 @@ PLAYER  = wildmidi.exe
 LIBS_DLL=
 LIBS_PLY= $(IMPNAME) winmm.lib
 
-DLL_OBJ = wm_error.obj file_io.obj lock.obj wildmidi_lib.obj reverb.obj gus_pat.obj f_xmidi.obj f_mus.obj f_hmp.obj f_midi.obj f_hmi.obj mus2mid.obj xmi2mid.obj internal_midi.obj patches.obj sample.obj sf2.obj
+DLL_OBJ = wm_error.obj file_io.obj lock.obj wildmidi_lib.obj reverb.obj gus_pat.obj f_xmidi.obj f_mus.obj f_hmp.obj f_midi.obj f_hmi.obj mus2mid.obj xmi2mid.obj hmp2mid.obj hmi2mid.obj internal_midi.obj patches.obj sample.obj sf2.obj
 PLY_OBJ = wm_tty.obj msleep.obj getopt_long.obj out_none.obj out_wave.obj out_win32mm.obj wildmidi.obj
 # out_openal.obj
 
@@ -48,6 +48,10 @@ f_hmi.obj: ..\src\f_hmi.c
 mus2mid.obj: ..\src\mus2mid.c
 	$(CC) $(DLL_FLAGS) $(INCLUDES) -c -Fo$@ $?
 xmi2mid.obj: ..\src\xmi2mid.c
+	$(CC) $(DLL_FLAGS) $(INCLUDES) -c -Fo$@ $?
+hmp2mid.obj: ..\src\hmp2mid.c
+	$(CC) $(DLL_FLAGS) $(INCLUDES) -c -Fo$@ $?
+hmi2mid.obj: ..\src\hmi2mid.c
 	$(CC) $(DLL_FLAGS) $(INCLUDES) -c -Fo$@ $?
 internal_midi.obj: ..\src\internal_midi.c
 	$(CC) $(DLL_FLAGS) $(INCLUDES) -c -Fo$@ $?

--- a/os2/makefile
+++ b/os2/makefile
@@ -38,7 +38,7 @@ BLD_TARGET=$(DLLNAME) $(PLAYER)
 INCPATH=-I"$(%WATCOM)/h/os2" -I"$(%WATCOM)/h"
 INCLUDES=$(INCPATH) -I. -I"../include"
 
-OBJ=wm_error.obj file_io.obj lock.obj wildmidi_lib.obj reverb.obj gus_pat.obj f_xmidi.obj f_mus.obj f_hmp.obj f_midi.obj f_hmi.obj mus2mid.obj xmi2mid.obj internal_midi.obj patches.obj sample.obj sf2.obj
+OBJ=wm_error.obj file_io.obj lock.obj wildmidi_lib.obj reverb.obj gus_pat.obj f_xmidi.obj f_mus.obj f_hmp.obj f_midi.obj f_hmi.obj mus2mid.obj xmi2mid.obj hmp2mid.obj hmi2mid.obj internal_midi.obj patches.obj sample.obj sf2.obj
 PLAYER_OBJ=wm_tty.obj msleep.obj getopt_long.obj out_none.obj out_wave.obj out_dart.obj wildmidi.obj
 
 all: $(BLD_TARGET)

--- a/os2/makefile.emx
+++ b/os2/makefile.emx
@@ -27,7 +27,7 @@ PLAYER_LIBS+=-lmmpm2
 CFLAGS_LIB= $(CFLAGS) -DWILDMIDI_BUILD
 CFLAGS_EXE= $(CFLAGS)
 
-OBJ=wm_error.o file_io.o lock.o wildmidi_lib.o reverb.o gus_pat.o f_xmidi.o f_mus.o f_hmp.o f_midi.o f_hmi.o mus2mid.o xmi2mid.o internal_midi.o patches.o sample.o sf2.o
+OBJ=wm_error.o file_io.o lock.o wildmidi_lib.o reverb.o gus_pat.o f_xmidi.o f_mus.o f_hmp.o f_midi.o f_hmi.o mus2mid.o xmi2mid.o hmp2mid.o hmi2mid.o internal_midi.o patches.o sample.o sf2.o
 PLAYER_OBJ=wm_tty.o msleep.o getopt_long.o out_none.o out_wave.o out_dart.o wildmidi.o
 
 all: $(LIBSTATIC) $(PLAYER_STATIC)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -17,6 +17,8 @@ SET(wildmidi_library_SRCS
     sf2.c
     mus2mid.c
     xmi2mid.c
+    hmp2mid.c
+    hmi2mid.c
 )
 
 SET(wildmidi_library_HDRS
@@ -39,6 +41,8 @@ SET(wildmidi_library_HDRS
  ../include/filenames.h
  ../include/mus2mid.h
  ../include/xmi2mid.h
+ ../include/hmp2mid.h
+ ../include/hmi2mid.h
  ../include/wm_tty.h
  ../include/wildplay.h
  ../src/tsf/tsf.h

--- a/src/hmi2mid.c
+++ b/src/hmi2mid.c
@@ -1,0 +1,636 @@
+/*
+ * HMI2MIDI: HMI Sound Operating System HMI to MIDI Library
+ *
+ * Copyright (C) WildMIDI Developers 2026
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public
+ * License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+ * Boston, MA  02110-1301, USA.
+ */
+
+/* HMI Converter
+ *
+ * Format info comes from f_hmi.c: an HMI file holds a set of tracks that
+ * play simultaneously, so we emit a type-1 MIDI file.  Tracks are standard
+ * MIDI event streams with conventional delta times and running status, plus
+ * two HMI extensions: 0xfe prefixed HMI-only events (skipped), and note on
+ * events that carry an extra variable length note duration instead of
+ * having matching note off events.  Like xmi2mid, we convert each track
+ * into a time sorted event list so the note off events generated from
+ * those durations can be merged in, then write the list out as an MTrk.
+ * The file tempo comes from a BPM byte in the header; divisions are fixed
+ * at 60.
+ */
+
+#include "config.h"
+
+#include <stddef.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "hmi2mid.h"
+#include "wm_error.h"
+
+#define HMI_DIVISIONS   60
+#define TRK_CHUNKSIZE   8
+
+typedef struct _midi_event {
+    int32_t time;
+    uint8_t status;
+    uint8_t data[2];
+    uint32_t len;
+    uint8_t *buffer;
+    struct _midi_event *next;
+} midi_event;
+
+struct hmi_ctx {
+    uint8_t *dst, *dst_ptr;
+    uint32_t dstsize, dstrem;
+    int oom;
+    midi_event *list;
+    midi_event *current;
+};
+
+#define DST_CHUNK 8192
+static void resize_dst(struct hmi_ctx *ctx) {
+    uint32_t pos = ctx->dst_ptr - ctx->dst;
+    uint8_t *newdst;
+
+    if (ctx->oom)
+        return;
+    newdst = (uint8_t *) realloc(ctx->dst, ctx->dstsize + DST_CHUNK);
+    if (newdst == NULL) {
+        ctx->oom = 1;
+        return;
+    }
+    ctx->dst = newdst;
+    ctx->dstsize += DST_CHUNK;
+    ctx->dstrem += DST_CHUNK;
+    ctx->dst_ptr = ctx->dst + pos;
+}
+
+static void write1(struct hmi_ctx *ctx, uint32_t val)
+{
+    if (ctx->dstrem < 1) {
+        resize_dst(ctx);
+        if (ctx->dstrem < 1)
+            return;
+    }
+    *ctx->dst_ptr++ = val & 0xff;
+    ctx->dstrem--;
+}
+
+static void write2(struct hmi_ctx *ctx, uint32_t val)
+{
+    if (ctx->dstrem < 2) {
+        resize_dst(ctx);
+        if (ctx->dstrem < 2)
+            return;
+    }
+    *ctx->dst_ptr++ = (val>>8) & 0xff;
+    *ctx->dst_ptr++ = val & 0xff;
+    ctx->dstrem -= 2;
+}
+
+static void write4(struct hmi_ctx *ctx, uint32_t val)
+{
+    if (ctx->dstrem < 4) {
+        resize_dst(ctx);
+        if (ctx->dstrem < 4)
+            return;
+    }
+    *ctx->dst_ptr++ = (val>>24)&0xff;
+    *ctx->dst_ptr++ = (val>>16)&0xff;
+    *ctx->dst_ptr++ = (val>>8) & 0xff;
+    *ctx->dst_ptr++ = val & 0xff;
+    ctx->dstrem -= 4;
+}
+
+static void seekdst(struct hmi_ctx *ctx, uint32_t pos) {
+    while (ctx->dstsize < pos) {
+        resize_dst(ctx);
+        if (ctx->oom)
+            return;
+    }
+    ctx->dst_ptr = ctx->dst + pos;
+    ctx->dstrem = ctx->dstsize - pos;
+}
+
+static void skipdst(struct hmi_ctx *ctx, int32_t pos) {
+    size_t newpos = (ctx->dst_ptr - ctx->dst) + pos;
+    while (ctx->dstsize < newpos) {
+        resize_dst(ctx);
+        if (ctx->oom)
+            return;
+    }
+    ctx->dst_ptr = ctx->dst + newpos;
+    ctx->dstrem = ctx->dstsize - newpos;
+}
+
+static uint32_t getdstpos(struct hmi_ctx *ctx) {
+    return (ctx->dst_ptr - ctx->dst);
+}
+
+static void DeleteEventList(midi_event *mlist) {
+    midi_event *event;
+    midi_event *next;
+
+    next = mlist;
+
+    while ((event = next) != NULL) {
+        next = event->next;
+        free(event->buffer);
+        free(event);
+    }
+}
+
+/* Sets current to the new event and updates list.
+ * Returns the new event, or NULL when out of memory. */
+static midi_event *CreateNewEvent(struct hmi_ctx *ctx, int32_t time) {
+    midi_event *event;
+
+    if (!ctx->list) {
+        event = (midi_event *) calloc(1, sizeof(midi_event));
+        if (event == NULL)
+            return (NULL);
+        ctx->list = ctx->current = event;
+        ctx->current->time = (time < 0)? 0 : time;
+        return (ctx->current);
+    }
+
+    if (time < 0) {
+        event = (midi_event *) calloc(1, sizeof(midi_event));
+        if (event == NULL)
+            return (NULL);
+        event->next = ctx->list;
+        ctx->list = ctx->current = event;
+        return (ctx->current);
+    }
+
+    if (ctx->current->time > time)
+        ctx->current = ctx->list;
+
+    while (ctx->current->next) {
+        if (ctx->current->next->time > time) {
+            event = (midi_event *) calloc(1, sizeof(midi_event));
+            if (event == NULL)
+                return (NULL);
+            event->next = ctx->current->next;
+            ctx->current->next = event;
+            ctx->current = event;
+            ctx->current->time = time;
+            return (ctx->current);
+        }
+
+        ctx->current = ctx->current->next;
+    }
+
+    event = (midi_event *) calloc(1, sizeof(midi_event));
+    if (event == NULL)
+        return (NULL);
+    ctx->current->next = event;
+    ctx->current = event;
+    ctx->current->time = time;
+    return (ctx->current);
+}
+
+static int PutVLQ(struct hmi_ctx *ctx, uint32_t value) {
+    int32_t buffer;
+    int i = 1, j;
+    buffer = value & 0x7F;
+    while (value >>= 7) {
+        buffer <<= 8;
+        buffer |= ((value & 0x7F) | 0x80);
+        i++;
+    }
+    for (j = 0; j < i; j++) {
+        write1(ctx, buffer & 0xFF);
+        buffer >>= 8;
+    }
+
+    return (i);
+}
+
+/* Conventional MIDI variable length quantity */
+static int GetVLQ(const uint8_t **pp, uint32_t *remaining, uint32_t *quant) {
+    const uint8_t *p = *pp;
+
+    *quant = 0;
+    while (*remaining) {
+        (*remaining)--;
+        *quant = (*quant << 7) | (*p & 0x7F);
+        if (!(*p++ & 0x80)) {
+            *pp = p;
+            return (0);
+        }
+    }
+    return (-1);
+}
+
+/* Converts an HMI track into a time sorted event list.
+ * Returns 0 on success, -1 on corrupt data, -2 when out of memory. */
+static int ConvertTracktoList(struct hmi_ctx *ctx, const uint8_t *data,
+                              uint32_t remaining) {
+    int32_t time = 0;
+    uint32_t delta = 0;
+    uint8_t running_event = 0;
+    uint8_t status;
+    int end = 0;
+
+    if (GetVLQ(&data, &remaining, &delta) < 0)
+        return (-1);
+    time += delta;
+
+    while (!end) {
+        if (!remaining)
+            return (-1);
+
+        if (data[0] == 0xfe) {
+            /* HMI only event of some sort. */
+            uint32_t skip;
+
+            if (remaining < 2)
+                return (-1);
+            if (data[1] == 0x10) {
+                if (remaining < 5)
+                    return (-1);
+                skip = data[4] + 5 + 4;
+            } else if (data[1] == 0x15) {
+                skip = 8;
+            } else {
+                skip = 4;
+            }
+            if (skip > remaining)
+                return (-1);
+            data += skip;
+            remaining -= skip;
+        } else {
+            if (data[0] >= 0x80) {
+                status = *data++;
+                remaining--;
+                /* Sysex resets running event data,
+                 * 0xff does not alter running event */
+                if ((status == 0xF0) || (status == 0xF7)) {
+                    running_event = 0;
+                } else if (status < 0xF0) {
+                    running_event = status;
+                }
+            } else {
+                if (!running_event)
+                    return (-1);
+                status = running_event;
+            }
+
+            switch (status >> 4) {
+            case 0x9: {
+                /* Note on has extra data stating note length */
+                uint32_t length = 0;
+                midi_event *prev;
+
+                if (remaining < 2)
+                    return (-1);
+                if (CreateNewEvent(ctx, time) == NULL)
+                    return (-2);
+                ctx->current->status = status;
+                ctx->current->data[0] = *data++;
+                ctx->current->data[1] = *data++;
+                remaining -= 2;
+
+                if (GetVLQ(&data, &remaining, &length) < 0)
+                    return (-1);
+
+                prev = ctx->current;
+                if (CreateNewEvent(ctx, time + length) == NULL)
+                    return (-2);
+                ctx->current->status = status;
+                ctx->current->data[0] = prev->data[0];
+                ctx->current->data[1] = 0;
+                ctx->current = prev;
+                break;
+            }
+
+            /* 2 byte data */
+            case 0x8:
+            case 0xa:
+            case 0xb:
+            case 0xe:
+                if (remaining < 2)
+                    return (-1);
+                if (CreateNewEvent(ctx, time) == NULL)
+                    return (-2);
+                ctx->current->status = status;
+                ctx->current->data[0] = *data++;
+                ctx->current->data[1] = *data++;
+                remaining -= 2;
+                break;
+
+            /* 1 byte data */
+            case 0xc:
+            case 0xd:
+                if (remaining < 1)
+                    return (-1);
+                if (CreateNewEvent(ctx, time) == NULL)
+                    return (-2);
+                ctx->current->status = status;
+                ctx->current->data[0] = *data++;
+                remaining--;
+                break;
+
+            case 0xf:
+                if (CreateNewEvent(ctx, time) == NULL)
+                    return (-2);
+                ctx->current->status = status;
+                if (status == 0xff) {
+                    if (remaining < 1)
+                        return (-1);
+                    ctx->current->data[0] = *data++;
+                    remaining--;
+                    if (ctx->current->data[0] == 0x2f)
+                        end = 1;
+                }
+                if (GetVLQ(&data, &remaining, &ctx->current->len) < 0)
+                    return (-1);
+                if (ctx->current->len > remaining)
+                    return (-1);
+                if (ctx->current->len) {
+                    ctx->current->buffer = (uint8_t *) malloc(ctx->current->len);
+                    if (ctx->current->buffer == NULL) {
+                        ctx->current->len = 0;
+                        return (-2);
+                    }
+                    memcpy(ctx->current->buffer, data, ctx->current->len);
+                    data += ctx->current->len;
+                    remaining -= ctx->current->len;
+                }
+                break;
+
+            default: /* Never occur */
+                return (-1);
+            }
+        }
+
+        if (end)
+            break;
+
+        if (GetVLQ(&data, &remaining, &delta) < 0)
+            return (-1);
+        time += delta;
+    }
+
+    /* Move the end of track marker after the note off events generated
+     * from the note durations, so none of them get cut short. */
+    if (ctx->current->next) {
+        midi_event *event = ctx->list;
+        midi_event *prev = NULL;
+        midi_event *tail;
+
+        while (event->next) {
+            if ((event->status == 0xff) && (event->data[0] == 0x2f)) {
+                if (prev)
+                    prev->next = event->next;
+                else
+                    ctx->list = event->next;
+                tail = event->next;
+                while (tail->next)
+                    tail = tail->next;
+                event->time = tail->time;
+                event->next = NULL;
+                tail->next = event;
+                break;
+            }
+            prev = event;
+            event = event->next;
+        }
+    }
+
+    return (0);
+}
+
+/* Converts an event list to a MTrk
+ * Returns bytes of the array */
+static uint32_t ConvertListToMTrk(struct hmi_ctx *ctx, midi_event *mlist) {
+    int32_t time = 0;
+    midi_event *event;
+    uint32_t delta;
+    uint8_t last_status = 0;
+    uint32_t i = 8;
+    uint32_t j;
+    uint32_t size_pos, cur_pos;
+    int end = 0;
+
+    write1(ctx, 'M');
+    write1(ctx, 'T');
+    write1(ctx, 'r');
+    write1(ctx, 'k');
+
+    size_pos = getdstpos(ctx);
+    skipdst(ctx, 4);
+
+    for (event = mlist; event && !end; event = event->next) {
+        delta = (event->time - time);
+        time = event->time;
+
+        i += PutVLQ(ctx, delta);
+
+        if ((event->status != last_status) || (event->status >= 0xF0)) {
+            write1(ctx, event->status);
+            i++;
+        }
+
+        last_status = event->status;
+
+        switch (event->status >> 4) {
+        /* 2 bytes data
+         * Note off, Note on, Aftertouch, Controller and Pitch Wheel */
+        case 0x8:
+        case 0x9:
+        case 0xA:
+        case 0xB:
+        case 0xE:
+            write1(ctx, event->data[0]);
+            write1(ctx, event->data[1]);
+            i += 2;
+            break;
+
+        /* 1 bytes data
+         * Program Change and Channel Pressure */
+        case 0xC:
+        case 0xD:
+            write1(ctx, event->data[0]);
+            i++;
+            break;
+
+        /* Variable length
+         * SysEx */
+        case 0xF:
+            if (event->status == 0xFF) {
+                if (event->data[0] == 0x2f)
+                    end = 1;
+                write1(ctx, event->data[0]);
+                i++;
+            }
+            i += PutVLQ(ctx, event->len);
+            if (event->len) {
+                for (j = 0; j < event->len; j++) {
+                    write1(ctx, event->buffer[j]);
+                    i++;
+                }
+            }
+            break;
+
+        /* Never occur */
+        default:
+            _WM_DEBUG_MSG("%s: unrecognized event", _WM_FUNCTION);
+            break;
+        }
+    }
+
+    cur_pos = getdstpos(ctx);
+    seekdst(ctx, size_pos);
+    write4(ctx, i - 8);
+    seekdst(ctx, cur_pos);
+
+    return (i);
+}
+
+#define READ_INT32LE(b) ((uint32_t)((b)[0] | ((b)[1] << 8) | ((b)[2] << 16) | ((b)[3] << 24)))
+
+int _WM_hmi2midi(const uint8_t *in, uint32_t insize,
+                 uint8_t **out, uint32_t *outsize) {
+    struct hmi_ctx ctx;
+    uint16_t hmi_bpm;
+    uint32_t hmi_track_cnt;
+    uint32_t tempo;
+    uint32_t i;
+    int ret = -1;
+
+    memset(&ctx, 0, sizeof(struct hmi_ctx));
+
+    if (insize <= 370) {
+        _WM_GLOBAL_ERROR(WM_ERR_CORUPT, "(too short)", 0);
+        return (-1);
+    }
+
+    if (memcmp(in, "HMI-MIDISONG061595", 18)) {
+        _WM_GLOBAL_ERROR(WM_ERR_NOT_HMI, NULL, 0);
+        return (-1);
+    }
+
+    hmi_bpm = in[212];
+    hmi_track_cnt = in[228];
+
+    if (!hmi_track_cnt) {
+        _WM_GLOBAL_ERROR(WM_ERR_CORUPT, "(no tracks)", 0);
+        return (-1);
+    }
+    if (!hmi_bpm) {
+        _WM_GLOBAL_ERROR(WM_ERR_INVALID, "(bad bpm)", 0);
+        return (-1);
+    }
+    tempo = 60000000 / hmi_bpm;
+
+    if (insize < (370 + (hmi_track_cnt * 4))) {
+        _WM_GLOBAL_ERROR(WM_ERR_CORUPT, "(too short)", 0);
+        return (-1);
+    }
+
+    ctx.dst = (uint8_t *) malloc(DST_CHUNK);
+    if (ctx.dst == NULL) {
+        _WM_GLOBAL_ERROR(WM_ERR_MEM, NULL, 0);
+        return (-1);
+    }
+    ctx.dst_ptr = ctx.dst;
+    ctx.dstsize = DST_CHUNK;
+    ctx.dstrem = DST_CHUNK;
+
+    /* MIDI header; +1 track for the tempo track */
+    write1(&ctx, 'M');
+    write1(&ctx, 'T');
+    write1(&ctx, 'h');
+    write1(&ctx, 'd');
+    write4(&ctx, 6);
+    write2(&ctx, 1);                /* type 1: tracks play simultaneously */
+    write2(&ctx, hmi_track_cnt + 1);
+    write2(&ctx, HMI_DIVISIONS);
+
+    /* tempo track */
+    write1(&ctx, 'M');
+    write1(&ctx, 'T');
+    write1(&ctx, 'r');
+    write1(&ctx, 'k');
+    write4(&ctx, 11);
+    write1(&ctx, 0x00); /* delta time */
+    write1(&ctx, 0xff); /* set tempo */
+    write2(&ctx, 0x5103);
+    write1(&ctx, (tempo & 0x00ff0000) >> 16);
+    write1(&ctx, (tempo & 0x0000ff00) >> 8);
+    write1(&ctx, tempo & 0x000000ff);
+    write1(&ctx, 0x00); /* delta time */
+    write1(&ctx, 0xff); /* end of track */
+    write2(&ctx, 0x2f00);
+
+    for (i = 0; i < hmi_track_cnt; i++) {
+        uint32_t track_offset = READ_INT32LE(&in[370 + (i * 4)]);
+        uint32_t track_header_length;
+        int cvt_ret;
+
+        /* written to avoid an integer overflow: insize > 370 here */
+        if (track_offset > insize - (0x5a + 4)) {
+            _WM_GLOBAL_ERROR(WM_ERR_NOT_HMI, "(too short)", 0);
+            goto _end;
+        }
+
+        if (memcmp(&in[track_offset], "HMI-MIDITRACK", 13)) {
+            _WM_GLOBAL_ERROR(WM_ERR_NOT_HMI, NULL, 0);
+            goto _end;
+        }
+
+        track_header_length = READ_INT32LE(&in[track_offset + 0x57]);
+        if (track_header_length >= insize - track_offset) {
+            _WM_GLOBAL_ERROR(WM_ERR_NOT_HMI, "(too short)", 0);
+            goto _end;
+        }
+        track_offset += track_header_length;
+
+        ctx.list = NULL;
+        if ((cvt_ret = ConvertTracktoList(&ctx, &in[track_offset], insize - track_offset)) < 0) {
+            if (cvt_ret == -2) {
+                _WM_GLOBAL_ERROR(WM_ERR_MEM, NULL, 0);
+            } else {
+                _WM_GLOBAL_ERROR(WM_ERR_CORUPT, "(too short)", 0);
+            }
+            DeleteEventList(ctx.list);
+            goto _end;
+        }
+        ConvertListToMTrk(&ctx, ctx.list);
+        DeleteEventList(ctx.list);
+        ctx.list = NULL;
+
+        if (ctx.oom) {
+            _WM_GLOBAL_ERROR(WM_ERR_MEM, NULL, 0);
+            goto _end;
+        }
+    }
+
+    *out = ctx.dst;
+    *outsize = ctx.dstsize - ctx.dstrem;
+    return (0);
+
+_end:
+    free(ctx.dst);
+    *out = NULL;
+    *outsize = 0;
+    return (ret);
+}

--- a/src/hmp2mid.c
+++ b/src/hmp2mid.c
@@ -1,0 +1,651 @@
+/*
+ * HMP2MIDI: HMI Sound Operating System HMP to MIDI Library
+ *
+ * Copyright (C) WildMIDI Developers 2026
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public
+ * License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+ * Boston, MA  02110-1301, USA.
+ */
+
+/* HMP Converter
+ *
+ * Format info comes from f_hmp.c: an HMP file is a set of chunks (tracks)
+ * that play simultaneously, so we emit a type-1 MIDI file.  Each chunk is
+ * a stream of standard MIDI events, but the delta times use HMI's own
+ * variable length coding: bytes with the high bit CLEAR are continuation
+ * bytes carrying 7 bits each least-significant-first, and the final byte
+ * has the high bit SET.  The file tempo comes from a BPM field in the
+ * header; divisions are fixed at 60.
+ */
+
+#include "config.h"
+
+#include <stddef.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "hmp2mid.h"
+#include "file_io.h"
+#include "wm_error.h"
+
+#define HMP_DIVISIONS   60
+#define TRK_CHUNKSIZE   8
+
+/* Gremlin Interactive games such as Fatal Racing (aka Whiplash) ship
+ * their HMP music "mangled" with a simple byte-oriented compression
+ * scheme.  The format was documented by the FatalDecomp project
+ * (https://github.com/FatalDecomp/Whiptools); this is an independent
+ * implementation written from that format description:
+ *
+ * The file starts with the decompressed size as a 32 bit little endian
+ * integer, followed by a stream of opcode driven commands:
+ *
+ *   0x00              end of stream
+ *   0x01-0x3f         copy the next (op) bytes verbatim
+ *   0x40-0x4f         byte ramp: emit (op & 0x0f) + 3 bytes, each the
+ *                     previous output byte plus the fixed difference of
+ *                     the last two output bytes
+ *   0x50-0x5f         word ramp: emit (op & 0x0f) + 2 little endian
+ *                     words, each the previous output word plus the
+ *                     fixed difference of the last two output words
+ *   0x60-0x6f         repeat the last output byte (op & 0x0f) + 3 times
+ *   0x70-0x7f         repeat the last output word (op & 0x0f) + 2 times
+ *   0x80-0xbf         copy 3 bytes from (op & 0x3f) + 3 bytes back in
+ *                     the output
+ *   0xc0-0xdf op2     copy ((op >> 2) & 0x07) + 4 bytes from
+ *                     (((op & 0x03) << 8) | op2) + 3 bytes back
+ *   0xe0-0xff op2 op3 copy (op3) + 5 bytes from
+ *                     (((op & 0x1f) << 8) | op2) + 3 bytes back
+ *
+ * Back references may overlap the bytes they produce and must be copied
+ * front to back one byte at a time.
+ */
+
+/* A mangled file begins with the 4 byte decompressed size, and the
+ * compressors always open with a verbatim copy long enough to cover the
+ * signature of the file inside.  So the byte at offset 4 is a literal
+ * opcode and the HMP/HMI magic sits at offset 5. */
+int _WM_IsMangled(const uint8_t *in, uint32_t insize) {
+    uint32_t run;
+
+    if (insize < 13)
+        return (0);
+    run = in[4];
+    if (run < 8 || run > 0x3f)
+        return (0);
+    if (!memcmp(&in[5], "HMIMIDIP", 8))
+        return (1);
+    if (run >= 12 && insize >= 17 && !memcmp(&in[5], "HMI-MIDISONG", 12))
+        return (1);
+    return (0);
+}
+
+int _WM_Unmangle(const uint8_t *in, uint32_t insize,
+                 uint8_t **out, uint32_t *outsize) {
+    uint8_t *dst;
+    uint32_t dstsize;
+    uint32_t inpos, outpos;
+    uint32_t op, count, offset, i;
+
+    *out = NULL;
+    *outsize = 0;
+
+    if (insize < 5) {
+        _WM_GLOBAL_ERROR(WM_ERR_CORUPT, "(too short)", 0);
+        return (-1);
+    }
+
+    dstsize = (uint32_t)in[0] | ((uint32_t)in[1] << 8) |
+              ((uint32_t)in[2] << 16) | ((uint32_t)in[3] << 24);
+    if (dstsize == 0 || dstsize > WM_MAXFILESIZE) {
+        _WM_GLOBAL_ERROR(WM_ERR_CORUPT, "(bad size)", 0);
+        return (-1);
+    }
+
+    dst = (uint8_t *) malloc(dstsize);
+    if (dst == NULL) {
+        _WM_GLOBAL_ERROR(WM_ERR_MEM, NULL, 0);
+        return (-1);
+    }
+
+    inpos = 4;
+    outpos = 0;
+
+    while (inpos < insize && outpos < dstsize) {
+        op = in[inpos++];
+
+        if (op == 0x00) { /* end of stream */
+            break;
+        }
+        else if (op <= 0x3f) { /* verbatim copy */
+            count = op;
+            if (count > insize - inpos || count > dstsize - outpos)
+                goto _bad;
+            memcpy(&dst[outpos], &in[inpos], count);
+            inpos += count;
+            outpos += count;
+        }
+        else if (op <= 0x4f) { /* byte ramp */
+            uint8_t step;
+            count = (op & 0x0f) + 3;
+            if (outpos < 2 || count > dstsize - outpos)
+                goto _bad;
+            step = dst[outpos - 1] - dst[outpos - 2];
+            for (i = 0; i < count; i++) {
+                dst[outpos] = dst[outpos - 1] + step;
+                outpos++;
+            }
+        }
+        else if (op <= 0x5f) { /* word ramp */
+            uint16_t word, step;
+            count = (op & 0x0f) + 2;
+            if (outpos < 4 || count > (dstsize - outpos) / 2)
+                goto _bad;
+            word = dst[outpos - 2] | (dst[outpos - 1] << 8);
+            step = word - (dst[outpos - 4] | (dst[outpos - 3] << 8));
+            for (i = 0; i < count; i++) {
+                word += step;
+                dst[outpos++] = word & 0xff;
+                dst[outpos++] = (word >> 8) & 0xff;
+            }
+        }
+        else if (op <= 0x6f) { /* byte run */
+            count = (op & 0x0f) + 3;
+            if (outpos < 1 || count > dstsize - outpos)
+                goto _bad;
+            memset(&dst[outpos], dst[outpos - 1], count);
+            outpos += count;
+        }
+        else if (op <= 0x7f) { /* word run */
+            count = (op & 0x0f) + 2;
+            if (outpos < 2 || count > (dstsize - outpos) / 2)
+                goto _bad;
+            for (i = 0; i < count; i++) {
+                dst[outpos] = dst[outpos - 2];
+                dst[outpos + 1] = dst[outpos - 1];
+                outpos += 2;
+            }
+        }
+        else { /* back reference */
+            if (op <= 0xbf) {
+                offset = (op & 0x3f) + 3;
+                count = 3;
+            } else if (op <= 0xdf) {
+                if (inpos >= insize)
+                    goto _bad;
+                offset = (((op & 0x03) << 8) | in[inpos++]) + 3;
+                count = ((op >> 2) & 0x07) + 4;
+            } else {
+                if (insize - inpos < 2)
+                    goto _bad;
+                offset = (((op & 0x1f) << 8) | in[inpos++]) + 3;
+                count = in[inpos++] + 5;
+            }
+            if (offset > outpos || count > dstsize - outpos)
+                goto _bad;
+            /* may overlap: copy front to back */
+            for (i = 0; i < count; i++) {
+                dst[outpos] = dst[outpos - offset];
+                outpos++;
+            }
+        }
+    }
+
+    if (outpos != dstsize)
+        goto _bad;
+
+    *out = dst;
+    *outsize = dstsize;
+    return (0);
+
+_bad:
+    free(dst);
+    _WM_GLOBAL_ERROR(WM_ERR_CORUPT, NULL, 0);
+    return (-1);
+}
+
+struct hmp_ctx {
+    uint8_t *dst, *dst_ptr;
+    uint32_t dstsize, dstrem;
+    int oom;
+};
+
+#define DST_CHUNK 8192
+static void resize_dst(struct hmp_ctx *ctx) {
+    uint32_t pos = ctx->dst_ptr - ctx->dst;
+    uint8_t *newdst;
+
+    if (ctx->oom)
+        return;
+    newdst = (uint8_t *) realloc(ctx->dst, ctx->dstsize + DST_CHUNK);
+    if (newdst == NULL) {
+        ctx->oom = 1;
+        return;
+    }
+    ctx->dst = newdst;
+    ctx->dstsize += DST_CHUNK;
+    ctx->dstrem += DST_CHUNK;
+    ctx->dst_ptr = ctx->dst + pos;
+}
+
+static void write1(struct hmp_ctx *ctx, uint32_t val)
+{
+    if (ctx->dstrem < 1) {
+        resize_dst(ctx);
+        if (ctx->dstrem < 1)
+            return;
+    }
+    *ctx->dst_ptr++ = val & 0xff;
+    ctx->dstrem--;
+}
+
+static void write2(struct hmp_ctx *ctx, uint32_t val)
+{
+    if (ctx->dstrem < 2) {
+        resize_dst(ctx);
+        if (ctx->dstrem < 2)
+            return;
+    }
+    *ctx->dst_ptr++ = (val>>8) & 0xff;
+    *ctx->dst_ptr++ = val & 0xff;
+    ctx->dstrem -= 2;
+}
+
+static void write4(struct hmp_ctx *ctx, uint32_t val)
+{
+    if (ctx->dstrem < 4) {
+        resize_dst(ctx);
+        if (ctx->dstrem < 4)
+            return;
+    }
+    *ctx->dst_ptr++ = (val>>24)&0xff;
+    *ctx->dst_ptr++ = (val>>16)&0xff;
+    *ctx->dst_ptr++ = (val>>8) & 0xff;
+    *ctx->dst_ptr++ = val & 0xff;
+    ctx->dstrem -= 4;
+}
+
+static void writen(struct hmp_ctx *ctx, const uint8_t *data, uint32_t len)
+{
+    while (ctx->dstrem < len) {
+        resize_dst(ctx);
+        if (ctx->oom)
+            return;
+    }
+    memcpy(ctx->dst_ptr, data, len);
+    ctx->dst_ptr += len;
+    ctx->dstrem -= len;
+}
+
+static void seekdst(struct hmp_ctx *ctx, uint32_t pos) {
+    while (ctx->dstsize < pos) {
+        resize_dst(ctx);
+        if (ctx->oom)
+            return;
+    }
+    ctx->dst_ptr = ctx->dst + pos;
+    ctx->dstrem = ctx->dstsize - pos;
+}
+
+static void skipdst(struct hmp_ctx *ctx, int32_t pos) {
+    size_t newpos = (ctx->dst_ptr - ctx->dst) + pos;
+    while (ctx->dstsize < newpos) {
+        resize_dst(ctx);
+        if (ctx->oom)
+            return;
+    }
+    ctx->dst_ptr = ctx->dst + newpos;
+    ctx->dstrem = ctx->dstsize - newpos;
+}
+
+static uint32_t getdstpos(struct hmp_ctx *ctx) {
+    return (ctx->dst_ptr - ctx->dst);
+}
+
+/* Conventional MIDI variable length quantity */
+static void putvlq(struct hmp_ctx *ctx, uint32_t value) {
+    uint32_t buffer;
+
+    buffer = value & 0x7F;
+    while (value >>= 7) {
+        buffer <<= 8;
+        buffer |= ((value & 0x7F) | 0x80);
+    }
+    while (1) {
+        write1(ctx, buffer & 0xFF);
+        if (buffer & 0x80)
+            buffer >>= 8;
+        else
+            break;
+    }
+}
+
+/* HMP delta: high bit clear = continuation (LSB first), high bit set = last */
+static int get_hmp_vlq(const uint8_t **pp, uint32_t *remaining, uint32_t *quant) {
+    const uint8_t *p = *pp;
+    uint32_t shift = 0;
+
+    *quant = 0;
+    while (*remaining) {
+        (*remaining)--;
+        if (*p & 0x80) {
+            *quant |= (uint32_t)(*p++ & 0x7F) << shift;
+            *pp = p;
+            return (0);
+        }
+        *quant |= (uint32_t)(*p++ & 0x7F) << shift;
+        shift += 7;
+    }
+    return (-1);
+}
+
+/* Conventional MIDI variable length quantity */
+static int get_vlq(const uint8_t **pp, uint32_t *remaining, uint32_t *quant) {
+    const uint8_t *p = *pp;
+
+    *quant = 0;
+    while (*remaining) {
+        (*remaining)--;
+        *quant = (*quant << 7) | (*p & 0x7F);
+        if (!(*p++ & 0x80)) {
+            *pp = p;
+            return (0);
+        }
+    }
+    return (-1);
+}
+
+#define READ_INT32LE(b) ((uint32_t)((b)[0] | ((b)[1] << 8) | ((b)[2] << 16) | ((b)[3] << 24)))
+
+int _WM_hmp2midi(const uint8_t *in, uint32_t insize,
+                 uint8_t **out, uint32_t *outsize) {
+    struct hmp_ctx ctx;
+    uint8_t is_hmp2 = 0;
+    uint32_t zero_cnt;
+    uint32_t i;
+    uint32_t hmp_chunks;
+    uint32_t hmp_bpm;
+    uint32_t tempo;
+    const uint8_t *p;
+    uint32_t remaining;
+    int ret = -1;
+
+    memset(&ctx, 0, sizeof(struct hmp_ctx));
+
+    if (insize < 776) {
+        _WM_GLOBAL_ERROR(WM_ERR_CORUPT, "(too short)", 0);
+        return (-1);
+    }
+
+    if (memcmp(in, "HMIMIDIP", 8)) {
+        _WM_GLOBAL_ERROR(WM_ERR_NOT_HMP, NULL, 0);
+        return (-1);
+    }
+    p = in + 8;
+    remaining = insize - 8;
+
+    if (!memcmp(p, "013195", 6)) {
+        if (remaining < 896) {
+            _WM_GLOBAL_ERROR(WM_ERR_CORUPT, "(too short)", 0);
+            return (-1);
+        }
+        p += 6;
+        remaining -= 6;
+        is_hmp2 = 1;
+    }
+
+    /* should be a bunch of \0's */
+    zero_cnt = is_hmp2 ? 18 : 24;
+    for (i = 0; i < zero_cnt; i++) {
+        if (p[i] != 0) {
+            _WM_GLOBAL_ERROR(WM_ERR_NOT_HMP, NULL, 0);
+            return (-1);
+        }
+    }
+    p += zero_cnt;
+    remaining -= zero_cnt;
+
+    /* file length, next 12 bytes normally \0: skip over them */
+    p += 4 + 12;
+    remaining -= 4 + 12;
+
+    hmp_chunks = READ_INT32LE(p);
+    p += 4;
+    remaining -= 4;
+
+    if (!hmp_chunks) {
+        _WM_GLOBAL_ERROR(WM_ERR_CORUPT, "(no tracks)", 0);
+        return (-1);
+    }
+
+    /* unknown */
+    p += 4;
+    remaining -= 4;
+
+    /* beats per minute */
+    hmp_bpm = READ_INT32LE(p);
+    p += 4;
+    remaining -= 4;
+
+    if (!hmp_bpm) {
+        _WM_GLOBAL_ERROR(WM_ERR_INVALID, "(bad bpm)", 0);
+        return (-1);
+    }
+    tempo = 60000000 / hmp_bpm;
+
+    /* song time, then the remainder of the header */
+    p += 4;
+    remaining -= 4;
+    if (is_hmp2) {
+        p += 840;
+        remaining -= 840;
+    } else {
+        p += 712;
+        remaining -= 712;
+    }
+
+    ctx.dst = (uint8_t *) malloc(DST_CHUNK);
+    if (ctx.dst == NULL) {
+        _WM_GLOBAL_ERROR(WM_ERR_MEM, NULL, 0);
+        return (-1);
+    }
+    ctx.dst_ptr = ctx.dst;
+    ctx.dstsize = DST_CHUNK;
+    ctx.dstrem = DST_CHUNK;
+
+    /* MIDI header; +1 track for the tempo track */
+    write1(&ctx, 'M');
+    write1(&ctx, 'T');
+    write1(&ctx, 'h');
+    write1(&ctx, 'd');
+    write4(&ctx, 6);
+    write2(&ctx, 1);                /* type 1: tracks play simultaneously */
+    write2(&ctx, hmp_chunks + 1);
+    write2(&ctx, HMP_DIVISIONS);
+
+    /* tempo track */
+    write1(&ctx, 'M');
+    write1(&ctx, 'T');
+    write1(&ctx, 'r');
+    write1(&ctx, 'k');
+    write4(&ctx, 11);
+    write1(&ctx, 0x00); /* delta time */
+    write1(&ctx, 0xff); /* set tempo */
+    write2(&ctx, 0x5103);
+    write1(&ctx, (tempo & 0x00ff0000) >> 16);
+    write1(&ctx, (tempo & 0x0000ff00) >> 8);
+    write1(&ctx, tempo & 0x000000ff);
+    write1(&ctx, 0x00); /* delta time */
+    write1(&ctx, 0xff); /* end of track */
+    write2(&ctx, 0x2f00);
+
+    for (i = 0; i < hmp_chunks; i++) {
+        const uint8_t *chunk;
+        uint32_t chunk_length;
+        uint32_t track_size_pos, begin_track_pos, current_pos;
+        uint32_t delta = 0;
+        uint32_t pending_delta;
+        int track_end = 0;
+
+        if (remaining < 12) {
+            goto tooshort;
+        }
+
+        chunk = p;
+        chunk_length = READ_INT32LE(&p[4]);
+
+        if (chunk_length < 12 || chunk_length > remaining) {
+            goto tooshort;
+        }
+        remaining -= chunk_length;
+
+        /* chunk number, chunk length and track number */
+        p += 12;
+        chunk_length -= 12;
+
+        begin_track_pos = getdstpos(&ctx);
+        write1(&ctx, 'M');
+        write1(&ctx, 'T');
+        write1(&ctx, 'r');
+        write1(&ctx, 'k');
+        track_size_pos = getdstpos(&ctx);
+        skipdst(&ctx, 4);
+
+        if (get_hmp_vlq(&p, &chunk_length, &delta) < 0) {
+            goto tooshort;
+        }
+        pending_delta = delta;
+
+        while (!track_end) {
+            uint32_t event_size;
+            uint8_t status;
+
+            if (!chunk_length) {
+                goto tooshort;
+            }
+            status = p[0];
+
+            if (((status & 0xf0) == 0xb0) && (chunk_length >= 3)
+                    && ((p[1] == 110) || (p[1] == 111)) && (p[2] > 0x7f)) {
+                /* Reserved for loop markers: drop them but keep the delta */
+                p += 3;
+                chunk_length -= 3;
+            } else {
+                switch (status >> 4) {
+                case 0x8:
+                case 0x9:
+                case 0xa:
+                case 0xb:
+                case 0xe:
+                    event_size = 3;
+                    break;
+                case 0xc:
+                case 0xd:
+                    event_size = 2;
+                    break;
+                case 0xf:
+                    if (status == 0xff) {
+                        uint32_t meta_length = 0;
+                        const uint8_t *meta = p + 2;
+                        uint32_t meta_remaining;
+
+                        if (chunk_length < 2) {
+                            goto tooshort;
+                        }
+                        meta_remaining = chunk_length - 2;
+                        if (get_vlq(&meta, &meta_remaining, &meta_length) < 0) {
+                            goto tooshort;
+                        }
+                        if (meta_length > meta_remaining) {
+                            goto tooshort;
+                        }
+                        event_size = (meta - p) + meta_length;
+                        if (p[1] == 0x2f) {
+                            track_end = 1;
+                        }
+                    } else if ((status == 0xf0) || (status == 0xf7)) {
+                        uint32_t sysex_length = 0;
+                        const uint8_t *sysex = p + 1;
+                        uint32_t sysex_remaining;
+
+                        if (chunk_length < 1) {
+                            goto tooshort;
+                        }
+                        sysex_remaining = chunk_length - 1;
+                        if (get_vlq(&sysex, &sysex_remaining, &sysex_length) < 0) {
+                            goto tooshort;
+                        }
+                        if (sysex_length > sysex_remaining) {
+                            goto tooshort;
+                        }
+                        event_size = (sysex - p) + sysex_length;
+                    } else {
+                        _WM_GLOBAL_ERROR(WM_ERR_CORUPT, "(unrecognized event)", 0);
+                        goto _end;
+                    }
+                    break;
+                default:
+                    /* HMP events always carry their status byte */
+                    _WM_GLOBAL_ERROR(WM_ERR_CORUPT, "(unrecognized event)", 0);
+                    goto _end;
+                }
+
+                if (event_size > chunk_length) {
+                    goto tooshort;
+                }
+                putvlq(&ctx, pending_delta);
+                writen(&ctx, p, event_size);
+                pending_delta = 0;
+                p += event_size;
+                chunk_length -= event_size;
+            }
+
+            if (track_end) {
+                break;
+            }
+            if (get_hmp_vlq(&p, &chunk_length, &delta) < 0) {
+                goto tooshort;
+            }
+            pending_delta += delta;
+        }
+
+        /* write out track length */
+        current_pos = getdstpos(&ctx);
+        seekdst(&ctx, track_size_pos);
+        write4(&ctx, current_pos - begin_track_pos - TRK_CHUNKSIZE);
+        seekdst(&ctx, current_pos);
+
+        /* goto start of next chunk */
+        p = chunk + READ_INT32LE(&chunk[4]);
+
+        if (ctx.oom) {
+            _WM_GLOBAL_ERROR(WM_ERR_MEM, NULL, 0);
+            goto _end;
+        }
+    }
+
+    *out = ctx.dst;
+    *outsize = ctx.dstsize - ctx.dstrem;
+    return (0);
+
+tooshort:
+    _WM_GLOBAL_ERROR(WM_ERR_CORUPT, "(too short)", 0);
+_end:
+    free(ctx.dst);
+    *out = NULL;
+    *outsize = 0;
+    return (ret);
+}

--- a/src/wildmidi_lib.c
+++ b/src/wildmidi_lib.c
@@ -51,6 +51,8 @@
 #include "sample.h"
 #include "mus2mid.h"
 #include "xmi2mid.h"
+#include "hmp2mid.h"
+#include "hmi2mid.h"
 #ifdef WILDMIDI_SF2
 #include "sf2.h"
 #endif
@@ -1613,6 +1615,24 @@ WM_SYMBOL int WildMidi_ConvertBufferToMidi (const uint8_t *in, uint32_t insize,
         return (-1);
     }
 
+    if (_WM_IsMangled(in, insize)) {
+        /* Gremlin games ship their HMP files compressed */
+        uint8_t *unmangled = NULL;
+        uint32_t unmangled_size = 0;
+        int ret;
+
+        if (_WM_Unmangle(in, insize, &unmangled, &unmangled_size) < 0) {
+            return (-1);
+        }
+        if (unmangled_size >= 12 && !memcmp(unmangled, "HMI-MIDISONG", 12)) {
+            ret = _WM_hmi2midi(unmangled, unmangled_size, out, outsize);
+        } else {
+            ret = _WM_hmp2midi(unmangled, unmangled_size, out, outsize);
+        }
+        free(unmangled);
+        return (ret);
+    }
+
     if (!memcmp(in, "FORM", 4)) {
         if (_WM_xmi2midi(in, insize, out, outsize,
                 _cvt_get_option(WM_CO_XMI_TYPE)) < 0) {
@@ -1622,6 +1642,16 @@ WM_SYMBOL int WildMidi_ConvertBufferToMidi (const uint8_t *in, uint32_t insize,
     else if (!memcmp(in, "MUS", 3)) {
         if (_WM_mus2midi(in, insize, out, outsize,
                 _cvt_get_option(WM_CO_FREQUENCY)) < 0) {
+            return (-1);
+        }
+    }
+    else if (insize >= 12 && !memcmp(in, "HMI-MIDISONG", 12)) {
+        if (_WM_hmi2midi(in, insize, out, outsize) < 0) {
+            return (-1);
+        }
+    }
+    else if (insize >= 8 && !memcmp(in, "HMIMIDIP", 8)) {
+        if (_WM_hmp2midi(in, insize, out, outsize) < 0) {
             return (-1);
         }
     }
@@ -1805,11 +1835,44 @@ WM_SYMBOL int WildMidi_Close(midi * handle) {
     return (0);
 }
 
+/* Detects the file format and parses the buffer into an mdi.
+ * Requires size >= 18. */
+static midi *parse_midi_buffer(const uint8_t *mididata, uint32_t midisize) {
+    uint8_t mus_hdr[] = { 'M', 'U', 'S', 0x1A };
+    uint8_t xmi_hdr[] = { 'F', 'O', 'R', 'M' };
+    midi * ret = NULL;
+
+    if (_WM_IsMangled(mididata, midisize)) {
+        /* Gremlin games ship their HMP files compressed */
+        uint8_t *unmangled = NULL;
+        uint32_t unmangled_size = 0;
+
+        if (_WM_Unmangle(mididata, midisize, &unmangled, &unmangled_size) == 0) {
+            if (unmangled_size >= 18 && memcmp(unmangled, "HMI-MIDISONG061595", 18) == 0) {
+                ret = (void *) _WM_ParseNewHmi(unmangled, unmangled_size);
+            } else {
+                ret = (void *) _WM_ParseNewHmp(unmangled, unmangled_size);
+            }
+            free(unmangled);
+        }
+    } else if (memcmp(mididata,"HMIMIDIP", 8) == 0) {
+        ret = (void *) _WM_ParseNewHmp(mididata, midisize);
+    } else if (memcmp(mididata, "HMI-MIDISONG061595", 18) == 0) {
+        ret = (void *) _WM_ParseNewHmi(mididata, midisize);
+    } else if (memcmp(mididata, mus_hdr, 4) == 0) {
+        ret = (void *) _WM_ParseNewMus(mididata, midisize);
+    } else if (memcmp(mididata, xmi_hdr, 4) == 0) {
+        ret = (void *) _WM_ParseNewXmi(mididata, midisize);
+    } else {
+        ret = (void *) _WM_ParseNewMidi(mididata, midisize);
+    }
+
+    return (ret);
+}
+
 WM_SYMBOL midi *WildMidi_Open(const char *midifile) {
     uint8_t *mididata = NULL;
     uint32_t midisize = 0;
-    uint8_t mus_hdr[] = { 'M', 'U', 'S', 0x1A };
-    uint8_t xmi_hdr[] = { 'F', 'O', 'R', 'M' };
     midi * ret = NULL;
 
     if (!WM_Initialized) {
@@ -1828,17 +1891,7 @@ WM_SYMBOL midi *WildMidi_Open(const char *midifile) {
         _WM_GLOBAL_ERROR(WM_ERR_CORUPT, "(too short)", 0);
         return (NULL);
     }
-    if (memcmp(mididata,"HMIMIDIP", 8) == 0) {
-        ret = (void *) _WM_ParseNewHmp(mididata, midisize);
-    } else if (memcmp(mididata, "HMI-MIDISONG061595", 18) == 0) {
-        ret = (void *) _WM_ParseNewHmi(mididata, midisize);
-    } else if (memcmp(mididata, mus_hdr, 4) == 0) {
-        ret = (void *) _WM_ParseNewMus(mididata, midisize);
-    } else if (memcmp(mididata, xmi_hdr, 4) == 0) {
-        ret = (void *) _WM_ParseNewXmi(mididata, midisize);
-    } else {
-        ret = (void *) _WM_ParseNewMidi(mididata, midisize);
-    }
+    ret = parse_midi_buffer(mididata, midisize);
     _WM_FreeBufferFile(mididata);
 
     if (ret) {
@@ -1852,8 +1905,6 @@ WM_SYMBOL midi *WildMidi_Open(const char *midifile) {
 }
 
 WM_SYMBOL midi *WildMidi_OpenBuffer(const uint8_t *midibuffer, uint32_t size) {
-    uint8_t mus_hdr[] = { 'M', 'U', 'S', 0x1A };
-    uint8_t xmi_hdr[] = { 'F', 'O', 'R', 'M' };
     midi * ret = NULL;
 
     if (!WM_Initialized) {
@@ -1873,17 +1924,7 @@ WM_SYMBOL midi *WildMidi_OpenBuffer(const uint8_t *midibuffer, uint32_t size) {
         _WM_GLOBAL_ERROR(WM_ERR_CORUPT, "(too short)", 0);
         return (NULL);
     }
-    if (memcmp(midibuffer,"HMIMIDIP", 8) == 0) {
-        ret = (void *) _WM_ParseNewHmp(midibuffer, size);
-    } else if (memcmp(midibuffer, "HMI-MIDISONG061595", 18) == 0) {
-        ret = (void *) _WM_ParseNewHmi(midibuffer, size);
-    } else if (memcmp(midibuffer, mus_hdr, 4) == 0) {
-        ret = (void *) _WM_ParseNewMus(midibuffer, size);
-    } else if (memcmp(midibuffer, xmi_hdr, 4) == 0) {
-        ret = (void *) _WM_ParseNewXmi(midibuffer, size);
-    } else {
-        ret = (void *) _WM_ParseNewMidi(midibuffer, size);
-    }
+    ret = parse_midi_buffer(midibuffer, size);
 
     if (ret) {
         if (add_handle(ret) != 0) {


### PR DESCRIPTION
**Validation**
Tested using HMI and HMP files provided in #75 
[testfiles.zip](https://github.com/user-attachments/files/29889005/testfiles.zip)

- All 11 files convert; rendered original vs converted to WAV with the player: all 9 HMPs byte-identical PCM; both HMIs identical length 

Closes #181

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added HMP and HMI file support for playback and MIDI conversion.
  * Added support for compressed (“mangled”) HMP files from select classic games.
  * The `-x/--tomidi` option and conversion APIs now accept MUS, XMI, HMP, and HMI formats.

* **Documentation**
  * Updated user and API documentation to describe the new supported formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->