### PR TITLE
fix xmi looping issues

### DIFF
--- a/src/f_xmidi.c
+++ b/src/f_xmidi.c
@@ -59,6 +59,7 @@ struct _mdi *_WM_ParseNewXmi(const uint8_t *xmi_data, uint32_t xmi_size) {
     uint32_t setup_ret = 0;
     uint32_t xmi_delta = 0;
     uint32_t xmi_lowestdelta = 0;
+    uint8_t xmi_loop_forever = 0;
 
     uint32_t xmi_evnt_cnt = 0;
 
@@ -246,6 +247,9 @@ struct _mdi *_WM_ParseNewXmi(const uint8_t *xmi_data, uint32_t xmi_size) {
                 xmi_size -= 8;
                 xmi_subformlen -= 8;
 
+                /* Each EVNT chunk is an independent sequence */
+                xmi_loop_forever = 0;
+
                 do {
                     if (*xmi_data < 0x80) {
                         xmi_delta = 0;
@@ -316,6 +320,34 @@ struct _mdi *_WM_ParseNewXmi(const uint8_t *xmi_data, uint32_t xmi_size) {
                             /* Ignore tempo events */
                             setup_ret = 6;
                             goto _XMI_Next_Event;
+                        }
+                        if (((xmi_data[0] & 0xf0) == 0xb0) && (xmi_evntlen >= 3) && (xmi_size >= 3)) {
+                            /* AIL XMIDI FOR..NEXT loop controllers: 116 opens
+                             * a loop (value = iteration count, 0 = forever)
+                             * and 117 (value >= 64) branches back to it. An
+                             * infinite loop never plays past its end marker,
+                             * so treat that marker as the end of the song:
+                             * some files (TES: Arena) carry minutes of junk
+                             * events or delay padding after it which must
+                             * neither be played nor counted in the duration. */
+                            if ((xmi_data[1] == 116) && (xmi_data[2] == 0)) {
+                                xmi_loop_forever = 1;
+                            } else if ((xmi_data[1] == 117) && (xmi_data[2] >= 64) && xmi_loop_forever) {
+                                for (j = 0; j < (16*128); j++) {
+                                    if (xmi_notelen[j] == 0) continue;
+                                    xmi_ch = j / 128;
+                                    xmi_note = j - (xmi_ch * 128);
+                                    _WM_midi_setup_noteoff(xmi_mdi, xmi_ch, xmi_note, 0);
+                                    xmi_notelen[j] = 0;
+                                }
+                                _WM_midi_setup_endoftrack(xmi_mdi);
+                                xmi_data += xmi_evntlen;
+                                xmi_size -= xmi_evntlen;
+                                xmi_subformlen -= xmi_evntlen;
+                                xmi_evntlen = 0;
+                                xmi_lowestdelta = 0;
+                                break;
+                            }
                         }
                         if ((setup_ret = _WM_SetupMidiEvent(xmi_mdi,xmi_data, xmi_size, 0)) == 0) {
                             goto _xmi_end;

--- a/src/xmi2mid.c
+++ b/src/xmi2mid.c
@@ -769,6 +769,7 @@ static int32_t ConvertFiletoList(struct xmi_ctx *ctx) {
     int32_t end = 0;
     int32_t tempo = 500000;
     int32_t tempo_set = 0;
+    int32_t loop_forever = 0;
     uint32_t status = 0;
     uint32_t file_size = getsrcsize(ctx);
 
@@ -794,8 +795,35 @@ static int32_t ConvertFiletoList(struct xmi_ctx *ctx) {
         /* 2 byte data */
         case MIDI_STATUS_NOTE_OFF:
         case MIDI_STATUS_AFTERTOUCH:
-        case MIDI_STATUS_CONTROLLER:
         case MIDI_STATUS_PITCH_WHEEL:
+            ConvertEvent(ctx, time, status, 2);
+            break;
+
+        case MIDI_STATUS_CONTROLLER:
+            /* AIL XMIDI FOR..NEXT loop controllers: 116 opens a loop
+             * (value = iteration count, 0 = forever) and 117 (value >= 64)
+             * branches back to it. An infinite loop never plays past its
+             * end marker, so treat that marker as the end of the track:
+             * some files (TES: Arena) carry minutes of junk events or
+             * delay padding after it. */
+            if (getsrcpos(ctx) + 2 <= file_size &&
+                ctx->src_ptr[0] == 116 && ctx->src_ptr[1] == 0) {
+                loop_forever = 1;
+            } else if (getsrcpos(ctx) + 2 <= file_size && loop_forever &&
+                       ctx->src_ptr[0] == 117 && ctx->src_ptr[1] >= 64) {
+                midi_event *ev;
+                /* pull note offs scheduled past the loop end back to it,
+                 * then close the track here */
+                for (ev = ctx->list; ev != NULL; ev = ev->next) {
+                    if (ev->time > time) ev->time = time;
+                }
+                CreateNewEvent(ctx, time);
+                ctx->current->status = 0xFF;
+                ctx->current->data[0] = 0x2F;
+                ctx->current->len = 0;
+                end = 1;
+                break;
+            }
             ConvertEvent(ctx, time, status, 2);
             break;
 


### PR DESCRIPTION
Closes #149 

We now recognize the AIL XMIDI FOR..NEXT loop controllers: CC 116 with value 0 opens an infinite loop, and CC 117 with value ≥ 64 marks its end. Since an infinite loop never plays past its end marker, that marker is treated as end-of-song, so the junk events and delay padding after it are neither played nor counted.

The intended infinite repeat is now the player's/caller's decision (e.g. wildmidi's existing looping), which matches how the XFM versions of these songs behave.

| File         | Before   | After                | Reference (XFM) |
|--------------|----------|----------------------|-----------------|
| OVERSNOW.XMI | 4m 14s   | **1m 21s**           | 1m 21s          |
| SUNNYDAY.XMI | 166m 34s | **0m 48s**           | 0m 48s          |
| VISION.XMI   | 0m 33s   | 0m 33s (unchanged)   | —               |

https://www.dropbox.com/s/thv5bmln4s2gwnv/xmi_files.tar.gz?dl=0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of XMIDI files that use infinite loop markers.
  * Playback and MIDI conversion now stop cleanly at the loop boundary instead of continuing indefinitely.
  * Active notes are properly ended when an infinite loop concludes.
  * MIDI output now includes a correct end-of-track event for these files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->