### PR TITLE
Add Yamaha MA FM synthesis for SMAF, plus HandyPhone score support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,6 +69,7 @@ OPTION(WANT_OPENAL "Include OpenAL (Cross Platform) support" OFF)
 OPTION(WANT_DEVTEST "Build WildMIDI DevTest file to check files" OFF)
 
 OPTION(WANT_SF2 "SoundFont2 (SF2) support via TinySoundFont" ON)
+OPTION(WANT_MAFM "Yamaha MA-series FM synthesis for SMAF files" ON)
 
 CMAKE_DEPENDENT_OPTION(WANT_MP_BUILD "Build with Multiple Processes (/MP)" OFF "WIN32;MSVC" OFF)
 CMAKE_DEPENDENT_OPTION(WANT_OSX_DEPLOYMENT "OSX Deployment" OFF "APPLE" OFF)
@@ -217,6 +218,10 @@ ENDIF()
 
 IF (WANT_SF2)
     SET(WILDMIDI_SF2 1)
+ENDIF()
+
+IF (WANT_MAFM)
+    SET(WILDMIDI_MAFM 1)
 ENDIF()
 
 IF (AMIGA OR AROS)

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,33 @@
+WildMIDI — third-party attributions
+===================================
+
+This product includes software developed by third parties, retained under
+their original licenses.  This NOTICE file is provided in satisfaction of the
+attribution requirements of those licenses.
+
+--------------------------------------------------------------------------------
+Yamaha MA-series FM / ADPCM synthesis (src/mafm/)
+--------------------------------------------------------------------------------
+
+The files under src/mafm/ are ported to C from the akustikrausch
+"yamaha-smaf-player" project:
+
+    https://github.com/akustikrausch/yamaha-smaf-player
+    Copyright (c) Andreas Wendorf (Akustikrausch)
+    Licensed under the Apache License, Version 2.0.
+
+The C translation preserves the original algorithms.  Each ported file retains
+its "SPDX-License-Identifier: Apache-2.0" header.  A copy of the Apache License,
+Version 2.0 is available at:
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Ported so far:
+    src/mafm/yamaha_adpcm.{c,h}   -- 4-bit Yamaha (OPNA-B) ADPCM codec
+    src/mafm/smaf_voice.{c,h}     -- VM35 / VMA voice-exclusive -> FM patch decode
+    src/mafm/ma_fm_core.{c,h}     -- FM DSP: operators, envelopes, 2/4-op voices
+
+The WildMIDI-side wrapper (src/mafm.c, include/mafm.h) that drives this synth is
+original WildMIDI code under the project's usual GPL/LGPL, not Apache-2.0.
+
+See docs/SMAF_FM.md for the design and the porting plan.

--- a/README.md
+++ b/README.md
@@ -73,6 +73,12 @@ cannot provide.
 CHANGELOG
 
 0.5.1 (unreleased)
+* Support for playing and converting Yamaha SMAF (`.mmf`) ringtone files:
+  the HandyPhone (MA-1/MA-2) and Mobile Standard (MA-3/MA-5) score formats.
+  The MA-7 "SEQU" format is not supported.
+* Yamaha MA-series FM synthesis for SMAF: a file carrying a custom FM voice
+  bank plays with its own instruments and embedded ADPCM percussion instead
+  of a General MIDI approximation. `WANT_MAFM=ON`; see `docs/SMAF_FM.md`.
 * Player: playlist support. A filename given to the player may now be a
   directory, which is searched recursively for files to play (bug #215.)
 * Player: new `-S/--shuffle` switch plays the files in random order.

--- a/amiga/Makefile
+++ b/amiga/Makefile
@@ -51,11 +51,13 @@ endif
 	$(CC) -c $(CFLAGS) -o $@ $<
 %.o: ../src/%.c
 	$(CC) -c $(CFLAGS) -o $@ $<
+%.o: ../src/mafm/%.c
+	$(CC) -c $(CFLAGS) -o $@ $<
 %.o: ../src/player/%.c
 	$(CC) -c $(CFLAGS) -o $@ $<
 
 # Objects
-LIB_OBJ= wm_error.o file_io.o lock.o wildmidi_lib.o reverb.o gus_pat.o f_xmidi.o f_mus.o f_hmp.o f_midi.o f_hmi.o mus2mid.o xmi2mid.o hmp2mid.o hmi2mid.o internal_midi.o patches.o sample.o sf2.o synth.o opl3.o
+LIB_OBJ= wm_error.o file_io.o lock.o wildmidi_lib.o reverb.o gus_pat.o f_xmidi.o f_mus.o f_hmp.o f_midi.o f_hmi.o f_smaf.o mus2mid.o xmi2mid.o hmp2mid.o hmi2mid.o smaf2mid.o internal_midi.o patches.o sample.o sf2.o mafm.o ma_fm_core.o smaf_voice.o yamaha_adpcm.o synth.o opl3.o
 PLAYER_OBJ= amiga.o wm_tty.o playlist.o msleep.o getopt_long.o out_none.o out_wave.o out_ahi.o wildmidi.o
 
 # Build targets

--- a/amiga/Makefile.vbcc
+++ b/amiga/Makefile.vbcc
@@ -30,11 +30,13 @@ endif
 	$(CC) -c $(CFLAGS) -o $@ $<
 %.o: ../src/%.c
 	$(CC) -c $(CFLAGS) -o $@ $<
+%.o: ../src/mafm/%.c
+	$(CC) -c $(CFLAGS) -o $@ $<
 %.o: ../src/player/%.c
 	$(CC) -c $(CFLAGS) -o $@ $<
 
 # Objects
-LIB_OBJ= wm_error.o file_io.o lock.o wildmidi_lib.o reverb.o gus_pat.o f_xmidi.o f_mus.o f_hmp.o f_midi.o f_hmi.o mus2mid.o xmi2mid.o hmp2mid.o hmi2mid.o internal_midi.o patches.o sample.o sf2.o synth.o opl3.o
+LIB_OBJ= wm_error.o file_io.o lock.o wildmidi_lib.o reverb.o gus_pat.o f_xmidi.o f_mus.o f_hmp.o f_midi.o f_hmi.o f_smaf.o mus2mid.o xmi2mid.o hmp2mid.o hmi2mid.o smaf2mid.o internal_midi.o patches.o sample.o sf2.o mafm.o ma_fm_core.o smaf_voice.o yamaha_adpcm.o synth.o opl3.o
 PLAYER_OBJ= amiga.o wm_tty.o playlist.o msleep.o getopt_long.o out_none.o out_wave.o out_ahi.o wildmidi.o
 
 # Build targets

--- a/amiga/config.h
+++ b/amiga/config.h
@@ -21,6 +21,7 @@
 /* #undef HAVE_SQRTF */
 /* #undef HAVE_POWF */
 
+#define WILDMIDI_MAFM 1
 #define WILDMIDI_SF2 1
 
 #define AUDIODRV_AHI 1

--- a/android/jni/Android.mk
+++ b/android/jni/Android.mk
@@ -12,6 +12,7 @@ LOCAL_SRC_FILES := \
 	src/f_hmp.c \
 	src/f_midi.c \
 	src/f_mus.c \
+	src/f_smaf.c \
 	src/f_xmidi.c \
 	src/file_io.c \
 	src/gus_pat.c \
@@ -22,12 +23,17 @@ LOCAL_SRC_FILES := \
 	src/reverb.c \
 	src/sample.c \
 	src/sf2.c \
+	src/mafm.c \
+	src/mafm/ma_fm_core.c \
+	src/mafm/smaf_voice.c \
+	src/mafm/yamaha_adpcm.c \
 	src/synth.c \
 	src/opl3.c \
 	src/wildmidi_lib.c \
 	src/wm_error.c \
 	src/xmi2mid.c \
 	src/hmp2mid.c \
-	src/hmi2mid.c
+	src/hmi2mid.c \
+	src/smaf2mid.c
 
 include $(BUILD_SHARED_LIBRARY)

--- a/android/jni/config.h
+++ b/android/jni/config.h
@@ -65,6 +65,7 @@
 #define HAVE_SQRTF 1
 #define HAVE_POWF 1
 
+#define WILDMIDI_MAFM 1
 #define WILDMIDI_SF2 1
 
 /* Define our audio drivers */

--- a/build.zig
+++ b/build.zig
@@ -4,6 +4,12 @@ pub fn build(b: *std.Build) void {
     const target = b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{});
 
+    // Yamaha MA-series FM synthesis for SMAF files.  On by default, but
+    // consumers can opt out with -Dmafm=false (mirrors the WANT_MAFM CMake
+    // option); the mafm sources then compile to their empty stubs.
+    const want_mafm = b.option(bool, "mafm", "Enable Yamaha MA FM synthesis for SMAF files") orelse true;
+    const mafm_define: ?i64 = if (want_mafm) 1 else null;
+
     const lib_mod = b.createModule(.{
         .target = target,
         .optimize = optimize,
@@ -31,14 +37,20 @@ pub fn build(b: *std.Build) void {
         "src/f_hmp.c",
         "src/f_hmi.c",
         "src/f_midi.c",
+        "src/f_smaf.c",
         "src/sample.c",
         "src/synth.c",
         "src/opl3.c",
         "src/sf2.c",
+        "src/mafm.c",
+        "src/mafm/ma_fm_core.c",
+        "src/mafm/smaf_voice.c",
+        "src/mafm/yamaha_adpcm.c",
         "src/mus2mid.c",
         "src/xmi2mid.c",
         "src/hmp2mid.c",
         "src/hmi2mid.c",
+        "src/smaf2mid.c",
     };
 
     const defaultFlags = .{
@@ -62,6 +74,7 @@ pub fn build(b: *std.Build) void {
             .HAVE_INTTYPES_H = 1,
             .WORDS_BIGENDIAN = null,
             .WILDMIDI_AMIGA = null,
+            .WILDMIDI_MAFM = mafm_define,
             .HAVE_SYS_SOUNDCARD_H = null,
             .AUDIODRV_ALSA = null,
             .AUDIODRV_OSS = null,

--- a/djgpp/Makefile
+++ b/djgpp/Makefile
@@ -50,6 +50,8 @@ endif
 	$(CC) -c $(CFLAGS) -o $@ $<
 %.o: ../src/%.c
 	$(CC) -c $(CFLAGS) -o $@ $<
+%.o: ../src/mafm/%.c
+	$(CC) -c $(CFLAGS) -o $@ $<
 %.o: ../src/player/%.c
 	$(CC) -c $(CFLAGS) -o $@ $<
 %.o: ../src/player/dos/%.c
@@ -57,7 +59,7 @@ endif
 
 
 # Objects
-LIB_OBJ= wm_error.o file_io.o lock.o wildmidi_lib.o reverb.o gus_pat.o f_xmidi.o f_mus.o f_hmp.o f_midi.o f_hmi.o mus2mid.o xmi2mid.o hmp2mid.o hmi2mid.o internal_midi.o patches.o sample.o sf2.o synth.o opl3.o
+LIB_OBJ= wm_error.o file_io.o lock.o wildmidi_lib.o reverb.o gus_pat.o f_xmidi.o f_mus.o f_hmp.o f_midi.o f_hmi.o f_smaf.o mus2mid.o xmi2mid.o hmp2mid.o hmi2mid.o smaf2mid.o internal_midi.o patches.o sample.o sf2.o mafm.o ma_fm_core.o smaf_voice.o yamaha_adpcm.o synth.o opl3.o
 PLAYER_OBJ= wm_tty.o playlist.o msleep.o getopt_long.o out_none.o dosirq.o dosdma.o dossb.o out_dossb.o out_wave.o wildmidi.o
 
 # Build targets

--- a/djgpp/config.h
+++ b/djgpp/config.h
@@ -20,6 +20,7 @@
 /* #undef HAVE_SQRTF */
 /* #undef HAVE_POWF */
 
+#define WILDMIDI_MAFM 1
 #define WILDMIDI_SF2 1
 
 #define AUDIODRV_DOSSB 1

--- a/docs/SMAF_FM.md
+++ b/docs/SMAF_FM.md
@@ -1,0 +1,261 @@
+# SMAF FM Synthesis Support (Design)
+
+Status: **IMPLEMENTED / IN PROGRESS** (M5 fidelity and coverage work remains).
+Author: WildMIDI Developers, 2026.
+
+## The problem
+
+WildMIDI already reads Yamaha SMAF (`.mmf`) files, but only by converting the
+score track to a Standard MIDI File (`smaf2mid.c`) and rendering it with the
+General-MIDI wavetable synth.  For many real files this sounds wrong — "beeps,
+flat, not musical" — because **the file's actual sound lives in data the GM
+converter discards**:
+
+* `Mtsu` (score-track setup) carries **custom FM voice definitions** as Yamaha
+  voice-exclusives (`F0 43 ...`).  A program-change like "program 84" is an
+  index into *these* voices, not a GM patch.  Sent to a GM synth it plays an
+  unrelated instrument (e.g. "FX 6 goblins").
+* `ATR` / `Awa` chunks carry **embedded ADPCM samples** (drums, phrases).
+
+Faithful playback therefore needs an **FM synthesizer** (the MA-series chip)
+plus an ADPCM decoder — not just a MIDI note stream.  The GM path stays as the
+fallback for files that ship no custom voices (they reference the chip's ROM
+voices, which are not public anyway).
+
+Reference: `docs/formats/SmafFileFormat.txt` (container + score encodings).
+
+## Why this cannot go through the SMF pipeline
+
+The current flow is:
+
+    .mmf --smaf2mid.c--> Standard MIDI File --f_midi--> _mdi events
+        --> wavetable synth --> PCM
+
+A Standard MIDI File has no way to express an FM operator patch.  The FM voice
+data has nowhere to live in that pipeline.  An FM engine must render **PCM
+directly** and have that PCM mixed into WildMIDI's output.
+
+## The precedent: TinySoundFont (SF2)
+
+WildMIDI already solved this exact shape of problem for SoundFonts.  It bundles
+a self-contained third-party synth and renders its PCM into the mix buffer
+instead of the wavetable output:
+
+* `src/tsf/tsf.h`      — vendored single-header synth (upstream, unmodified).
+* `src/sf2.c` / `include/sf2.h` — a thin WildMIDI wrapper: `_WM_SF2_*`.
+* `src/wildmidi_lib.c` — when a soundfont is active the render loop calls
+  `_WM_SF2_Event()` per event and `_WM_SF2_Render()` to fill the buffer
+  (see the `mdi->sf2_synth` branches), bypassing the wavetable mixer.
+
+The SF2 wrapper interface (the template to mirror):
+
+    _WM_SF2_Magic / Load / Unload / Active     -- bank lifecycle
+    _WM_SF2_NewSynth / FreeSynth / Reset       -- per-mdi instance
+    _WM_SF2_Event(synth, mdi, event)           -- feed a MIDI event
+    _WM_SF2_ActiveVoices(synth)                -- release-tail tracking
+    _WM_SF2_Render(synth, out, frames)         -- stereo PCM into mix buffer
+
+**An FM engine slots in the same way, behind a parallel `_WM_MAFM_*` wrapper.**
+
+## Proposed approach: vendor the akustikrausch FM core
+
+Rather than write an FM synth from scratch, vendor the one open,
+permissively-licensed, ROM-free implementation that already works:
+
+* Upstream: https://github.com/akustikrausch/yamaha-smaf-player
+* License: **Apache-2.0** (clean per-file SPDX headers).  Apache-2.0 is FSF-
+  approved compatible **into** (L)GPLv3 (one-way); WildMIDI is LGPLv3 (lib) /
+  GPLv3 (player).  Incorporating it is allowed, provided we **preserve the
+  Apache notices and add attribution** (a `NOTICE`/per-file header, and a line
+  in the WildMIDI docs/credits).  Do NOT relicense the vendored files; keep
+  their Apache headers and add WildMIDI's wrapper as separate LGPL files.
+
+The upstream pieces and rough sizes:
+
+| upstream file        | lines | role                                        |
+|----------------------|-------|---------------------------------------------|
+| `ma_fm_core.{h,cpp}` | ~560  | FM DSP: operators, EG, 2-op/4-op algorithms |
+| `smaf_voice.{h,cpp}` | ~280  | VMA/VM35 voice-exclusive -> FM patch         |
+| `yamaha_adpcm.h`     | ~70   | Yamaha 4-bit ADPCM codec                    |
+| `ma_player.{h,cpp}`  | ~870  | event decoders + scheduler (we have our own) |
+| `smaf_file.{h,cpp}`  | ~410  | container parser (we have our own)          |
+
+We need the **synth** (fm core + voice decode + adpcm).  We do NOT need upstream's
+container parser or event scheduler — `smaf2mid.c` / `f_smaf.c` already parse the
+container and we drive events from our side.
+
+### Vendoring choice: DECIDED — port the synth to C
+
+The three synth modules (`ma_fm_core`, `smaf_voice`, `yamaha_adpcm`) are ported
+to C89-ish C to match the rest of the library, so they build on every target in
+the tree (mingw / os2 / djgpp / amiga) with no C++ toolchain required.  The port
+preserves the upstream algorithm; each ported file keeps its Apache-2.0 SPDX
+header and an attribution note (see NOTICE).  Divergence from upstream is the
+accepted cost of a single-language, portable build.
+
+We do NOT vendor upstream's container parser (`smaf_file`) or event scheduler
+(`ma_player`) — `smaf2mid.c` / `f_smaf.c` already own that ground.
+
+## Integration plan (mirrors SF2)
+
+New files:
+
+    src/mafm/ma_fm_core.*     vendored (Apache-2.0), FM DSP
+    src/mafm/smaf_voice.*     vendored (Apache-2.0), voice-exclusive decode
+    src/mafm/yamaha_adpcm.h   vendored (Apache-2.0), ADPCM
+    src/mafm.c  include/mafm.h  WildMIDI wrapper (LGPL): the _WM_MAFM_* ABI
+
+Wrapper interface (parallel to `sf2.h`):
+
+    int   _WM_MAFM_HasCustomVoices(const uint8_t *smaf, uint32_t size);
+          /* true if the file carries Mtsu/ATR voice or wave data worth
+             synthesising; false -> use the existing GM conversion path. */
+    void *_WM_MAFM_NewSynth(uint16_t rate);
+    void  _WM_MAFM_FreeSynth(void *synth);
+    void  _WM_MAFM_Reset(void *synth);
+    int   _WM_MAFM_LoadVoices(void *synth, const uint8_t *smaf, uint32_t size);
+          /* parse Mtsu voice-exclusives + ATR/Awa waves into the synth */
+    void  _WM_MAFM_Event(void *synth, struct _mdi *mdi, struct _event *event);
+    int   _WM_MAFM_ActiveVoices(void *synth);
+    void  _WM_MAFM_Render(void *synth, int32_t *out, uint32_t frames);
+
+Flow for a custom-voice SMAF file:
+
+    .mmf --f_smaf.c--> (still) smaf2mid.c to get the note/timing event stream
+        --> _mdi events, BUT tag the mdi so the render loop routes to _WM_MAFM_*
+            instead of the wavetable synth
+        --> _WM_MAFM_LoadVoices() binds Mtsu voices + Awa samples
+        --> render loop: _WM_MAFM_Event per event, _WM_MAFM_Render to PCM
+
+The mdi carries a new optional `void *mafm_synth` next to `sf2_synth`; the render
+loop grows a third branch (wavetable | sf2 | mafm).  Program-change events map to
+the bound FM voice rather than a GM patch; percussion / Awa notes trigger the
+ADPCM one-shots.
+
+Files that ship **no** custom voices keep the current behaviour unchanged
+(`_WM_MAFM_HasCustomVoices` returns false -> GM conversion).
+
+## Milestones
+
+* **M0 — this design + licensing sign-off.**  Confirm Apache-2.0 vendoring is
+  acceptable to the project and pick the vendoring option (C++ island vs C port).
+* **M1 — ADPCM codec** (smallest, self-contained).  DONE: ported to
+  `src/mafm/yamaha_adpcm.{c,h}`.  Verified decoding `Solid Soda`'s `Awa\x01`
+  block (rate class from fmt2 nibble = 8000 Hz, LOW-nibble-first, ADPCM data
+  begins 2 bytes into the wave body after `[formatByte][fmt2]`).  Output is a
+  0.66 s one-shot with a clean attack-decay envelope (8191 -> 4324 -> 731
+  mean-abs across the sample), i.e. a real percussion sample, not hash.
+* **M2 — voice-exclusive decode.**  DONE: ported to `src/mafm/smaf_voice.{c,h}`
+  (+ the patch structs and `_WM_MAFM_DefaultPatch` in `src/mafm/ma_fm_core.{c,h}`).
+  Verified on `Solid Soda`'s `Mtsu`: all 6 custom voices decode (the MA-1/2 VMA
+  `43 03` form), each `valid`, with bank/PC keys that match the score's program
+  changes exactly — voice0 (bank2,pc84), voice1 (bank2,pc72), voice2 (bank2,pc71),
+  voices3-5 (pc101 on banks 2/3/4).  FM fields are in range and distinct per
+  voice, so the voice<->note binding will resolve.  Covers the MA-3 packed
+  (`43 79 06`), MA-5 direct (`43 79 07` / `43 05 01`) and VMA (`43 03`) forms and
+  PCM voices; only the VMA path is exercised so far (the samples are MA-1/2).
+* **M3 — FM core, offline.**  DONE: ported to `src/mafm/ma_fm_core.{c,h}`
+  (envelope, operator, voice; 8 connection algorithms; per-op feedback; voice
+  LFO with vibrato/tremolo; KSR/KSL scaling; the built-in GM and drum
+  approximation banks).  Verified by rendering `Solid Soda`'s decoded voices to
+  WAV: pitch is correct (C5 note -> ~522 Hz measured vs 523 expected), envelopes
+  have the right shape (voice 0 a fast pluck decaying by ~0.2 s, voice 3
+  sustaining and ringing 0.17 s past key-off), voices retire cleanly (no stuck
+  drones), and output peaks near full scale without clipping.  All three ported
+  modules compile clean under `-std=c89 -pedantic -Wall -Wextra` (log2 replaced
+  with a natural-log helper for C89), so they build on every target in the tree.
+* **M4 — WildMIDI integration.**  DONE.  New `src/mafm.c` + `include/mafm.h`: the
+  `_WM_MAFM_*` wrapper parses the file's Mtsu voice bank, keeps per-channel
+  bank/program/volume/pitch state, allocates a 32-voice pool, and renders PCM.
+  Wired in exactly like SF2: a `mafm_synth` field on `struct _mdi`;
+  `f_smaf.c` creates it via `_WM_MAFM_NewSynth` when `_WM_MAFM_HasCustomVoices`
+  is true (else the plain GM path); a `WM_GetOutput_MAFM` render loop (a copy of
+  `WM_GetOutput_SF2` with the synth calls swapped) plus the dispatch, seek and
+  free hooks in `wildmidi_lib.c` / `internal_midi.c`.  Build: `WANT_MAFM`
+  option -> `WILDMIDI_MAFM` (CMake + build.zig), sources listed in both, `src`
+  added to the include path.  Verified: `Solid Soda` renders 20.2 s of audio
+  through the FM path (confirmed by the mono L==R render signature vs the GM
+  wavetable's stereo), no clipping; a plain MIDI still renders stereo GM (no
+  regression); tokenize test passes; both CMake and the Zig build (which has SF2
+  OFF, MAFM ON -- proving the guards are independent) compile clean.
+* **M5 — fidelity + coverage.**  IN PROGRESS.  DONE: the ATR sampled-drum path.
+  `mafm.c` now decodes the `Awa` ADPCM wave bank and the `Atsq` trigger sequence
+  at synth-creation time and plays the samples on a 16-slot PCM pool against the
+  synth's own sample clock (a `mafm_pcm_tick` advanced once per output frame,
+  summed with the FM voices).  Verified on `Solid Soda`: 2 waves, 9 triggers,
+  drums land at the right times (transients at ~2.2/6.3/10.9/15/18.5 s match the
+  decoded schedule); `Mars Mine` also renders.  Notes learned: the `Atsq` shares
+  the score tick base (4 ms/tick here) -- don't misread the ATR header's own
+  timebase field, a wrong value halves/doubles every hit; the `Awa` body is
+  `[formatByte][fmt2][adpcm]` (data +2), LOW-nibble-first; ATR sub-chunks are
+  found by scanning for known ids since the ATR header width varies.  Pending
+  triggers are NOT counted as active voices (that could spin the end-of-song
+  drain forever).  STILL OPEN: PCM voice-exclusives (`43 79` type!=0, distinct
+  from ATR triggers) and smarter voice-stealing (currently slot 0; not
+  reproducible with the current corpus).
+
+## Non-goals (first pass)
+
+* Bit-exact hardware emulation.  "Recognised, and it plays" (upstream's stance).
+* The MA-7 SEQU score format (still declined in `smaf2mid.c`).
+* MFi (`.mld`) — a separate format; see `docs/formats/MFIFileFormat.txt`.  Its FM
+  playback would reuse the same engine later.
+
+## Resolved during implementation
+
+1. Build language: RESOLVED - the synth was PORTED TO C (not vendored as a C++
+   TU), so it builds on every target with no C++ toolchain.  All three synth
+   modules compile under -std=c89 -pedantic -Wall -Wextra.
+2. Build gating: RESOLVED - gated behind the WANT_MAFM CMake option ->
+   WILDMIDI_MAFM (default ON), mirrored in build.zig.  Size-constrained builds
+   that leave it off get the stub (mafm.c compiles empty, like sf2.c does).
+3. Voice binding: RESOLVED - the wrapper (mafm.c) keeps per-channel bank/program
+   state (chan_bank / chan_program) from the ev_control_bank_select / ev_patch
+   events and resolves the custom voice itself; smaf2mid.c stays generic.
+
+## Still open (polish, non-blocking)
+
+* PCM voice-exclusives (43 79 type!=0): sampled *instruments* (as opposed to the
+  ATR drum triggers, which are done).  Parsed by smaf_voice.c but not played.
+  A 32-file MA-1..MA-7 corpus turned up two GM7 files that carry PCM VE bodies
+  (AB00221GM7, AB03957GM7), but both use the MA-7 SEQU score format which
+  smaf2mid.c still declines, so runtime never reaches PCM-VE decode.  Path is
+  reachable only after MA-7 SEQU support lands (currently a non-goal).
+* MA-3 / MA-5 FM voice forms (43 79 06/07): tested and working.  Every file in
+  the MA-1..MA-7 corpus that ships a custom voice bank engages the FM path
+  and renders through _WM_MAFM_*.  The parser walks Mtsu accepting both the
+  MA-1/2 ff-f0-prefixed and the MA-3/5/6 bare-f0 sysex forms (mafm.c
+  mafm_parse_mtsu).  smaf2mid.c now forwards SMAF's bank-select bytes
+  (Mobile Standard CC 0x00/0x20 and HandyPhone data 0x1) as MIDI CC 0x00
+  so MAFM can key voice-bank lookups on bank_lsb.  Without this every
+  program-change fell back to the generic GmApprox and the file sounded
+  like blippy chip music instead of using its own custom voices.
+* Voice-stealing: FM pool now uses round-robin (matches the reference), was
+  always slot 0.  PCM pool still slot 0; not currently reproducible with the
+  corpus (max concurrent PCM voices well under the 16-slot pool).
+* Output gain overshoot: RESOLVED.  A soft peak limiter in the render loop
+  (30000 threshold in int16 mix units, instant attack, slow release) keeps
+  a dozen voices summing at full-scale under the int16 cap that
+  wildmidi_lib's output stage hard-clips at.  Zero clipped frames across
+  the 32-file MA-1..MA-7 corpus post-fix; quiet files unaffected (the
+  limiter is dormant until peaks approach the threshold).
+* Loop (WM_MO_LOOP) and mid-song seek through the FM path are wired (Reset hooks
+  in wildmidi_lib.c) but NOT yet verified; the PCM trigger cursor (s->cursor in
+  mafm.c) in particular may not survive a reset/seek and needs testing.
+* CPU cost: the FM render uses per-sample double math x 32 voices.  Real
+  numbers on an Apple Silicon Mac (offline wav render, no audio driver):
+  Solid Soda 19 s of audio in 0.31 s wall (~60x real-time); OPL3 alternative
+  path (-O) on the same file 0.46 s.  So MAFM is fast enough on modern
+  hardware, but the doubles make it costlier than needed for FPU-less
+  embedded targets.  No optimisation pass yet.
+
+## Build coverage
+
+CMake and the Zig build enable the FM path (WANT_MAFM / WILDMIDI_MAFM).  The
+Android NDK build (android/jni/Android.mk) also enables it.  The Watcom builds:
+os2/makefile.wat and win32wat/makefile both enable it (WILDMIDI_MAFM defined,
+mafm objects listed, ../src added to the include path so the mafm/ subheaders
+resolve).  All the _WM_MAFM_* call sites in
+wildmidi_lib.c / internal_midi.c / f_smaf.c are guarded by #ifdef WILDMIDI_MAFM,
+so a target that does not define it builds and links cleanly without the mafm
+sources.

--- a/docs/formats/SmafFileFormat.txt
+++ b/docs/formats/SmafFileFormat.txt
@@ -1,0 +1,435 @@
+SMAF / MMF File Format
+(Incomplete - Under Construction)
+
+Document version 1
+Authored by the WildMIDI Developers
+
+Last Edited 22 July 2026
+
+Copyright (C) 2026 WildMidi Developers
+This document is licensed under the
+Creative Commons Attribution-ShareAlike 4.0 International License.
+To view a copy of this license, visit
+http://creativecommons.org/licenses/by-sa/4.0/
+
+
+Introduction
+
+This document describes the SMAF format (Synthetic music Mobile Application
+Format, Yamaha; file extension .mmf) as used by the WildMIDI project.  It is not
+a complete description of the SMAF file format and only those parts that have
+been deciphered and are relevant to the WildMidi project are described here.
+Unfortunately we cannot answer questions about the format that are not described
+within this document.  If you feel there is an error in this document please feel
+free to report it as a bug at
+https://github.com/Mindwerks/wildmidi/issues/
+
+Tracking issue: https://github.com/Mindwerks/wildmidi/issues/118
+
+SMAF is a chunked (RIFF/IFF-style) container used by early-2000s feature phones
+for polyphonic ringtones, played on Yamaha MA-series synth chips.  It resembles
+Standard MIDI - a stream of timed note/control events - but may also embed its
+own instrument data (FM parameters, PCM/ADPCM samples), graphics and text.
+
+For WildMIDI the core path is the score-track SEQUENCE (the MIDI-like event
+stream), which is converted to a Standard MIDI File and handed to the existing
+synth.  In addition, WildMIDI has an optional Yamaha MA-series FM synthesizer
+(build option WANT_MAFM): when a file carries a custom FM voice bank (Mtsu
+voice-exclusives), those voices are decoded and played with real FM synthesis
+instead of the General MIDI approximation, and the embedded ADPCM samples in the
+audio track (ATR) are played as sampled drums/phrases alongside them.  See
+docs/SMAF_FM.md for that engine.  Files with no custom voice bank still fall back
+to the GM conversion.
+
+The Mobile Standard layout below was verified by decoding a corpus of real .mmf
+files from the MA-2/MA-3/MA-5/MA-6 generations, cross-checked against the
+vavi-sound reference decoder (identical note output).  The MA-7 "SEQU" format
+(format_type 0x03) is a different, compressed encoding that is NOT decoded -
+WildMIDI declines it; see its section below for reverse-engineering notes.  The
+HandyPhone Standard encoding (format_type 0x00) IS decoded (verified against
+real MA-1/MA-2 .mmf files); see its section below.
+
+NOTE: All multi-byte integers are BIG-ENDIAN.  All chunks have the form
+      { uint8_t id[4]; uint32_t size; uint8_t data[size]; }.  Unknown chunks
+      must be skipped by their declared size - this is what makes the format
+      forward-compatible.
+
+
+Description - Container
+
+// FILE
+{
+    uint8_t  text[4] = "MMMD";        // magic
+    uint32_t size;                    // = filesize - 8 (excludes the CRC trailer)
+
+    // one or more chunks follow, until the CRC trailer:
+    //   "CNTI"  ContentsInfo   (class / type / code-type / copy status ...)
+    //   "OPDA"  OptionalData   (title / artist / ... ; 2-uppercase-letter keys)
+    //   "MTR?"  ScoreTrack     (see below; '?' = format code byte)
+    //   "ATR?"  AudioTrack     (embedded PCM/ADPCM; e.g. "AspI"/"Atsq"/"Awa\x01")
+    //   "MSTR"  master track   (seen in some MA-3 files)
+
+    uint16_t crc;                     // last 2 bytes of file, CRC-16 over the file
+}
+
+The final 2 bytes of the file are a CRC-16.  WildMIDI does not need to validate
+it for read-only conversion.
+
+
+Description - Score Track
+
+// MTR? CHUNK   ('?' is a format-code byte: seen as 0x05, 0x06, 0x07 in the wild)
+{
+    uint8_t  id[4] = "MTR" <code>;
+    uint32_t size;
+
+    // ---- track header ----
+    uint8_t  format_type;      // 0x00 HandyPhone | 0x01,0x02 Mobile | 0x03 SEQU(MA-7)
+    uint8_t  sequence_type;    // 0x00 (single sequence) in all known samples
+    uint8_t  timebase_dur;     // duration  tick resolution code (see table)
+    uint8_t  timebase_gate;    // gate-time tick resolution code (see table)
+    uint8_t  channel_status[]; // width depends on format_type:
+                               //   0x00 -> 2 bytes, 0x01/0x02 -> 16, 0x03 -> 32
+                               //   (header total 6 / 20 / 36 bytes)
+
+    // ---- inner sub-chunks (in order) ----
+    //   "Mtsu"  Setup Data   (FM/PCM voice definitions; decoded by the FM
+    //                         engine - Yamaha voice-exclusives, see below)
+    //   "MspI"  Setup Info   (rare; 16 bytes in the MA-3 samples)
+    //   "Mtsq"  Sequence     (the event stream - see below)
+    //   "Mtsp"  Stream/PCM   (embedded PCM wave blocks)
+}
+
+Timebase code -> milliseconds per tick:
+
+    code   ms/tick
+    0x00     1
+    0x01     2
+    0x02     4          <- used by the entire sample corpus
+    0x03     5
+    0x10..0x13   mirror 0x00..0x03
+
+The score's tempo/division for the emitted Standard MIDI File is derived from
+timebase_dur (ticks -> ms), and note gate lengths from timebase_gate.
+
+
+The score-track format_type byte selects the sequence encoding:
+
+    0x00  HandyPhone Standard      (MA-1/MA-2, 4-channel; SUPPORTED, see below)
+    0x01  Mobile Standard          (Huffman-compressed; see note below)
+    0x02  Mobile Standard          (uncompressed; the common MA-2/3/5/6 case)
+    0x03  SEQU                      (the MA-7 format; NOT supported - declined)
+
+WildMIDI converts 0x00 and 0x02.  0x01 is the Huffman-compressed variant of
+Mobile Standard; the converter treats it like 0x02 and will only work if the
+body is not actually compressed (decompression is not implemented).  0x03
+(SEQU / MA-7) is declined - see the SEQU section below for the (incomplete)
+reverse-engineering notes.  0x00 (HandyPhone) uses a different, simpler encoding
+(see its section below) and is decoded by decode_handyphone().
+
+
+MA-chip support summary
+-----------------------
+
+Two independent axes: the SCORE encoding (always -> Standard MIDI) and, for the
+optional FM engine, the VOICE/instrument form.
+
+  Score (format_type):
+    MA-1 / MA-2   HandyPhone (0x00)            decoded, tested on real files
+    MA-2 / 3 / 5  Mobile uncompressed (0x02)   decoded, tested on real files
+    (any)         Mobile compressed (0x01)     only if not actually Huffman'd
+    MA-7          SEQU (0x03)                   NOT supported (see SEQU section)
+
+  FM voice-exclusives (Mtsu; decoded by src/mafm/smaf_voice.c, played by the FM
+  engine when WANT_MAFM is on):
+    MA-1 / MA-2   VMA form         "43 03 ..."          decoded, tested
+    MA-3          VM35 packed      "43 79 06 7F 01 ..."  decoded, UNTESTED
+    MA-5          VM35 direct      "43 79 07 ..." /
+                                   "43 05 01 ..."        decoded, UNTESTED
+    MA-3 / MA-5   PCM (sampled)    "43 79 .. type!=0"    parsed, not yet played
+
+  Net: MA-1 and MA-2 are fully supported and verified (score + FM voices + ATR
+  ADPCM drums).  MA-3 / MA-5 score plays; their FM voice forms are implemented
+  but not yet exercised (need MA-3/5 sample files).  MA-7 is unsupported (its
+  SEQU score format was never reverse-engineered).
+
+
+Description - Sequence Data (Mtsq), Mobile Standard  (format_type 0x01 / 0x02)
+
+The sequence is a series of records:
+
+    [ duration ] [ event ]
+
+  duration : variable-length quantity, 7 bits per byte, high bit = "more".
+             Number of ticks to wait BEFORE the event.
+
+The event begins with a status byte 's'.  MIDI-style RUNNING STATUS applies: a
+byte < 0x80 in the status position reuses the previous status byte, and the
+current byte is the first data byte.  A system message (0xF0/0xFF) cancels
+running status.
+
+    s        event
+    -------  --------------------------------------------------------------
+    < 0x80   running status (reuse previous 's'); if none set yet, stray - skip
+    0x8n     Note (off-velocity): uint8 note; then GATE-TIME (VLQ).
+             velocity = this channel's running velocity.
+    0x9n     Note (on-velocity):  uint8 note; uint8 vel (sets running
+             velocity); then GATE-TIME (VLQ).
+    0xAn     reserved - 2 data bytes, ignore
+    0xBn     Control Change: uint8 cc; uint8 val.
+                 cc 0x00 Bank MSB    cc 0x20 Bank LSB
+                 cc 0x07 Volume      cc 0x0A Pan
+                 cc 0x0B Expression  cc 0x01 Modulation
+    0xCn     Program Change: uint8 pc
+    0xDn     reserved - 1 data byte, ignore
+    0xEn     Pitch Bend: uint8 lsb; uint8 msb   (14-bit)
+    0xF0     Exclusive: VLQ len; then len bytes (Yamaha id 0x43 ...,
+             optionally terminated by 0xF7).  Carries voice/mode setup.
+    0xFF     Meta: uint8 m;  m==0x00 NOP; m==0x2F End Of Sequence;
+             otherwise uint8 len followed by len bytes to skip.
+
+  'n' is the channel number (low nibble of the status byte, 0-15).
+
+Notes carry their OWN duration (the trailing gate-time), unlike Standard MIDI.
+To convert:  emit a MIDI Note On at the current tick, and schedule the matching
+Note Off gate-time ticks later (a small pending-note queue).  A 0x8n note reuses
+the channel's last 0x9n velocity (initial value 64).  A note with gate-time 0 is
+skipped.
+
+IMPORTANT - Bank Select must NOT be forwarded to a General MIDI synth.  SMAF
+bank-select values (commonly 0x7C) address Yamaha's own internal / custom voice
+banks (bound via the Mtsu setup chunk), not GM banks.  A GM synth handed bank
+0x7C finds no instrument and plays SILENCE.  When converting to GM, DROP the
+Bank MSB/LSB control changes entirely and let the Program Change select the GM
+patch.  (This bug manifested as faint or silent playback until fixed.)
+
+A duration VLQ never legitimately begins with 0xFF; a 0xFF where a duration is
+expected is the trailing NOP/End-Of-Sequence padding after the last event
+(e.g. "ff 00 00  ff 2f 00") and marks the end of useful data.
+
+
+Description - Sequence Data (Mtsq), SEQU  (format_type 0x03, "MA-7")  NOT SUPPORTED
+
+  ***********************************************************************
+  *  STATUS: NOT DECODED.  WildMIDI DECLINES format 0x03.               *
+  *  This section records what reverse-engineering DID and did NOT      *
+  *  establish, so a future attempt can start ahead.  Do not trust it   *
+  *  as a working spec - it is deliberately incomplete and partly       *
+  *  wrong (the parts known to be wrong are marked).                    *
+  ***********************************************************************
+
+MA-7 (YMU786, 2005) is the last SMAF generation.  Its score track uses a
+distinct sequence encoding that vavi-sound calls "SEQU" (the 4th value of its
+FormatType enum: 0=HandyPhone, 1=Mobile-compressed, 2=Mobile-uncompressed,
+3=SEQU).  The score-track header carries a 32-byte channel-status field (vs 16
+for Mobile), which is the reliable way to recognise it alongside format_type
+0x03 and the MTR id trailing byte 0x07.
+
+Why it is undocumented:  SEQU is a COMPRESSED / packed format and no public
+byte-level specification exists.  Checked and found lacking: the LPC wiki
+(Yamaha_SMAF and Yamaha_SMAF/MA-7 pages - chip/phone info only), the ltva1
+MA-7 hardware research page (FM operator internals, not the file format), the
+KDDI au ezfactory archive (device catalog), and Yamaha's own references.  The
+real encoder lives in the proprietary "MA-7 author tool" / "MCP MA-7" DLLs.
+
+Reference decoders do NOT handle these files correctly either:
+  - vavi-sound's readSEQU emits hundreds of "gateTime == 0" warnings and, on a
+    known 914-note song, produced only 94 notes over 46 s (the true song is
+    ~37 s with 914 notes).  Its readSEQU note formula is
+    note = (e1 & 15) + ((e1>>4 & 3) + 3) * 12 with NO velocity byte - which does
+    NOT reproduce the reference output.
+  - akustikrausch's C++ player routes 0x03 through its Mobile decoder, whose
+    "if (status < 0x80) continue;" silently drops the SEQU note bytes.
+
+What reverse-engineering (against a matched .mmf / .mid / .mp3 triplet where the
+.mid is the authoring tool's own output - the oracle) DID establish:
+
+  Container / framing (solid):
+    - Records are still [duration VLQ][event], duration-first, same VLQ as
+      Mobile Standard.  Timebase math is identical (durationTimeBase and
+      gateTimeBase from the header; 0x02 = 4 ms/tick).
+    - Leading 0xff 0x00 (NOP) and 0xf0 ... 0xf7 (exclusive) parse normally.
+    - The song's whole SETUP block (first ~105 events: per-channel control
+      changes, then a per-channel setup byte, then the first melody notes)
+      parses with clean byte boundaries under the tentative status scheme below,
+      and the first melody NOTE PITCHES AND VELOCITIES matched the reference
+      exactly (e.g. ch0 note 29 vel 105; the ch2/ch3 four-note chords; the ch1
+      line 69 -> 72 -> 74).  So the note-event field order below is close for
+      the "sparse" sections.
+
+  Tentative status scheme (works for the sparse intro, WRONG in dense sections):
+      status byte = (type_nibble << 4) | channel_nibble, channels 0-9 observed
+        0x0n  note, reuse running velocity : [note][gate VLQ]
+        0x1n  note, set velocity           : [note][vel][gate VLQ]
+        0x3n  control change               : [cc][val]  (cc = MIDI controller:
+                00 bankMSB, 20 bankLSB, 07 vol, 0a pan, 5a/5b/5d fx, ...)
+        0x4n  per-channel setup            : [value]     (see "programs" below)
+
+  KNOWN-WRONG / UNSOLVED (why 0x03 is declined):
+    1. Program numbers do NOT match.  Decoding 0x4n as MIDI program change gives
+       ch0=1 where the reference has ch0=38 (no constant offset; e.g. ref
+       {0:38,1:54,2:5,3:48,4:55,5:81,6:11,7:11,8:81}).  Notably our decoded
+       values pair up the same way the reference does (ch6==ch7, ch5==ch8),
+       suggesting 0x4n carries a SMAF voice/bank index that must be resolved
+       through the Mtsu setup (voice) chunk, not a GM program - i.e. not
+       directly convertible without modelling the voice bank.
+    2. The dominant dense-section record is a 4-byte group led by 0x61
+       (0x61 appears ~520 times in one 7940-byte Mtsq; 0x02 ~507 times):
+           61 XX YY 0Z   with 0Z small (00-04)
+       Its field layout was NOT determined.  Splitting it as
+       [status][d1][d2][dur] and treating d2 as the note yields a smooth-looking
+       line (e.g. 65,67,69,70,69,66,65,61,52,...) that nevertheless matches NO
+       reference channel by absolute pitch OR by interval - so that split is
+       wrong.  Whatever 0x61 encodes, it is the main melodic/rhythmic payload
+       of the busy sections and must be decoded for a usable result.
+    3. Drum channel (ch9) notes decode to wrong pitches (e.g. 20, 17 where the
+       reference has 38, 39) - likely a drum note-map and/or a different record
+       layout on the rhythm channel.
+
+  Net effect if force-decoded with the tentative scheme: ~1000+ notes over
+  ~375 s for a song that is really ~914 notes over ~37 s - i.e. far too many
+  notes stretched ~8x too long, which sounds like large gaps between notes.
+  Hence: declined, not shipped.
+
+  Short expression / modulation tables that appear in vavi's readSEQU control
+  path (kept here for reference; part of the 0x00-led control events vavi
+  documents but which did not reproduce this file):
+    expr: 00 00 1f 27 2f 37 3f 47 4f 57 5f 67 6f 77 7f 7f
+    mod:  00 00 08 10 18 20 28 30 38 40 48 50 60 70 7f 7f
+
+  For a future attempt: the matched .mmf/.mid oracle approach is the right one -
+  align the byte stream to the authoring tool's .mid note list and solve the
+  0x61 record and the 0x4n->voice mapping first, ideally with more than one
+  MA-7 sample to cross-check.
+
+
+Description - Sequence Data (Mtsq), HandyPhone Standard   (format_type 0x00)
+
+  ***********************************************************************
+  *  STATUS: SUPPORTED.  WildMIDI decodes format 0x00 (decode_handyphone *
+  *  in src/smaf2mid.c).  Verified against real MA-1/MA-2 .mmf files     *
+  *  (the "Yamaha SMAF (downloadable)" items in the archive.org          *
+  *  RingtoneBangers21 collection, e.g. Solid Soda / Mars Mine): the     *
+  *  streams parse with clean byte boundaries and convert to musical     *
+  *  multi-channel MIDI.  Pitch mapping follows the vavi-sound reference. *
+  ***********************************************************************
+
+format_type 0x00 is the earliest SMAF score encoding (MA-1 / MA-2 chips).  It
+lives in the same MMMD container and MTR?/Mtsq chunks as Mobile Standard; only
+the Mtsq event stream differs, and the score-track header carries a 2-byte
+channel-status field (vs 16 for Mobile / 32 for SEQU), which is the reliable
+way to recognise it alongside format_type 0x00.  There are only 4 channels
+(the channel index is 2 bits; see below).
+
+Records are still  [ duration ] [ event ] , duration first.
+
+  duration / gate-time VLQ (DIFFERENT from Mobile's standard MIDI VLQ - it is a
+  1-or-2 byte form, max 14-bit):
+        b = next byte
+        if (b & 0x80) == 0 :  value = b                       (0x00..0x7F)
+        else               :  value = (((b & 0x7F) + 1) << 7) | nextbyte
+  Both the leading duration and a note's trailing gate-time use this VLQ.
+
+The byte after the duration is the lead byte e1:
+
+  e1 == 0xFF   Meta / exclusive / NOP.  Read e2:
+                 0x00        NOP
+                 0x2F        End Of Track     ) uint8 len; then len bytes
+                 0x51        Tempo (meta)     ) (standard MIDI meta payloads)
+                 0x58        Time Signature   )
+                 0xF0        Exclusive: uint8 len; then len bytes
+                 other       undefined - skip
+
+  e1 == 0x00   Control event.  Read e2, then:
+                 e2 == 0x00 : read e3;  e3 == 0x00 -> End Of Sequence,
+                              otherwise undefined.
+                 else       : channel = (e2 & 0xC0) >> 6   (0-3)
+                              event   = (e2 & 0x30) >> 4   (0-3)
+                              data    =  e2 & 0x0F         (0-15)
+                   event 3 : LONG control - read one more value byte:
+                                data 0x0 Program Change (0x00..0x7F)
+                                data 0x1 Bank Select (0x00..0x7F normal,
+                                                      0x80..0xFF drum)
+                                data 0x2 Octave Shift (0..4, 0x81..0x84)
+                                data 0x3 Modulation   (0x00..0x7F)
+                                data 0x4 Pitch Bend   (value<<7; 0..0x40..0x7F)
+                                data 0x7 Volume       (0x00..0x7F)
+                                data 0xA Pan          (0x00..0x40..0x7F)
+                                data 0xB Expression   (0x00..0x7F)
+                   event 2 : SHORT modulation - value = modTable[data]
+                   event 1 : SHORT pitch bend - value = (data * 8) << 7
+                   event 0 : SHORT expression - value = data==1 ? 0
+                                                                : data*8 + 15
+                 (SHORT forms carry NO extra byte; the nibble IS the value.)
+
+                 modTable[16] (index by data 0x1..0x0E):
+                   -1 00 08 10 18 20 28 30 38 40 48 50 60 70 7F -1
+
+                 IMPORTANT (as for Mobile Standard): DROP Bank Select when
+                 converting to General MIDI - SMAF bank values address Yamaha's
+                 own voice banks and a GM synth plays SILENCE for them.
+
+  otherwise    NOTE.  e1 is the note status byte, packed as:
+                   bits 7-6 : channel  (0-3)
+                   bits 5-4 : octave   (0-3)
+                   bits 3-0 : note     (semitone within the octave)
+                 followed by a gate-time VLQ.
+                   MIDI pitch = note + octave*12 + 36, then apply the channel's
+                   octave-shift (0x00 control, event 3 data 2):
+                     1..4       -> +12, +24, +36, +48
+                     0x81..0x84 -> -12, -24, -36, -48
+                 (The +36 base and the octave shift come from the vavi-sound
+                 reference; without the base, pitches decode ~3 octaves too low.)
+                 HandyPhone notes carry no velocity byte; use a fixed default.
+
+As with Mobile Standard, a note carries its own gate-time: emit Note On at the
+current tick and schedule the Note Off gate-time ticks later.
+
+Multiple score tracks:  a HandyPhone song is commonly split across up to four
+MTR* tracks of four channels each.  They share one timeline, so WildMIDI decodes
+every 0x00 track and merges the events (track N -> MIDI channels N*4 .. N*4+3),
+sorted by absolute time, into a single MIDI track.
+
+Percussion:  the 2-byte channel-status field carries a 2-bit type per channel
+(0 NoCare, 1 Melody, 2 NoMelody, 3 Rhythm).  A "Rhythm" channel is percussion:
+its notes are rerouted to MIDI channel 9, and the program-change byte is used
+as the drum-note pitch (the program-change event itself is suppressed).  This
+matches the vavi-sound reference implementation
+(ProgramChangeMessage.getMidiEvents).
+
+
+Description - Audio Track (ATR)
+
+// ATR? CHUNK
+{
+    uint8_t  id[4] = "ATR" <code>;
+    uint32_t size;
+    uint8_t  format_type;
+    uint8_t  sequence_type;
+    // + more header bytes (timebase, wave-type...) whose width varies, so the
+    //   sub-chunks below are located by scanning for their ids, not a fixed
+    //   header size.
+    // sub-chunks: "AspI" setup info, "Atsq" trigger sequence,
+    //             "Awa\x01" ADPCM wave data.
+}
+
+The GM conversion (smaf2mid.c) ignores audio tracks.  The optional FM engine
+(WANT_MAFM) plays them: the "Awa" waves are the sampled drums/phrases and the
+"Atsq" sequence triggers them in time.
+
+  Awa<n> wave body (verified on real MA-1/2 files):
+      [formatByte] [fmt2] [ADPCM data ...]
+    The 4th id byte <n> is the wave number.  The ADPCM data starts at body+2.
+    fmt2 low nibble selects the sample rate:
+      0 -> 4000, 1 -> 8000, 2 -> 11025, 3 -> 22050, 4 -> 44100 Hz.
+    The codec is 4-bit Yamaha (OPNA-B) ADPCM, LOW-nibble-first (two samples per
+    byte).  See src/mafm/yamaha_adpcm.c.
+
+  Atsq trigger sequence:
+    Same [duration VLQ][event] framing as the HandyPhone score, with the same
+    1-or-2 byte VLQ.  A note event's lead byte carries the WAVE NUMBER to play
+    (low 6 bits); 0xFF and 0x00 lead bytes are meta/control as in the score.
+    The tick base is the SCORE's (4 ms/tick in the sample corpus) - the ATR
+    header's own timebase field is NOT reliably placed, so a decoder should use
+    the score tick base rather than read it (a wrong value halves/doubles every
+    hit).

--- a/docs/man/man1/wildmidi.1
+++ b/docs/man/man1/wildmidi.1
@@ -14,11 +14,11 @@ wildmidi \- example player for libWildMidi
 .SH DESCRIPTION
 This is a demonstration program to show the capabilities of libWildMidi.
 .PP
-\fImidifile\fP can be a MIDI type file in the HMI, HMP, MIDI, MUS or XMI formats and is processed by libWildMidi and the resulting audio is output by the player.
+\fImidifile\fP can be a MIDI type file in the HMI, HMP, MIDI, MUS, SMAF or XMI formats and is processed by libWildMidi and the resulting audio is output by the player.
 .PP
 You can have more than one \fImidifile\fP on the command line and \fBwildmidi\fP will pass them to libWildMidi for processing, one after the other. You can also use wildcards, for example: \fBwildmidi *.mid\fP
 .PP
-\fImidifile\fP may also be a directory, including a symlink to one. Directories are searched recursively and every file whose name ends in .mid, .midi, .rmi, .kar, .mus, .xmi, .hmp or .hmi is added to the playlist. Symlinked subdirectories found during that search are not followed, so that a link pointing back into its own parent cannot cause the same files to be added over and over. A file named directly on the command line is always played regardless of its name, since libWildMidi detects the format from the file contents. Use \fB\-S\fP to play the resulting playlist in random order, and \fB\-L\fP to repeat it once it ends.
+\fImidifile\fP may also be a directory, including a symlink to one. Directories are searched recursively and every file whose name ends in .mid, .midi, .rmi, .kar, .mus, .xmi, .hmp, .hmi or .mmf is added to the playlist. Symlinked subdirectories found during that search are not followed, so that a link pointing back into its own parent cannot cause the same files to be added over and over. A file named directly on the command line is always played regardless of its name, since libWildMidi detects the format from the file contents. Use \fB\-S\fP to play the resulting playlist in random order, and \fB\-L\fP to repeat it once it ends.
 .PP
 .SH OPTIONS
 .IP "\fB\-0\fP"
@@ -94,7 +94,7 @@ Skips any silence at the start of playback.
 Display version and copyright information.
 .PP
 .IP "\fB\-x\fP \fIfile\fP | \fB\-\-tomidi=\fIfile\fP"
-Convert a MUS, XMI, HMP or HMI file to midi and save it as \fIfile\fP.
+Convert a MUS, XMI, HMP, HMI or SMAF file to midi and save it as \fIfile\fP.
 .PP
 .SH TEST OPTIONS
 These options are not designed for general use. Instead these options are designed to make it easier to listen to specific sound samples.

--- a/docs/man/man3/WildMidi_ConvertToMidi.3
+++ b/docs/man/man3/WildMidi_ConvertToMidi.3
@@ -14,7 +14,7 @@ WildMidi_ConvertToMidi \- Convert a MIDI-like file into a new MIDI file.
 Takes a MIDI-like file as input and tries to detect, convert and write to a memory buffer in MIDI format.
 .PP
 .IP \fIfile\fP
-The input file that contains MIDI-like content: XMI, MUS, HMP or HMI.
+The input file that contains MIDI-like content: XMI, MUS, HMP, HMI or SMAF.
 .PP
 .IP \fIout\fP
 The output buffer. It will be allocated with \fBmalloc\fP() and must be \fBfree\fP()d by the caller when it is no longer needed.

--- a/docs/man/man3/WildMidi_Open.3
+++ b/docs/man/man3/WildMidi_Open.3
@@ -10,7 +10,7 @@ WildMidi_Open \- Open a midi file for processing
 .B midi *WildMidi_Open (const char *\fImidifile\fP)
 .PP
 .SH DESCRIPTION
-Open a MIDI type file pointed to by \fImidifile\fP for processing. This file must be in HMP, HMI, MIDI, SMAF, or XMIDI format.
+Open a MIDI type file pointed to by \fImidifile\fP for processing. This file must be in HMP, HMI, MIDI, MUS, SMAF, or XMIDI format.
 .PP
 .SH "RETURN VALUE"
 Returns NULL on error and sends a message to stderr, otherwise returns a handle for the midi file opened. This handle is used by most functions in libWildMidi to identify which midi file we are referring to.

--- a/docs/man/man3/WildMidi_Open.3
+++ b/docs/man/man3/WildMidi_Open.3
@@ -10,7 +10,7 @@ WildMidi_Open \- Open a midi file for processing
 .B midi *WildMidi_Open (const char *\fImidifile\fP)
 .PP
 .SH DESCRIPTION
-Open a MIDI type file pointed to by \fImidifile\fP for processing. This file must be in HMP, HMI, MIDI, or XMIDI format.
+Open a MIDI type file pointed to by \fImidifile\fP for processing. This file must be in HMP, HMI, MIDI, SMAF, or XMIDI format.
 .PP
 .SH "RETURN VALUE"
 Returns NULL on error and sends a message to stderr, otherwise returns a handle for the midi file opened. This handle is used by most functions in libWildMidi to identify which midi file we are referring to.

--- a/docs/man/man3/WildMidi_OpenBuffer.3
+++ b/docs/man/man3/WildMidi_OpenBuffer.3
@@ -14,7 +14,7 @@ WildMidi_OpenBuffer \- Open a midi file buffer for processing
 Open a file, that you have buffered in memory, for processing.
 .PP
 .IP \fImidibuffer\fP
-The memory location of the buffered file. This buffer needs to be in either HMP, HMI, MIDI, or XMIDI file format. Once this function is called, any changes to the buffer will have no effect.
+The memory location of the buffered file. This buffer needs to be in either HMP, HMI, MIDI, SMAF, or XMIDI file format. Once this function is called, any changes to the buffer will have no effect.
 .PP
 .IP \fIsize\fP
 This is the size of the midi file in bytes that is stored in memory.

--- a/docs/man/man3/WildMidi_OpenBuffer.3
+++ b/docs/man/man3/WildMidi_OpenBuffer.3
@@ -14,7 +14,7 @@ WildMidi_OpenBuffer \- Open a midi file buffer for processing
 Open a file, that you have buffered in memory, for processing.
 .PP
 .IP \fImidibuffer\fP
-The memory location of the buffered file. This buffer needs to be in either HMP, HMI, MIDI, SMAF, or XMIDI file format. Once this function is called, any changes to the buffer will have no effect.
+The memory location of the buffered file. This buffer needs to be in either HMP, HMI, MIDI, MUS, SMAF, or XMIDI file format. Once this function is called, any changes to the buffer will have no effect.
 .PP
 .IP \fIsize\fP
 This is the size of the midi file in bytes that is stored in memory.

--- a/include/config.h.cmake
+++ b/include/config.h.cmake
@@ -62,6 +62,9 @@
 /* define this to enable SoundFont2 support via TinySoundFont */
 #cmakedefine WILDMIDI_SF2 1
 
+/* define this to enable Yamaha MA-series FM synthesis for SMAF files */
+#cmakedefine WILDMIDI_MAFM 1
+
 /* Define if you have the <stdint.h> header file. */
 #cmakedefine HAVE_STDINT_H
 

--- a/include/f_smaf.h
+++ b/include/f_smaf.h
@@ -1,0 +1,29 @@
+/*
+ * f_smaf.h -- Midi Wavetable Processing library
+ *
+ * Copyright (C) WildMIDI Developers 2026
+ *
+ * This file is part of WildMIDI.
+ *
+ * WildMIDI is free software: you can redistribute and/or modify the player
+ * under the terms of the GNU General Public License and you can redistribute
+ * and/or modify the library under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation, either version 3 of
+ * the licenses, or(at your option) any later version.
+ *
+ * WildMIDI is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License and
+ * the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License and the
+ * GNU Lesser General Public License along with WildMIDI.  If not,  see
+ * <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef __F_SMAF_H
+#define __F_SMAF_H
+
+extern struct _mdi *_WM_ParseNewSmaf(const uint8_t *smaf_data, uint32_t smaf_size);
+
+#endif /* __F_SMAF_H */

--- a/include/internal_midi.h
+++ b/include/internal_midi.h
@@ -163,6 +163,7 @@ struct _mdi {
     char *lyric;
 
     void *sf2_synth; /* per-mdi TinySoundFont instance, NULL unless a soundfont is loaded */
+    void *mafm_synth; /* per-mdi Yamaha FM instance, NULL unless a SMAF file carries custom voices */
 };
 
 

--- a/include/mafm.h
+++ b/include/mafm.h
@@ -1,0 +1,58 @@
+/*
+ * mafm.h -- Yamaha MA-series FM rendering for SMAF files.
+ *
+ * Copyright (C) WildMIDI Developers 2026
+ *
+ * This file is part of WildMIDI.
+ *
+ * WildMIDI is free software: you can redistribute and/or modify the player
+ * under the terms of the GNU General Public License and you can redistribute
+ * and/or modify the library under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation, either version 3 of
+ * the licenses, or(at your option) any later version.
+ *
+ * WildMIDI is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License and
+ * the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License and the
+ * GNU Lesser General Public License along with WildMIDI.  If not,  see
+ * <http://www.gnu.org/licenses/>.
+ *
+ * This is the WildMIDI-side wrapper around the (Apache-2.0) FM synth core under
+ * src/mafm/.  It follows the same shape as sf2.h: a per-mdi synth instance that
+ * consumes WildMIDI events and renders PCM into the mix buffer.  The
+ * SMAF-specific instrument-bank parsing (Mtsu voice-exclusives + ATR/Awa waves)
+ * lives here with the synth, so the SMAF->MIDI converter (smaf2mid.c) stays
+ * format-generic.  See docs/SMAF_FM.md.
+ */
+
+#ifndef __MAFM_H
+#define __MAFM_H
+
+#include <stdint.h>
+
+struct _mdi;
+struct _event;
+
+/* Does this .mmf carry custom FM voice data (an Mtsu voice bank) worth
+ * synthesising?  If not, the caller should use the plain GM conversion path. */
+int _WM_MAFM_HasCustomVoices(const uint8_t *smaf, uint32_t size);
+
+/* Create / free a per-mdi FM synth instance at the given output rate.  The
+ * synth parses the .mmf's voice + wave banks on creation. */
+void *_WM_MAFM_NewSynth(const uint8_t *smaf, uint32_t size, uint16_t rate);
+void  _WM_MAFM_FreeSynth(void *synth);
+void  _WM_MAFM_Reset(void *synth);
+
+/* Translate a WildMIDI event to the synth. */
+void  _WM_MAFM_Event(void *synth, struct _mdi *mdi, struct _event *event);
+
+/* Nonzero while notes are still sounding (release tails). */
+int   _WM_MAFM_ActiveVoices(void *synth);
+
+/* Render stereo frames into the 32-bit mix buffer (accumulates). */
+void  _WM_MAFM_Render(void *synth, int32_t *out, uint32_t frames);
+
+#endif /* __MAFM_H */

--- a/include/smaf2mid.h
+++ b/include/smaf2mid.h
@@ -1,0 +1,30 @@
+/*
+ * SMAF2MIDI: Yamaha SMAF (MMF) to MIDI Library Header
+ *
+ * Copyright (C) WildMIDI Developers 2026
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public
+ * License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+ * Boston, MA  02110-1301, USA.
+ */
+
+#ifndef SMAFLIB_H
+#define SMAFLIB_H
+
+#include <stdint.h>
+
+int _WM_smaf2midi(const uint8_t *in, uint32_t insize,
+                  uint8_t **out, uint32_t *outsize);
+
+#endif /* SMAFLIB_H */

--- a/include/wm_error.h
+++ b/include/wm_error.h
@@ -43,6 +43,7 @@ enum {
     WM_ERR_CONVERT,
     WM_ERR_NOT_MUS,
     WM_ERR_NOT_XMI,
+    WM_ERR_NOT_SMAF,
 
     WM_ERR_MAX
 };

--- a/macosx/Makefile
+++ b/macosx/Makefile
@@ -68,7 +68,7 @@ LDLIBS_EXE+=-L. -l$(LIBNAME)
 
 # Objects
 LIB_OBJ = wm_error.o file_io.o lock.o wildmidi_lib.o reverb.o gus_pat.o
-LIB_OBJ+= f_xmidi.o f_mus.o f_hmp.o f_midi.o f_hmi.o mus2mid.o xmi2mid.o hmp2mid.o hmi2mid.o internal_midi.o patches.o sample.o sf2.o synth.o opl3.o
+LIB_OBJ+= f_xmidi.o f_mus.o f_hmp.o f_midi.o f_hmi.o f_smaf.o mus2mid.o xmi2mid.o hmp2mid.o hmi2mid.o smaf2mid.o internal_midi.o patches.o sample.o sf2.o mafm.o ma_fm_core.o smaf_voice.o yamaha_adpcm.o synth.o opl3.o
 PLAYER_OBJ = wm_tty.o playlist.o msleep.o out_none.o out_wave.o out_coreaudio.o wildmidi.o
 # out_openal.o
 
@@ -108,6 +108,8 @@ $(PLAYER_STATIC): $(PLAYER_OBJ) $(LIBSTATIC)
 %.o: %.c
 	$(CC) -c $(CFLAGS_LIB) -o $@ $<
 %.o: ../src/%.c
+	$(CC) -c $(CFLAGS_LIB) -o $@ $<
+%.o: ../src/mafm/%.c
 	$(CC) -c $(CFLAGS_LIB) -o $@ $<
 # for player objects:
 wildmidi.o: ../src/player/wildmidi.c

--- a/macosx/config.h
+++ b/macosx/config.h
@@ -25,6 +25,7 @@
 #define HAVE_SQRTF 1
 #define HAVE_POWF 1
 
+#define WILDMIDI_MAFM 1
 #define WILDMIDI_SF2 1
 
 /* #undef AUDIODRV_OPENAL */

--- a/mingw/Makefile
+++ b/mingw/Makefile
@@ -52,7 +52,7 @@ LDLIBS_EXE+=-L. -l$(LIBNAME)
 
 # Objects
 LIB_OBJ = wm_error.o file_io.o lock.o wildmidi_lib.o reverb.o gus_pat.o
-LIB_OBJ+= f_xmidi.o f_mus.o f_hmp.o f_midi.o f_hmi.o mus2mid.o xmi2mid.o hmp2mid.o hmi2mid.o internal_midi.o patches.o sample.o sf2.o synth.o opl3.o
+LIB_OBJ+= f_xmidi.o f_mus.o f_hmp.o f_midi.o f_hmi.o f_smaf.o mus2mid.o xmi2mid.o hmp2mid.o hmi2mid.o smaf2mid.o internal_midi.o patches.o sample.o sf2.o mafm.o ma_fm_core.o smaf_voice.o yamaha_adpcm.o synth.o opl3.o
 PLAYER_OBJ = wm_tty.o playlist.o msleep.o getopt_long.o out_none.o out_wave.o out_win32mm.o wildmidi.o
 # out_openal.o
 
@@ -88,6 +88,8 @@ $(PLAYER_STATIC): $(PLAYER_OBJ) $(LIBSTATIC)
 %.o: %.c
 	$(CC) -c $(CFLAGS_LIB) -o $@ $<
 %.o: ../src/%.c
+	$(CC) -c $(CFLAGS_LIB) -o $@ $<
+%.o: ../src/mafm/%.c
 	$(CC) -c $(CFLAGS_LIB) -o $@ $<
 # for player objects:
 wildmidi.o: ../src/player/wildmidi.c

--- a/mingw/config.h
+++ b/mingw/config.h
@@ -21,6 +21,7 @@
 #define HAVE_SQRTF 1
 #define HAVE_POWF 1
 
+#define WILDMIDI_MAFM 1
 #define WILDMIDI_SF2 1
 
 /* #undef AUDIODRV_OPENAL */

--- a/msvc/common.mak
+++ b/msvc/common.mak
@@ -11,7 +11,7 @@ PLAYER  = wildmidi.exe
 LIBS_DLL=
 LIBS_PLY= $(IMPNAME) winmm.lib
 
-DLL_OBJ = wm_error.obj file_io.obj lock.obj wildmidi_lib.obj reverb.obj gus_pat.obj f_xmidi.obj f_mus.obj f_hmp.obj f_midi.obj f_hmi.obj mus2mid.obj xmi2mid.obj hmp2mid.obj hmi2mid.obj internal_midi.obj patches.obj sample.obj sf2.obj synth.obj opl3.obj
+DLL_OBJ = wm_error.obj file_io.obj lock.obj wildmidi_lib.obj reverb.obj gus_pat.obj f_xmidi.obj f_mus.obj f_hmp.obj f_midi.obj f_hmi.obj f_smaf.obj mus2mid.obj xmi2mid.obj hmp2mid.obj hmi2mid.obj smaf2mid.obj internal_midi.obj patches.obj sample.obj sf2.obj mafm.obj ma_fm_core.obj smaf_voice.obj yamaha_adpcm.obj synth.obj opl3.obj
 PLY_OBJ = wm_tty.obj msleep.obj getopt_long.obj out_none.obj out_wave.obj out_win32mm.obj wildmidi.obj
 # out_openal.obj
 
@@ -45,6 +45,8 @@ f_midi.obj: ..\src\f_midi.c
 	$(CC) $(DLL_FLAGS) $(INCLUDES) -c -Fo$@ $?
 f_hmi.obj: ..\src\f_hmi.c
 	$(CC) $(DLL_FLAGS) $(INCLUDES) -c -Fo$@ $?
+f_smaf.obj: ..\src\f_smaf.c
+	$(CC) $(DLL_FLAGS) $(INCLUDES) -c -Fo$@ $?
 mus2mid.obj: ..\src\mus2mid.c
 	$(CC) $(DLL_FLAGS) $(INCLUDES) -c -Fo$@ $?
 xmi2mid.obj: ..\src\xmi2mid.c
@@ -53,6 +55,8 @@ hmp2mid.obj: ..\src\hmp2mid.c
 	$(CC) $(DLL_FLAGS) $(INCLUDES) -c -Fo$@ $?
 hmi2mid.obj: ..\src\hmi2mid.c
 	$(CC) $(DLL_FLAGS) $(INCLUDES) -c -Fo$@ $?
+smaf2mid.obj: ..\src\smaf2mid.c
+	$(CC) $(DLL_FLAGS) $(INCLUDES) -c -Fo$@ $?
 internal_midi.obj: ..\src\internal_midi.c
 	$(CC) $(DLL_FLAGS) $(INCLUDES) -c -Fo$@ $?
 patches.obj: ..\src\patches.c
@@ -60,6 +64,14 @@ patches.obj: ..\src\patches.c
 sample.obj: ..\src\sample.c
 	$(CC) $(DLL_FLAGS) $(INCLUDES) -c -Fo$@ $?
 sf2.obj: ..\src\sf2.c
+	$(CC) $(DLL_FLAGS) $(INCLUDES) -c -Fo$@ $?
+mafm.obj: ..\src\mafm.c
+	$(CC) $(DLL_FLAGS) $(INCLUDES) -c -Fo$@ $?
+ma_fm_core.obj: ..\src\mafm\ma_fm_core.c
+	$(CC) $(DLL_FLAGS) $(INCLUDES) -c -Fo$@ $?
+smaf_voice.obj: ..\src\mafm\smaf_voice.c
+	$(CC) $(DLL_FLAGS) $(INCLUDES) -c -Fo$@ $?
+yamaha_adpcm.obj: ..\src\mafm\yamaha_adpcm.c
 	$(CC) $(DLL_FLAGS) $(INCLUDES) -c -Fo$@ $?
 synth.obj: ..\src\synth.c
 	$(CC) $(DLL_FLAGS) $(INCLUDES) -c -Fo$@ $?

--- a/msvc/config.h
+++ b/msvc/config.h
@@ -27,6 +27,7 @@
 #endif
 #pragma warning(disable:4761) /* integral size mismatch in argument; conversion supplied (for MSVC6 and older.) */
 
+#define WILDMIDI_MAFM 1
 #define WILDMIDI_SF2 1
 
 /* #undef AUDIODRV_OPENAL */

--- a/os2/config.h
+++ b/os2/config.h
@@ -20,6 +20,7 @@
 #define HAVE_POWF 1
 #endif
 
+#define WILDMIDI_MAFM 1
 #define WILDMIDI_SF2 1
 
 #define AUDIODRV_OS2DART 1

--- a/os2/makefile.emx
+++ b/os2/makefile.emx
@@ -44,7 +44,7 @@ PLAYER_LIBS+=-lmmpm2
 CFLAGS_LIB= $(CFLAGS) -DWILDMIDI_BUILD
 CFLAGS_EXE= $(CFLAGS)
 
-OBJ=wm_error.o file_io.o lock.o wildmidi_lib.o reverb.o gus_pat.o f_xmidi.o f_mus.o f_hmp.o f_midi.o f_hmi.o mus2mid.o xmi2mid.o hmp2mid.o hmi2mid.o internal_midi.o patches.o sample.o sf2.o synth.o opl3.o
+OBJ=wm_error.o file_io.o lock.o wildmidi_lib.o reverb.o gus_pat.o f_xmidi.o f_mus.o f_hmp.o f_midi.o f_hmi.o f_smaf.o mus2mid.o xmi2mid.o hmp2mid.o hmi2mid.o smaf2mid.o internal_midi.o patches.o sample.o sf2.o mafm.o ma_fm_core.o smaf_voice.o yamaha_adpcm.o synth.o opl3.o
 PLAYER_OBJ=wm_tty.o playlist.o msleep.o getopt_long.o out_none.o out_wave.o out_dart.o wildmidi.o
 
 all: $(LIB_DLL) $(IMPLIB_A) $(IMPLIB_OMF) $(LIBSTATIC) $(PLAYER)
@@ -63,6 +63,8 @@ $(PLAYER): $(IMPLIB_OMF) $(PLAYER_OBJ)
 
 # rules for library objs:
 %.o: ../src/%.c
+	$(CC) -c $(CFLAGS_LIB) -o $@ $<
+%.o: ../src/mafm/%.c
 	$(CC) -c $(CFLAGS_LIB) -o $@ $<
 # rules for player objs:
 getopt_long.o: ../src/getopt_long.c

--- a/os2/makefile.wat
+++ b/os2/makefile.wat
@@ -38,7 +38,7 @@ BLD_TARGET=$(DLLNAME) $(PLAYER)
 INCPATH=-I"$(%WATCOM)/h/os2" -I"$(%WATCOM)/h"
 INCLUDES=$(INCPATH) -I. -I"../include"
 
-OBJ=wm_error.obj file_io.obj lock.obj wildmidi_lib.obj reverb.obj gus_pat.obj f_xmidi.obj f_mus.obj f_hmp.obj f_midi.obj f_hmi.obj mus2mid.obj xmi2mid.obj hmp2mid.obj hmi2mid.obj internal_midi.obj patches.obj sample.obj sf2.obj synth.obj opl3.obj
+OBJ=wm_error.obj file_io.obj lock.obj wildmidi_lib.obj reverb.obj gus_pat.obj f_xmidi.obj f_mus.obj f_hmp.obj f_midi.obj f_hmi.obj f_smaf.obj mus2mid.obj xmi2mid.obj hmp2mid.obj hmi2mid.obj smaf2mid.obj internal_midi.obj patches.obj sample.obj sf2.obj mafm.obj ma_fm_core.obj smaf_voice.obj yamaha_adpcm.obj synth.obj opl3.obj
 PLAYER_OBJ=wm_tty.obj playlist.obj msleep.obj getopt_long.obj out_none.obj out_wave.obj out_dart.obj wildmidi.obj
 
 all: $(BLD_TARGET)
@@ -58,7 +58,7 @@ $(PLAYER_STATIC): $(LIBSTATIC) $(PLAYER_OBJ)
 	wlink N $@ SYS OS2V2 OP q LIBR {$(LIBSTATIC) $(PLAYER_LIBS)} F {$(PLAYER_OBJ)}
 
 # rules for library objs:
-.c: ../src;../src/player
+.c: ../src;../src/player;../src/mafm
 .c.obj:
 	wcc386 $(CFLAGS_LIB) $(INCLUDES) -fo=$^@ $<
 #silence unused function tsf_xx() warnings in sf2.c

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -13,14 +13,20 @@ SET(wildmidi_library_SRCS
     f_hmp.c
     f_midi.c
     f_hmi.c
+    f_smaf.c
     sample.c
     synth.c
     opl3.c
     sf2.c
+    mafm.c
+    mafm/ma_fm_core.c
+    mafm/smaf_voice.c
+    mafm/yamaha_adpcm.c
     mus2mid.c
     xmi2mid.c
     hmp2mid.c
     hmi2mid.c
+    smaf2mid.c
 )
 
 SET(wildmidi_library_HDRS
@@ -35,6 +41,7 @@ SET(wildmidi_library_HDRS
  ../include/f_hmp.h
  ../include/f_midi.h
  ../include/f_hmi.h
+ ../include/f_smaf.h
  ../include/internal_midi.h
  ../include/patches.h
  ../include/sample.h
@@ -49,6 +56,7 @@ SET(wildmidi_library_HDRS
  ../include/xmi2mid.h
  ../include/hmp2mid.h
  ../include/hmi2mid.h
+ ../include/smaf2mid.h
  ../include/wm_tty.h
  ../include/wildplay.h
  ../src/tsf/tsf.h

--- a/src/f_smaf.c
+++ b/src/f_smaf.c
@@ -1,0 +1,76 @@
+/*
+ * f_smaf.c -- Midi Wavetable Processing library
+ *
+ * Copyright (C) WildMIDI Developers 2026
+ *
+ * This file is part of WildMIDI.
+ *
+ * WildMIDI is free software: you can redistribute and/or modify the player
+ * under the terms of the GNU General Public License and you can redistribute
+ * and/or modify the library under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation, either version 3 of
+ * the licenses, or(at your option) any later version.
+ *
+ * WildMIDI is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License and
+ * the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License and the
+ * GNU Lesser General Public License along with WildMIDI.  If not,  see
+ * <http://www.gnu.org/licenses/>.
+ */
+
+/*
+ * Yamaha SMAF ("MMF") support.  SMAF score tracks are converted to a Standard
+ * MIDI File by smaf2mid.c and then parsed by the regular MIDI parser, so this
+ * file is a thin wrapper that keeps SMAF loading consistent with the other
+ * f_*.c format front-ends.
+ */
+
+#include "config.h"
+
+#include <stdint.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "common.h"
+#include "wm_error.h"
+#include "wildmidi_lib.h"
+#include "internal_midi.h"
+#include "reverb.h"
+#include "f_midi.h"
+#include "smaf2mid.h"
+#include "f_smaf.h"
+#ifdef WILDMIDI_MAFM
+#include "mafm.h"
+#endif
+
+struct _mdi *_WM_ParseNewSmaf(const uint8_t *smaf_data, uint32_t smaf_size) {
+    struct _mdi *smaf_mdi = NULL;
+    uint8_t *smf_data = NULL;
+    uint32_t smf_size = 0;
+
+    if (_WM_smaf2midi(smaf_data, smaf_size, &smf_data, &smf_size) < 0) {
+        /* smaf2midi has already set the global error */
+        return NULL;
+    }
+
+    smaf_mdi = _WM_ParseNewMidi(smf_data, smf_size);
+    free(smf_data);
+
+#ifdef WILDMIDI_MAFM
+    /* If the file carries a custom FM voice bank (Mtsu voice-exclusives), attach
+     * an FM synth so playback uses the chip's real voices instead of the GM
+     * approximation.  The note/timing stream still comes from smaf2midi above;
+     * the FM synth only replaces the sound generation.  Files with no custom
+     * voices keep the plain GM path. */
+    if (smaf_mdi != NULL && _WM_MAFM_HasCustomVoices(smaf_data, smaf_size)) {
+        smaf_mdi->mafm_synth = _WM_MAFM_NewSynth(smaf_data, smaf_size,
+                                                 _WM_SampleRate);
+    }
+#endif
+
+    return smaf_mdi;
+}

--- a/src/internal_midi.c
+++ b/src/internal_midi.c
@@ -43,6 +43,9 @@
 #ifdef WILDMIDI_SF2
 #include "sf2.h"
 #endif
+#ifdef WILDMIDI_MAFM
+#include "mafm.h"
+#endif
 
 #ifndef SIZE_MAX
 #define SIZE_MAX ((size_t) (-1))
@@ -2046,6 +2049,9 @@ void _WM_freeMDI(struct _mdi *mdi) {
     free(mdi->mix_buffer);
 #ifdef WILDMIDI_SF2
     _WM_SF2_FreeSynth(mdi->sf2_synth);
+#endif
+#ifdef WILDMIDI_MAFM
+    _WM_MAFM_FreeSynth(mdi->mafm_synth);
 #endif
     if (mdi->tmp_info) {
         free(mdi->tmp_info->copyright);

--- a/src/mafm.c
+++ b/src/mafm.c
@@ -1,0 +1,697 @@
+/*
+ * mafm.c -- Yamaha MA-series FM rendering for SMAF files.
+ *
+ * Copyright (C) WildMIDI Developers 2026
+ *
+ * This file is part of WildMIDI.
+ *
+ * WildMIDI is free software: you can redistribute and/or modify the player
+ * under the terms of the GNU General Public License and you can redistribute
+ * and/or modify the library under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation, either version 3 of
+ * the licenses, or(at your option) any later version.
+ *
+ * WildMIDI is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License and
+ * the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License and the
+ * GNU Lesser General Public License along with WildMIDI.  If not,  see
+ * <http://www.gnu.org/licenses/>.
+ *
+ * The WildMIDI-side wrapper around the FM synth core in src/mafm/.  It parses a
+ * SMAF file's custom instrument bank (Mtsu voice-exclusives) and drives the FM
+ * core as a per-mdi synth instance, mirroring sf2.c.  See docs/SMAF_FM.md.
+ */
+
+#include "config.h"
+
+#ifndef WILDMIDI_MAFM
+
+typedef char mafm_char20[20]; /* no empty source. */
+
+#else
+
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <math.h>
+
+#include "common.h"
+#include "wildmidi_lib.h"
+#include "internal_midi.h"
+#include "mafm.h"
+#include "mafm/ma_fm_core.h"
+#include "mafm/smaf_voice.h"
+#include "mafm/yamaha_adpcm.h"
+
+/* big-endian 32-bit read */
+#define MAFM_BE32(p) (((uint32_t)(p)[0] << 24) | ((uint32_t)(p)[1] << 16) | \
+                      ((uint32_t)(p)[2] << 8)  |  (uint32_t)(p)[3])
+
+#define MAFM_MAX_BANK   64      /* custom voices we keep from one file */
+#define MAFM_POLYPHONY  32      /* simultaneously sounding FM voices */
+#define MAFM_MAX_WAVES  32      /* decoded ADPCM waves kept from one file */
+#define MAFM_PCM_POOL   16      /* simultaneously sounding sampled voices */
+#define MAFM_MAX_TRIGS  1024    /* scheduled ATR wave hits */
+
+/* One entry in the file's custom voice bank. */
+struct mafm_bank_entry {
+    int bank;                        /* SMAF bank (from the voice key) */
+    int pc;                          /* program number */
+    int is_pcm;                      /* PCM (sampled) voice; play the wave */
+    int wave_id;                     /* pcm.wave_id if is_pcm */
+    struct mafm_voice_patch patch;
+};
+
+/* A decoded ADPCM wave (Awa) from the ATR audio track. */
+struct mafm_wave {
+    int16_t *pcm;
+    uint32_t len;                    /* samples */
+    int fs;                          /* native sample rate (Hz) */
+};
+
+/* A sampled voice playing back a wave. */
+struct mafm_pcm_voice {
+    const int16_t *pcm;
+    uint32_t len;
+    double pos;                      /* fractional read position (samples) */
+    double step;                     /* native_fs / output_rate */
+    float  gain;
+    int    active;
+};
+
+/* One scheduled ATR wave trigger. */
+struct mafm_trigger {
+    uint32_t at_sample;              /* absolute output-sample time */
+    int      wave;                   /* wave number */
+};
+
+struct mafm_synth {
+    double rate;
+
+    struct mafm_bank_entry bank[MAFM_MAX_BANK];
+    int bank_count;
+
+    /* ADPCM wave bank + scheduled ATR triggers */
+    struct mafm_wave waves[MAFM_MAX_WAVES];
+    int wave_count;
+    struct mafm_trigger trigs[MAFM_MAX_TRIGS];
+    int trig_count;
+    int trig_next;                   /* index of the next pending trigger */
+    uint32_t cursor;                 /* output samples rendered so far */
+    struct mafm_pcm_voice pcm[MAFM_PCM_POOL];
+
+    /* per-MIDI-channel selection state (16 channels) */
+    uint8_t chan_bank[16];
+    uint8_t chan_program[16];
+    float   chan_volume[16];
+    float   chan_expression[16];     /* CC 0x0B; multiplied with volume */
+    int     chan_pitch[16];          /* 14-bit pitch wheel, centred 0x2000 */
+    uint8_t chan_pan[16];            /* 0..127 pan CC, 64 = centre; 0xff = unset */
+    double  lim_env;                 /* soft peak-limiter state, in mix units */
+
+    struct mafm_voice voices[MAFM_POLYPHONY];
+};
+
+/* ------------------------------------------------------------------------- */
+/* Parse the file's Mtsu voice-exclusives into the bank.                     */
+
+/* Walk one Mtsu chunk body, decoding each voice-exclusive.  MA-1/2 handyphone
+ * files prefix each SysEx with the meta-event byte ("ff f0 <len> 43 ... f7");
+ * MA-3/5/6 files store bare "f0 <len> 43 ... f7" instead.  Accept both. */
+static void mafm_parse_mtsu(struct mafm_synth *s, const uint8_t *body,
+                            uint32_t n) {
+    uint32_t p = 0;
+    while (p + 2 <= n) {
+        uint32_t hdr;
+        if (body[p] == 0xff && p + 3 <= n && body[p + 1] == 0xf0)
+            hdr = 3;                                /* ff f0 <len> */
+        else if (body[p] == 0xf0)
+            hdr = 2;                                /* f0 <len> */
+        else { p++; continue; }
+        {
+            uint8_t len = body[p + hdr - 1];
+            const uint8_t *payload = body + p + hdr;
+            uint32_t plen = len;
+            struct mafm_parsed_voice pv;
+            if ((uint32_t)p + hdr + len > n) break;
+            if (plen > 0 && payload[plen - 1] == 0xf7) plen--;
+            _WM_MAFM_ParseVoiceExclusive(payload, plen, &pv);
+            if (pv.valid && s->bank_count < MAFM_MAX_BANK) {
+                struct mafm_bank_entry *e = &s->bank[s->bank_count++];
+                e->bank = pv.key.bank_lsb;
+                e->pc = pv.key.pc;
+                e->is_pcm = pv.is_pcm;
+                e->wave_id = pv.pcm.wave_id;
+                e->patch = pv.patch;
+            }
+            p += hdr + len;
+        }
+    }
+}
+
+/* Scan the whole SMAF container for Mtsu chunks (inside MTR* score tracks). */
+static void mafm_build_bank(struct mafm_synth *s, const uint8_t *in,
+                            uint32_t insize) {
+    uint32_t pos = 8, end = insize;
+    if (insize >= 8) {
+        uint32_t declared = MAFM_BE32(in + 4);
+        if ((uint64_t)8 + declared <= insize) end = 8 + declared;
+    }
+    while (pos + 8 <= end) {
+        const uint8_t *c = in + pos;
+        uint32_t sz = MAFM_BE32(c + 4);
+        uint32_t body = pos + 8;
+        if ((uint64_t)body + sz > insize) sz = insize - body;
+
+        if (memcmp(c, "MTR", 3) == 0) {
+            /* header width depends on the format byte; scan the inner chunks */
+            uint8_t fmt = (sz >= 1) ? c[8] : 0xff;
+            uint8_t chlen = (fmt == 0x00) ? 2 : (fmt == 0x03) ? 32 : 16;
+            uint32_t hdr = 4 + chlen;
+            uint32_t q = body + hdr, tend = body + sz;
+            while (q + 8 <= tend) {
+                const uint8_t *sc = in + q;
+                uint32_t ssz = MAFM_BE32(sc + 4);
+                uint32_t sbody = q + 8;
+                if ((uint64_t)sbody + ssz > insize) ssz = insize - sbody;
+                if (memcmp(sc, "Mtsu", 4) == 0)
+                    mafm_parse_mtsu(s, in + sbody, ssz);
+                q = sbody + ssz;
+                if (ssz == 0) q++;
+            }
+        }
+        pos = body + sz;
+        if (sz == 0) pos++;
+    }
+}
+
+/* ------------------------------------------------------------------------- */
+/* ADPCM wave bank + ATR wave-trigger schedule.                              */
+
+/* rate class (fmt2 low nibble) -> Hz */
+static int mafm_wave_rate(uint8_t fmt2) {
+    switch (fmt2 & 0x0f) {
+    case 0: return 4000;
+    case 1: return 8000;
+    case 2: return 11025;
+    case 3: return 22050;
+    case 4: return 44100;
+    default: return 8000;
+    }
+}
+
+/* Decode one Awa wave body ([formatByte][fmt2][adpcm...]) into the bank. */
+static void mafm_add_wave(struct mafm_synth *s, int number,
+                          const uint8_t *body, uint32_t sz) {
+    struct mafm_wave *w;
+    const uint8_t *adpcm;
+    uint32_t alen;
+    if (s->wave_count >= MAFM_MAX_WAVES || number < 0 || number >= MAFM_MAX_WAVES)
+        return;
+    if (sz < 2) return;
+    adpcm = body + 2;
+    alen = sz - 2;
+    w = &s->waves[number];
+    if (w->pcm) return;              /* already have this wave number */
+    w->pcm = (int16_t *) calloc((size_t)alen, 2 * sizeof(int16_t));
+    if (!w->pcm) return;
+    w->len = _WM_MAFM_AdpcmDecodeAll(adpcm, alen, 0 /* low-nibble-first */, w->pcm);
+    w->fs = mafm_wave_rate(body[1]);
+    if (number + 1 > s->wave_count) s->wave_count = number + 1;
+}
+
+/* HandyPhone VLQ (1-or-2 byte), as in smaf2mid.c / the ATR sequence. */
+static uint32_t mafm_hps_vlq(const uint8_t *seq, uint32_t *pp, uint32_t end) {
+    uint32_t p = *pp;
+    uint8_t b;
+    uint32_t val;
+    if (p >= end) { *pp = end; return 0; }
+    b = seq[p++];
+    if (b & 0x80) {
+        if (p >= end) { *pp = end; return 0; }
+        val = (((uint32_t)(b & 0x7f) + 1) << 7) | seq[p++];
+    } else {
+        val = b;
+    }
+    *pp = p;
+    return val;
+}
+
+/* Decode an ATR Atsq sequence: like a HandyPhone stream, but a note event's
+ * lead byte carries the wave number to trigger.  Schedule each hit on the
+ * synth's output-sample clock.  ms/tick comes from the ATR timebase. */
+static void mafm_decode_atsq(struct mafm_synth *s, const uint8_t *seq,
+                             uint32_t seqlen, uint32_t ms_dur) {
+    uint32_t p = 0, cur_ms = 0;
+    while (p < seqlen && s->trig_count < MAFM_MAX_TRIGS) {
+        uint32_t dur;
+        uint8_t e1;
+        dur = mafm_hps_vlq(seq, &p, seqlen);
+        cur_ms += dur * ms_dur;
+        if (p >= seqlen) break;
+        e1 = seq[p++];
+        if (e1 == 0xff) {                       /* meta / exclusive */
+            uint8_t e2;
+            if (p >= seqlen) break;
+            e2 = seq[p++];
+            if (e2 == 0x00) continue;
+            if (e2 == 0xf0) {                   /* exclusive: len + payload */
+                uint32_t len = mafm_hps_vlq(seq, &p, seqlen);
+                if ((uint64_t)p + len > seqlen) break;
+                p += len;
+            } else {                            /* meta: len byte + payload */
+                uint8_t len;
+                if (p >= seqlen) break;
+                len = seq[p++];
+                if ((uint32_t)p + len > seqlen) break;
+                p += len;
+            }
+        } else if (e1 == 0x00) {                /* control event */
+            uint8_t e2;
+            if (p >= seqlen) break;
+            e2 = seq[p++];
+            if (e2 == 0x00) {                   /* 00 00 xx */
+                if (p >= seqlen) break;
+                if (seq[p++] == 0x00) break;    /* end of sequence */
+            } else if (((e2 >> 4) & 3) == 3) {  /* long control: skip value */
+                if (p >= seqlen) break;
+                p++;
+            }
+        } else {                                /* note: e1 = wave number + gate */
+            uint8_t wave = e1 & 0x3f;
+            uint32_t gate = mafm_hps_vlq(seq, &p, seqlen);
+            (void) gate;
+            if (s->trig_count < MAFM_MAX_TRIGS) {
+                struct mafm_trigger *t = &s->trigs[s->trig_count++];
+                t->at_sample = (uint32_t)((double)cur_ms * s->rate / 1000.0);
+                t->wave = wave;
+            }
+        }
+    }
+}
+
+/* Scan the container's ATR audio track(s) for the Awa waves + Atsq triggers. */
+static void mafm_build_waves(struct mafm_synth *s, const uint8_t *in,
+                             uint32_t insize) {
+    uint32_t pos = 8, end = insize;
+    if (insize >= 8) {
+        uint32_t declared = MAFM_BE32(in + 4);
+        if ((uint64_t)8 + declared <= insize) end = 8 + declared;
+    }
+    while (pos + 8 <= end) {
+        const uint8_t *c = in + pos;
+        uint32_t sz = MAFM_BE32(c + 4);
+        uint32_t body = pos + 8;
+        if ((uint64_t)body + sz > insize) sz = insize - body;
+
+        if (memcmp(c, "ATR", 3) == 0 && sz >= 6) {
+            /* ATR header: format_type, sequence_type, timebase_dur,
+             * timebase_gate, wave_type ... whose width varies.  Rather than
+             * assume it, scan for the known sub-chunk ids (AspI / Atsq / Awa*)
+             * and process each; advance a byte at a time when the id is
+             * unrecognised. */
+            uint32_t q = body, tend = body + sz;
+            /* The ATR Atsq shares the score's tick base; the sample corpus uses
+             * 4 ms/tick (timebase code 0x02).  The ATR header's own timebase
+             * field placement varies by wave-type, so default to 4 ms rather
+             * than risk misreading it (a wrong value halves/doubles every hit). */
+            uint32_t ms_dur = 4;
+            while (q + 8 <= tend) {
+                const uint8_t *sc = in + q;
+                uint32_t ssz = MAFM_BE32(sc + 4);
+                uint32_t sbody = q + 8;
+                int matched = 0;
+                if ((uint64_t)sbody + ssz <= insize && sbody + ssz <= tend) {
+                    if (memcmp(sc, "Awa", 3) == 0) {
+                        mafm_add_wave(s, sc[3], in + sbody, ssz);
+                        matched = 1;
+                    } else if (memcmp(sc, "Atsq", 4) == 0) {
+                        mafm_decode_atsq(s, in + sbody, ssz, ms_dur);
+                        matched = 1;
+                    } else if (memcmp(sc, "AspI", 4) == 0) {
+                        matched = 1;    /* setup info: skip by size */
+                    }
+                }
+                if (matched) {
+                    q = sbody + ssz;
+                    if (ssz == 0) q++;
+                } else {
+                    q++;                /* header byte: step past it */
+                }
+            }
+        }
+        pos = body + sz;
+        if (sz == 0) pos++;
+    }
+}
+
+/* ------------------------------------------------------------------------- */
+
+int _WM_MAFM_HasCustomVoices(const uint8_t *smaf, uint32_t size) {
+    struct mafm_synth *tmp;
+    int has;
+    if (size < 8 || memcmp(smaf, "MMMD", 4) != 0) return 0;
+    tmp = (struct mafm_synth *) calloc(1, sizeof(*tmp));
+    if (!tmp) return 0;
+    mafm_build_bank(tmp, smaf, size);
+    has = tmp->bank_count > 0;
+    free(tmp);
+    return has;
+}
+
+/* Resolve a channel's (bank, program) to a bank patch, or fall back to the
+ * GM/drum approximation. */
+/* Returns >=0 with the bank index on match (caller inspects s->bank[i].is_pcm
+ * to route PCM playback vs FM playback), -1 for a fallback to a built-in
+ * approximation (which is filled into *out). */
+static int mafm_select_patch(struct mafm_synth *s, int ch, int is_drum,
+                             int note, struct mafm_voice_patch *out) {
+    int i;
+    int bank = s->chan_bank[ch];
+    int pc = s->chan_program[ch];
+    for (i = 0; i < s->bank_count; i++) {
+        if (s->bank[i].pc == pc &&
+            (s->bank[i].bank == bank || s->bank_count <= 4)) {
+            /* bank match, or a tiny bank where the pc alone disambiguates */
+            *out = s->bank[i].patch;
+            return i;
+        }
+    }
+    if (is_drum) _WM_MAFM_DrumApprox(note, out);
+    else         _WM_MAFM_GmApprox(pc, out);
+    return -1;
+}
+
+static double mafm_note_hz(int midi_note, int pitch14) {
+    /* pitch14 centred at 0x2000; +/- 2 semitones default range */
+    double bend = ((double)(pitch14 - 0x2000) / 8192.0) * 2.0;
+    return 440.0 * pow(2.0, ((double)midi_note - 69.0 + bend) / 12.0);
+}
+
+/* Find a free (or steal the quietest) voice slot. */
+static struct mafm_voice *mafm_alloc_voice(struct mafm_synth *s) {
+    static int rr = 0;               /* round-robin slot pointer for stealing */
+    int i, steal;
+    for (i = 0; i < MAFM_POLYPHONY; i++)
+        if (!_WM_MAFM_VoiceActive(&s->voices[i])) return &s->voices[i];
+    /* All busy: steal round-robin (matches the reference).  Better than
+     * always slot 0 because a dense burst spreads the churn across slots
+     * instead of thrashing one voice into silence permanently. */
+    steal = rr;
+    rr = (rr + 1) % MAFM_POLYPHONY;
+    return &s->voices[steal];
+}
+
+void *_WM_MAFM_NewSynth(const uint8_t *smaf, uint32_t size, uint16_t rate) {
+    struct mafm_synth *s;
+    int i;
+    s = (struct mafm_synth *) calloc(1, sizeof(struct mafm_synth));
+    if (!s) return NULL;
+    s->rate = rate ? (double) rate : 44100.0;
+    for (i = 0; i < 16; i++) {
+        s->chan_bank[i] = 0;
+        s->chan_program[i] = 0;
+        s->chan_volume[i] = 1.0f;
+        s->chan_expression[i] = 1.0f;
+        s->chan_pitch[i] = 0x2000;
+        s->chan_pan[i] = 0xff;       /* sentinel: use patch pan_default */
+    }
+    for (i = 0; i < MAFM_POLYPHONY; i++)
+        _WM_MAFM_VoiceInit(&s->voices[i], s->rate);
+    mafm_build_bank(s, smaf, size);
+    mafm_build_waves(s, smaf, size);
+    return s;
+}
+
+void _WM_MAFM_FreeSynth(void *synth) {
+    struct mafm_synth *s = (struct mafm_synth *) synth;
+    int i;
+    if (!s) return;
+    for (i = 0; i < MAFM_MAX_WAVES; i++)
+        free(s->waves[i].pcm);
+    free(s);
+}
+
+void _WM_MAFM_Reset(void *synth) {
+    struct mafm_synth *s = (struct mafm_synth *) synth;
+    int i;
+    for (i = 0; i < MAFM_POLYPHONY; i++)
+        _WM_MAFM_VoiceInit(&s->voices[i], s->rate);
+    for (i = 0; i < MAFM_PCM_POOL; i++)
+        s->pcm[i].active = 0;
+    s->cursor = 0;
+    s->trig_next = 0;
+    for (i = 0; i < 16; i++) {
+        s->chan_bank[i] = 0;
+        s->chan_program[i] = 0;
+        s->chan_volume[i] = 1.0f;
+        s->chan_expression[i] = 1.0f;
+        s->chan_pitch[i] = 0x2000;
+        s->chan_pan[i] = 0xff;       /* sentinel: use patch pan_default */
+    }
+}
+
+int _WM_MAFM_ActiveVoices(void *synth) {
+    struct mafm_synth *s = (struct mafm_synth *) synth;
+    int i, n = 0;
+    for (i = 0; i < MAFM_POLYPHONY; i++)
+        if (_WM_MAFM_VoiceActive(&s->voices[i])) n++;
+    for (i = 0; i < MAFM_PCM_POOL; i++)
+        if (s->pcm[i].active) n++;
+    /* Note: pending triggers are NOT counted as active.  They fire while the
+     * song's event list is still playing; using them to hold the synth alive
+     * past the end-of-track could spin forever if the cursor never reaches a
+     * late trigger.  A currently-sounding sample (above) is what rings out. */
+    return n;
+}
+
+/* Start a sampled wave playing on a free PCM slot (drums are one-shot). */
+static void mafm_start_pcm(struct mafm_synth *s, int wave) {
+    struct mafm_wave *w;
+    struct mafm_pcm_voice *pv = NULL;
+    int i;
+    if (wave < 0 || wave >= s->wave_count) return;
+    w = &s->waves[wave];
+    if (!w->pcm || w->len == 0) return;
+    for (i = 0; i < MAFM_PCM_POOL; i++)
+        if (!s->pcm[i].active) { pv = &s->pcm[i]; break; }
+    if (!pv) pv = &s->pcm[0];       /* steal slot 0 if the pool is full */
+    pv->pcm = w->pcm;
+    pv->len = w->len;
+    pv->pos = 0.0;
+    pv->step = (double) w->fs / s->rate;
+    pv->gain = 1.0f;
+    pv->active = 1;
+}
+
+/* Advance the ATR trigger schedule and render one PCM sample (summed mono). */
+static double mafm_pcm_tick(struct mafm_synth *s) {
+    double mix = 0.0;
+    int i;
+    /* fire any triggers whose time has arrived */
+    while (s->trig_next < s->trig_count &&
+           s->trigs[s->trig_next].at_sample <= s->cursor) {
+        mafm_start_pcm(s, s->trigs[s->trig_next].wave);
+        s->trig_next++;
+    }
+    for (i = 0; i < MAFM_PCM_POOL; i++) {
+        struct mafm_pcm_voice *pv = &s->pcm[i];
+        uint32_t idx;
+        if (!pv->active) continue;
+        idx = (uint32_t) pv->pos;
+        if (idx >= pv->len) { pv->active = 0; continue; }
+        mix += (double) pv->pcm[idx] / 32768.0 * pv->gain;
+        pv->pos += pv->step;
+    }
+    s->cursor++;
+    return mix;
+}
+
+static void mafm_note_on(struct mafm_synth *s, int ch, int note, int vel) {
+    struct mafm_voice_patch patch;
+    struct mafm_voice *v;
+    int is_drum = (ch == 9);
+    int bank_idx = mafm_select_patch(s, ch, is_drum, note, &patch);
+    int sounding_note;
+    float vel01, vel_curve;
+    /* Matched voice is PCM (a sampled instrument, not FM).  We don't yet play
+     * PCM voice-exclusives (see docs/SMAF_FM.md, "Still open" list); play
+     * silence instead of falling back to the generic FM approximation, which
+     * would be an obviously-wrong voice for the file's own sound design. */
+    if (bank_idx >= 0 && s->bank[bank_idx].is_pcm) return;
+    /* Apply the patch's own basic-octave transpose (BO field): a voice can
+     * declare it plays an octave up/down from the incoming MIDI note. */
+    sounding_note = note + patch.note_shift;
+    if (sounding_note < 0)   sounding_note = 0;
+    if (sounding_note > 127) sounding_note = 127;
+    v = mafm_alloc_voice(s);
+    /* Volume x expression, matching the reference mixer.  A file that keeps
+     * volume at 100/127 and rides expression for dynamics needs both to
+     * combine, otherwise the swells never reach the voice. */
+    _WM_MAFM_VoiceSetVolume(v, s->chan_volume[ch] * s->chan_expression[ch]);
+    /* Squared velocity curve.  A linear map made every mid-velocity note
+     * nearly full-scale and constantly pushed the limiter; squaring keeps the
+     * musical dynamic range and matches how the chip's own velocity table
+     * feels (reference does the same). */
+    vel01 = vel ? (float) vel / 127.0f : (100.0f / 127.0f);
+    vel_curve = vel01 * vel01;
+    _WM_MAFM_VoiceNoteOn(v, &patch,
+                         mafm_note_hz(sounding_note, s->chan_pitch[ch]),
+                         vel_curve);
+    v->channel = ch;
+    v->note = note;              /* raw key for note-off matching */
+}
+
+static void mafm_note_off(struct mafm_synth *s, int ch, int note) {
+    int i;
+    /* Release only ONE matching voice, matching the reference.  If the score
+     * hits the same (channel, note) twice with overlap, killing every match
+     * would cut the previous voice's release tail short and make legato
+     * passages sound staccato. */
+    for (i = 0; i < MAFM_POLYPHONY; i++) {
+        struct mafm_voice *v = &s->voices[i];
+        if (_WM_MAFM_VoiceActive(v) && v->channel == ch && v->note == note) {
+            _WM_MAFM_VoiceNoteOff(v);
+            return;
+        }
+    }
+}
+
+void _WM_MAFM_Event(void *synth, struct _mdi *mdi, struct _event *event) {
+    struct mafm_synth *s = (struct mafm_synth *) synth;
+    uint8_t ch = event->event_data.channel;
+    uint32_t val = event->event_data.data.value;
+    (void) mdi;
+    if (ch > 15) return;
+
+    switch (event->evtype) {
+    case ev_note_on:
+        if ((val & 0xFF) == 0)
+            mafm_note_off(s, ch, (val >> 8) & 0x7F);
+        else
+            mafm_note_on(s, ch, (val >> 8) & 0x7F, val & 0x7F);
+        break;
+    case ev_note_off:
+        mafm_note_off(s, ch, (val >> 8) & 0x7F);
+        break;
+    case ev_patch:
+        s->chan_program[ch] = val & 0x7F;
+        break;
+    case ev_control_bank_select:
+        s->chan_bank[ch] = val & 0x7F;
+        break;
+    case ev_pitch: {
+        int i;
+        s->chan_pitch[ch] = val & 0x3FFF;
+        for (i = 0; i < MAFM_POLYPHONY; i++) {
+            struct mafm_voice *v = &s->voices[i];
+            if (_WM_MAFM_VoiceActive(v) && v->channel == ch)
+                _WM_MAFM_VoiceSetPitch(v, mafm_note_hz(v->note, s->chan_pitch[ch]));
+        }
+    } break;
+    case ev_control_channel_volume:
+    case ev_control_channel_expression: {
+        /* Update ALL currently-sounding voices on this channel so volume
+         * swells / expression rides reach in-flight notes.  Without this a
+         * long note that started at low volume stays low forever, missing
+         * the crescendo the score encodes as CC 7/11 rises. */
+        int j;
+        float v_gain;
+        if (event->evtype == ev_control_channel_volume)
+            s->chan_volume[ch] = (float)(val & 0x7F) / 127.0f;
+        else
+            s->chan_expression[ch] = (float)(val & 0x7F) / 127.0f;
+        v_gain = s->chan_volume[ch] * s->chan_expression[ch];
+        for (j = 0; j < MAFM_POLYPHONY; j++) {
+            struct mafm_voice *vp = &s->voices[j];
+            if (_WM_MAFM_VoiceActive(vp) && vp->channel == ch)
+                _WM_MAFM_VoiceSetVolume(vp, v_gain);
+        }
+    } break;
+    case ev_control_channel_pan:
+        s->chan_pan[ch] = (uint8_t)(val & 0x7F);
+        break;
+    default:
+        break;
+    }
+}
+
+/* Constant-power-ish pan law matching the reference mixer: pan is centred at
+ * 0, negative = left, +1 = full right.  L gain = (1 - pan), R gain = (1 + pan),
+ * so a centred voice hits both sides equally and a hard-panned voice moves all
+ * of its energy to one side (total energy stays constant across the field). */
+static void mafm_voice_pan_gains(const struct mafm_synth *s,
+                                 const struct mafm_voice *v,
+                                 float *gl, float *gr) {
+    float pan;
+    uint8_t chan_pan = s->chan_pan[v->channel];
+    if (chan_pan == 0xff) {
+        pan = v->patch.pan_default;                  /* -1..+1 */
+    } else {
+        pan = ((float)chan_pan - 64.0f) / 64.0f;     /* CC 0..127 -> -1..+1 */
+    }
+    if      (pan < -1.0f) pan = -1.0f;
+    else if (pan >  1.0f) pan =  1.0f;
+    *gl = 1.0f - pan;
+    *gr = 1.0f + pan;
+}
+
+void _WM_MAFM_Render(void *synth, int32_t *out, uint32_t frames) {
+    struct mafm_synth *s = (struct mafm_synth *) synth;
+    /* Soft peak limiter: a dozen voices summing at full-scale would exceed
+     * int16 and get hard-clipped by wildmidi_lib's output stage (which
+     * sounds harsh).  A gain-rider with instant attack and slow release
+     * keeps tuttis clean without squashing sparse passages.  Threshold is
+     * below the 32767 cap to leave headroom for reverb / master volume. */
+    const double LIM_THRESHOLD = 30000.0;
+    const double LIM_RELEASE   = 0.9999;
+    uint32_t f, i;
+    /* Cache per-voice pan gains once per Render call: pan is a mix of the
+     * channel's pan CC and the voice's patch pan_default, both of which are
+     * set at note-on time and don't change during the callback window. */
+    float pan_l[MAFM_POLYPHONY], pan_r[MAFM_POLYPHONY];
+    for (i = 0; i < MAFM_POLYPHONY; i++) {
+        struct mafm_voice *v = &s->voices[i];
+        if (_WM_MAFM_VoiceActive(v)) mafm_voice_pan_gains(s, v, &pan_l[i], &pan_r[i]);
+        else { pan_l[i] = 1.0f; pan_r[i] = 1.0f; }
+    }
+    for (f = 0; f < frames; f++) {
+        double l = 0.0, r = 0.0, pcm, peak, gain;
+        for (i = 0; i < MAFM_POLYPHONY; i++) {
+            struct mafm_voice *v = &s->voices[i];
+            if (_WM_MAFM_VoiceActive(v)) {
+                double x = _WM_MAFM_VoiceTick(v);
+                l += x * pan_l[i];
+                r += x * pan_r[i];
+            }
+        }
+        /* ATR sampled drums/phrases play alongside the FM voices, on the
+         * synth's own sample clock (advanced once per output frame).  PCM
+         * triggers have no per-voice channel; keep them centred. */
+        pcm = mafm_pcm_tick(s);
+        /* Match the reference mixer: 0.32 headroom * int16 range = ~10485 per
+         * voice at centre pan (per channel).  With the (1-pan)/(1+pan) pan
+         * law above, each channel receives voice_sum * 0.32 at centre, up to
+         * voice_sum * 0.64 when hard-panned toward it -- constant total
+         * energy across the pan field.  The soft limiter below catches
+         * dense-passage overshoot without squashing sparse notes. */
+        l = l * 10500.0 + pcm * 20000.0;
+        r = r * 10500.0 + pcm * 20000.0;
+        peak = fabs(l) > fabs(r) ? fabs(l) : fabs(r);
+        if (peak > s->lim_env) s->lim_env = peak;
+        else s->lim_env *= LIM_RELEASE;
+        if (s->lim_env > LIM_THRESHOLD) {
+            gain = LIM_THRESHOLD / s->lim_env;
+            l *= gain;
+            r *= gain;
+        }
+        out[f * 2]     += (int32_t) l;
+        out[f * 2 + 1] += (int32_t) r;
+    }
+}
+
+#endif /* WILDMIDI_MAFM */

--- a/src/mafm/ma_fm_core.c
+++ b/src/mafm/ma_fm_core.c
@@ -1,0 +1,435 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * ma_fm_core.c -- the FM DSP: phase generator, exponential ADSR, operators,
+ *                 2-op/4-op algorithms, and a compact built-in GM patch bank.
+ *
+ * Ported to C for WildMIDI from the akustikrausch yamaha-smaf-player
+ * (https://github.com/akustikrausch/yamaha-smaf-player), Copyright (c) Andreas
+ * Wendorf, licensed under the Apache License, Version 2.0.  See NOTICE and
+ * docs/SMAF_FM.md.
+ *
+ * The chip did all of this in fixed point with log/exp lookup ROMs; we do it in
+ * double.  What matters is that the envelope shape and the operator algebra
+ * match -- FM timbre lives in the modulator/carrier ratio and the attack/decay
+ * curve, not in the mantissa.
+ */
+
+#include "config.h"
+
+#ifndef WILDMIDI_MAFM
+
+typedef char mafm_core20[20]; /* no empty src. */
+
+#else
+
+#include "ma_fm_core.h"
+
+#include <math.h>
+#include <string.h>
+
+#include "common.h"      /* M_PI, M_LN2 */
+
+#define MAFM_TWO_PI (2.0 * M_PI)
+
+/* base-2 log via natural log (log2 is C99+; keep this C89-portable) */
+static double mafm_log2(double x) {
+    return log(x) / M_LN2;
+}
+
+static double clampd(double v, double lo, double hi) {
+    return v < lo ? lo : (v > hi ? hi : v);
+}
+
+static float clampf(float v, float lo, float hi) {
+    return v < lo ? lo : (v > hi ? hi : v);
+}
+
+/* total-level (attenuation) -> linear gain.  0.75 dB per TL unit, 63 ~ silence. */
+static double tl_to_gain(uint8_t tl) {
+    if (tl >= 63) return 0.0;
+    return pow(10.0, (-0.75 * (double) tl) / 20.0);
+}
+
+/* a chip "rate" (0..15) mapped to a per-sample linear envelope step. */
+static double rate_to_step(uint8_t rate, double sample_rate, int attack) {
+    double fast, slow, t, samples;
+    if (rate == 0) {
+        /* rate 0: attack completes instantly (caller floors it); a zero-step
+         * decay/sustain/release would freeze the level and never retire, so
+         * floor it to a slow ~20 s glide. */
+        return attack ? 0.0 : (1.0 / (sample_rate * 20.0));
+    }
+    fast = attack ? 0.0008 : 0.004;   /* rate 15 */
+    slow = attack ? 0.35   : 4.0;     /* rate 1  */
+    t = slow * pow(fast / slow, ((double) rate - 1.0) / 14.0);
+    samples = t * sample_rate;
+    if (samples < 1.0) samples = 1.0;
+    return 1.0 / samples;
+}
+
+/* ── patches ────────────────────────────────────────────────────────────── */
+
+void _WM_MAFM_DefaultPatch(struct mafm_voice_patch *v) {
+    struct mafm_op_patch *op0, *op1;
+    memset(v, 0, sizeof(*v));
+    v->four_op = 0;
+    v->algorithm = 0;      /* op0 modulates op1 (carrier) */
+    v->feedback = 0;
+    v->note_shift = 0;
+    v->pan_default = 0.0f;
+    v->lfo = 0;
+
+    op0 = &v->ops[0];
+    op0->multi = 2; op0->tl = 20; op0->ar = 15; op0->dr = 6; op0->sr = 2;
+    op0->rr = 7; op0->sl = 4; op0->eg_type = 1;
+
+    op1 = &v->ops[1];
+    op1->multi = 1; op1->tl = 0; op1->ar = 15; op1->dr = 4; op1->sr = 1;
+    op1->rr = 7; op1->sl = 2; op1->eg_type = 1;
+}
+
+void _WM_MAFM_GmApprox(int program, struct mafm_voice_patch *out) {
+    int fam;
+    _WM_MAFM_DefaultPatch(out);
+    if (program < 0) program = 0;
+    if (program > 127) program = 127;
+    fam = program / 8;                 /* 16 GM families */
+    switch (fam) {
+    case 0:  out->ops[0].multi=1; out->ops[0].dr=7; break;      /* pianos */
+    case 1:  out->ops[0].multi=2; out->ops[0].tl=14; break;     /* chromatic perc */
+    case 2:  out->ops[0].multi=1; out->ops[1].sr=0; out->ops[0].dr=2; break; /* organs */
+    case 3:  out->ops[0].multi=1; out->ops[0].dr=5; break;      /* guitars */
+    case 4:  out->ops[0].multi=2; out->ops[0].dr=4; break;      /* basses */
+    case 5:  out->ops[0].multi=1; out->ops[1].sr=0; out->ops[0].dr=1; break; /* strings */
+    case 6:  out->ops[0].multi=1; out->ops[1].sr=0; break;      /* ensemble */
+    case 7:  out->ops[0].multi=3; out->ops[1].sr=0; break;      /* brass */
+    case 8:  out->ops[0].multi=1; out->ops[1].sr=0; out->ops[0].tl=26; break; /* reed */
+    case 9:  out->ops[0].multi=1; out->ops[1].sr=0; out->ops[0].tl=28; break; /* pipe */
+    case 10: out->ops[0].multi=4; out->ops[0].wave=1; break;    /* synth lead */
+    case 11: out->ops[0].multi=1; out->ops[0].wave=2; out->ops[1].sr=0; break; /* synth pad */
+    case 12: out->ops[0].multi=6; out->ops[0].wave=3; break;    /* synth fx */
+    case 13: out->ops[0].multi=2; out->ops[0].dr=6; break;      /* ethnic */
+    case 14: out->ops[0].multi=8; out->ops[0].dr=10; out->ops[0].wave=1; break; /* percussive */
+    default: out->ops[0].multi=12; out->ops[0].wave=4; out->ops[0].dr=12; break; /* sfx */
+    }
+}
+
+void _WM_MAFM_DrumApprox(int note, struct mafm_voice_patch *out) {
+    /* three short percussive hits, all eg_type=0 so they retire on their own. */
+    struct mafm_op_patch *op0, *op1;
+    _WM_MAFM_DefaultPatch(out);
+    op0 = &out->ops[0];
+    op1 = &out->ops[1];
+    if (note < 44) {                   /* kick-ish: sub carrier, fast thump */
+        memset(op0, 0, sizeof(*op0)); memset(op1, 0, sizeof(*op1));
+        op0->multi=0; op0->tl=8;  op0->ar=15; op0->dr=10; op0->rr=12; op0->sl=15;
+        op1->multi=0; op1->tl=0;  op1->ar=15; op1->dr=9;  op1->rr=12; op1->sl=15; op1->fb=5;
+    } else if (note < 52) {            /* snare-ish: mid noise burst */
+        memset(op0, 0, sizeof(*op0)); memset(op1, 0, sizeof(*op1));
+        op0->multi=11; op0->tl=4; op0->ar=15; op0->dr=9;  op0->rr=11; op0->sl=15; op0->fb=7;
+        op1->multi=1;  op1->tl=2; op1->ar=15; op1->dr=8;  op1->rr=11; op1->sl=15;
+    } else {                           /* hat-ish: short metallic tick */
+        memset(op0, 0, sizeof(*op0)); memset(op1, 0, sizeof(*op1));
+        op0->multi=15; op0->tl=6; op0->ar=15; op0->dr=12; op0->rr=13; op0->sl=15; op0->fb=7;
+        op1->multi=9;  op1->tl=8; op1->ar=15; op1->dr=12; op1->rr=13; op1->sl=15;
+    }
+}
+
+/* ── envelope ───────────────────────────────────────────────────────────── */
+
+static void env_configure(struct mafm_env *e, const struct mafm_op_patch *p,
+                          double sample_rate, double rate_scale) {
+    e->atk_step = rate_to_step(p->ar, sample_rate, 1) * rate_scale;
+    e->dec_step = rate_to_step(p->dr, sample_rate, 0) * rate_scale;
+    e->sus_step = rate_to_step(p->sr, sample_rate, 0) * rate_scale;
+    e->rel_step = rate_to_step(p->rr, sample_rate, 0) * rate_scale;
+    e->sus_level = 1.0 - ((double) p->sl / 15.0);   /* sl 0 = top, 15 = ~silent */
+    e->sustaining = p->eg_type;
+    e->xof = p->xof;
+    e->phase = MAFM_EG_IDLE;
+    e->level = 0.0;
+}
+
+static void env_key_on(struct mafm_env *e) { e->phase = MAFM_EG_ATTACK; }
+
+static void env_key_off(struct mafm_env *e) {
+    /* XOF: ignore key-off and ring out on the envelope; only for percussive
+     * shapes (a sustaining XOF voice would never retire). */
+    if (e->xof && !e->sustaining) return;
+    if (e->phase != MAFM_EG_IDLE) e->phase = MAFM_EG_RELEASE;
+}
+
+static float env_advance(struct mafm_env *e) {
+    switch (e->phase) {
+    case MAFM_EG_IDLE:
+        return 0.0f;
+    case MAFM_EG_ATTACK:
+        e->level += (e->atk_step <= 0.0 ? 1.0 : e->atk_step);
+        if (e->level >= 1.0) { e->level = 1.0; e->phase = MAFM_EG_DECAY; }
+        break;
+    case MAFM_EG_DECAY:
+        e->level -= e->dec_step;
+        if (e->level <= e->sus_level) {
+            e->level = e->sus_level;
+            e->phase = e->sustaining ? MAFM_EG_SUSTAIN : MAFM_EG_RELEASE;
+        }
+        break;
+    case MAFM_EG_SUSTAIN:
+        e->level -= e->sus_step;   /* second-decay: slow bleed to silence */
+        if (e->level <= 0.0) { e->level = 0.0; e->phase = MAFM_EG_IDLE; }
+        break;
+    case MAFM_EG_RELEASE:
+        e->level -= e->rel_step;
+        if (e->level <= 0.0) { e->level = 0.0; e->phase = MAFM_EG_IDLE; }
+        break;
+    }
+    return (float) e->level;
+}
+
+static int env_finished(const struct mafm_env *e) {
+    return e->phase == MAFM_EG_IDLE;
+}
+
+/* ── operator ───────────────────────────────────────────────────────────── */
+
+static void op_recalc(struct mafm_operator *o) {
+    /* MA/YMF825 frequency multiple: 0 => x0.5, n(1..15) => x n.  LINEAR, not the
+     * OPL doubling table. */
+    static const double ksl_db_per_oct[4] = { 0.0, 1.5, 3.0, 6.0 };
+    double m = (o->patch.multi == 0) ? 0.5 : (double)(o->patch.multi & 15);
+    double detune = 1.0 + ((double) o->patch.dt - 3.5) * 0.0006;
+    double oct, att;
+    o->phase_inc = (o->freq_hz * m * detune) / o->sample_rate;
+    oct = mafm_log2((o->freq_hz > 1.0 ? o->freq_hz : 1.0) / 261.63);
+    att = ksl_db_per_oct[o->patch.ksl & 3] * (oct > 0.0 ? oct : 0.0);
+    o->ksl_gain = pow(10.0, -att / 20.0);
+    /* nyquist guard: a high note x high MULTI can land above fs/2; mute it. */
+    o->ny_mute = (o->phase_inc >= 0.5);
+}
+
+static void op_configure(struct mafm_operator *o, const struct mafm_op_patch *p,
+                         double sample_rate, double rate_scale) {
+    static const double k_vib[4]  = { 0.00196, 0.00387, 0.00774, 0.01548 };
+    static const float  k_trem[4] = { 0.129f, 0.242f, 0.424f, 0.669f };
+    o->patch = *p;
+    o->sample_rate = sample_rate;
+    o->wave = p->wave;
+    o->tl_gain = tl_to_gain(p->tl);
+    o->vib_amt = p->vib ? k_vib[p->dvb & 3] : 0.0;
+    o->am_amt  = p->am  ? k_trem[p->dam & 3] : 0.0f;
+    o->phase = 0.0;
+    o->freq_hz = 440.0;
+    env_configure(&o->env, p, sample_rate, rate_scale);
+}
+
+static void op_note_on(struct mafm_operator *o, double freq_hz) {
+    o->freq_hz = freq_hz;
+    o->phase = 0.0;
+    op_recalc(o);
+    env_key_on(&o->env);
+}
+
+static void op_note_off(struct mafm_operator *o) { env_key_off(&o->env); }
+
+static void op_set_base_freq(struct mafm_operator *o, double f) {
+    o->freq_hz = f;
+    op_recalc(o);
+}
+
+/* the OPL/YMF825 sine-derived waveform family (low 3 bits). */
+static float op_waveform(uint8_t wave, double phase01) {
+    double x = phase01 - floor(phase01);
+    double s = sin(MAFM_TWO_PI * x);
+    switch (wave & 7) {
+    case 0: return (float) s;                          /* sine */
+    case 1: return (float)(s > 0 ? s : 0.0);           /* half sine */
+    case 2: return (float) fabs(s);                    /* abs sine (rectified) */
+    case 3: {                                          /* quarter sine */
+        double q = x - floor(x * 2.0) * 0.5;           /* fold to [0,0.5) */
+        return (float)(q < 0.25 ? fabs(sin(MAFM_TWO_PI * q)) : 0.0);
+    }
+    case 4: return (float)(x < 0.5 ? sin(MAFM_TWO_PI * 2.0 * x) : 0.0);        /* even sine */
+    case 5: return (float)(x < 0.5 ? fabs(sin(MAFM_TWO_PI * 2.0 * x)) : 0.0);  /* even abs */
+    case 6: return (float) tanh(s * 3.0);              /* soft "square" */
+    default: {                                         /* soft saw */
+        double v = sin(MAFM_TWO_PI * x) + 0.5 * sin(MAFM_TWO_PI * 2 * x)
+                 + 0.333 * sin(MAFM_TWO_PI * 3 * x);
+        return (float)(v * 0.6);
+    }
+    }
+}
+
+static float op_tick(struct mafm_operator *o, double mod_cycles, double lfo_sin) {
+    float env_gain = env_advance(&o->env);
+    double inc, out;
+    float am_gain;
+    if (o->ny_mute) return 0.0f;
+    inc = o->phase_inc;
+    if (o->vib_amt != 0.0) inc *= 1.0 + o->vib_amt * lfo_sin;
+    o->phase += inc;
+    if (o->phase >= 1.0) o->phase -= floor(o->phase);
+    out = op_waveform(o->wave, o->phase + mod_cycles);
+    am_gain = (o->am_amt != 0.0f)
+            ? 1.0f - o->am_amt * (float)(0.5 + 0.5 * lfo_sin) : 1.0f;
+    return (float)(out * o->tl_gain * o->ksl_gain * env_gain * am_gain);
+}
+
+/* ── voice ──────────────────────────────────────────────────────────────── */
+
+/* how deep a modulator drives a carrier's phase (in cycles), the musical FM
+ * range Yamaha voices sit in. */
+#define MAFM_MOD_DEPTH 0.42
+
+void _WM_MAFM_VoiceInit(struct mafm_voice *v, double sample_rate) {
+    memset(v, 0, sizeof(*v));
+    v->sample_rate = sample_rate;
+    v->velocity = 1.0f;
+    v->volume = 1.0f;
+    v->active = 0;
+    v->channel = -1;
+    v->note = -1;
+}
+
+void _WM_MAFM_VoiceNoteOn(struct mafm_voice *v, const struct mafm_voice_patch *p,
+                          double freq_hz, float velocity) {
+    static const double k_lfo_hz[4] = { 1.8, 4.0, 6.0, 9.7 };
+    double semis_up;
+    int nops, i;
+
+    v->patch = *p;
+    v->four_op = p->four_op;
+    v->algo = p->algorithm & 7;
+    v->feedback = p->feedback;
+    v->velocity = clampf(velocity, 0.0f, 1.0f);
+    for (i = 0; i < 4; i++) {
+        v->fb_mem[i][0] = v->fb_mem[i][1] = 0.0;
+        v->op_fb[i] = p->ops[i].fb;
+    }
+    /* VMA/2-op voices carry feedback only in the header; honour it on op0. */
+    if (p->feedback && !v->op_fb[0]) v->op_fb[0] = p->feedback;
+
+    v->lfo_inc = k_lfo_hz[p->lfo & 3] / v->sample_rate;
+    v->lfo_phase = 0.0;
+    v->lfo_sin = 0.0;
+
+    /* KSR key-scaling: envelopes speed up as the note rises. */
+    semis_up = 12.0 * mafm_log2((freq_hz > 1.0 ? freq_hz : 1.0) / 261.63);
+    nops = v->four_op ? 4 : 2;
+    for (i = 0; i < nops; i++) {
+        double rs = pow(2.0, semis_up / (p->ops[i].ksr ? 24.0 : 96.0));
+        op_configure(&v->ops[i], &p->ops[i], v->sample_rate, clampd(rs, 0.5, 4.0));
+        op_note_on(&v->ops[i], freq_hz);
+    }
+    v->active = 1;
+}
+
+void _WM_MAFM_VoiceNoteOff(struct mafm_voice *v) {
+    int nops = v->four_op ? 4 : 2, i;
+    for (i = 0; i < nops; i++) op_note_off(&v->ops[i]);
+}
+
+void _WM_MAFM_VoiceSetPitch(struct mafm_voice *v, double freq_hz) {
+    int nops = v->four_op ? 4 : 2, i;
+    for (i = 0; i < nops; i++) op_set_base_freq(&v->ops[i], freq_hz);
+}
+
+void _WM_MAFM_VoiceSetVolume(struct mafm_voice *v, float vol) {
+    v->volume = vol;
+}
+
+int _WM_MAFM_VoiceActive(const struct mafm_voice *v) {
+    return v->active;
+}
+
+/* run operator i with its own feedback added to the external phase-mod input. */
+static float voice_mod_op(struct mafm_voice *v, int i, double ext_mod_cycles) {
+    double fbc = 0.0;
+    float o;
+    if (v->op_fb[i] > 0) {
+        double avg = (v->fb_mem[i][0] + v->fb_mem[i][1]) * 0.5;
+        fbc = avg * ((double) v->op_fb[i] / 24.0);
+    }
+    o = op_tick(&v->ops[i], ext_mod_cycles + fbc, v->lfo_sin);
+    v->fb_mem[i][1] = v->fb_mem[i][0];
+    v->fb_mem[i][0] = o;
+    return o;
+}
+
+float _WM_MAFM_VoiceTick(struct mafm_voice *v) {
+    const double d = MAFM_MOD_DEPTH;
+    double out = 0.0;
+    int any_live, nops, i;
+
+    if (!v->active) return 0.0f;
+
+    /* advance the voice LFO once; every VIB/AM operator reads it. */
+    v->lfo_phase += v->lfo_inc;
+    if (v->lfo_phase >= 1.0) v->lfo_phase -= 1.0;
+    v->lfo_sin = sin(MAFM_TWO_PI * v->lfo_phase);
+
+    /* the real MA/YMF825 connection algorithms.  op indices 0..3 = chip ops
+     * 1..4.  carriers are summed; "a->b" = a modulates b's phase. */
+    switch (v->algo) {
+    case 0: {                                   /* FB(1)->2         [2-op] */
+        double m = voice_mod_op(v, 0, 0.0);
+        out = voice_mod_op(v, 1, m * d);
+    } break;
+    case 1: {                                   /* FB(1) + 2        [2-op] */
+        double a = voice_mod_op(v, 0, 0.0);
+        double b = voice_mod_op(v, 1, 0.0);
+        out = (a + b) * 0.5;
+    } break;
+    case 2: {                                   /* FB(1)+2+FB(3)+4 */
+        double a = voice_mod_op(v, 0, 0.0);
+        double b = voice_mod_op(v, 1, 0.0);
+        double c = voice_mod_op(v, 2, 0.0);
+        double e = voice_mod_op(v, 3, 0.0);
+        out = (a + b + c + e) * 0.35;
+    } break;
+    case 3: {                                   /* (FB(1)+2->3)->4 */
+        double a = voice_mod_op(v, 0, 0.0);
+        double b = voice_mod_op(v, 1, 0.0);
+        double c = voice_mod_op(v, 2, (a + b) * d);
+        out = voice_mod_op(v, 3, c * d);
+    } break;
+    case 4: {                                   /* FB(1)->2->3->4 (serial) */
+        double a = voice_mod_op(v, 0, 0.0);
+        double b = voice_mod_op(v, 1, a * d);
+        double c = voice_mod_op(v, 2, b * d);
+        out = voice_mod_op(v, 3, c * d);
+    } break;
+    case 5: {                                   /* FB(1)->2 + FB(3)->4 */
+        double a = voice_mod_op(v, 0, 0.0);
+        double b = voice_mod_op(v, 1, a * d);
+        double c = voice_mod_op(v, 2, 0.0);
+        double e = voice_mod_op(v, 3, c * d);
+        out = (b + e) * 0.5;
+    } break;
+    case 6: {                                   /* FB(1) + 2->3->4 */
+        double a = voice_mod_op(v, 0, 0.0);
+        double b = voice_mod_op(v, 1, 0.0);
+        double c = voice_mod_op(v, 2, b * d);
+        double e = voice_mod_op(v, 3, c * d);
+        out = (a + e) * 0.5;
+    } break;
+    default: {                                  /* 7: FB(1) + 2->3 + 4 */
+        double a = voice_mod_op(v, 0, 0.0);
+        double b = voice_mod_op(v, 1, 0.0);
+        double c = voice_mod_op(v, 2, b * d);
+        double e = voice_mod_op(v, 3, 0.0);
+        out = (a + c + e) * 0.4;
+    } break;
+    }
+
+    /* all operators finished -> voice is done. */
+    any_live = 0;
+    nops = v->four_op ? 4 : 2;
+    for (i = 0; i < nops; i++) {
+        if (!env_finished(&v->ops[i].env)) { any_live = 1; break; }
+    }
+    if (!any_live) v->active = 0;
+
+    return (float)(out * v->velocity * v->volume * 0.7);
+}
+#endif /* WILDMIDI_MAFM */

--- a/src/mafm/ma_fm_core.h
+++ b/src/mafm/ma_fm_core.h
@@ -1,0 +1,128 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * ma_fm_core.h -- FM voice engine of the Yamaha MA-series ringtone chips.
+ *
+ * Ported to C for WildMIDI from the akustikrausch yamaha-smaf-player
+ * (https://github.com/akustikrausch/yamaha-smaf-player), Copyright (c) Andreas
+ * Wendorf, licensed under the Apache License, Version 2.0.  See NOTICE and
+ * docs/SMAF_FM.md.
+ *
+ * The MA-3/MA-5 sound source is a close cousin of the classic OPL/OPN Yamaha FM
+ * line: sine-family operators, an exponential envelope generator, 2-op and 4-op
+ * voices with a small set of connection algorithms.  Patch field values are in
+ * the chip's own units (0..15 rates, 0..63 TL, ...) so sequencer register bytes
+ * drop straight in.  The DSP runs in double where the chip used fixed-point
+ * log/exp ROMs; what matters is that the envelope shape and operator algebra
+ * match, which is where FM timbre lives.
+ */
+
+#ifndef MAFM_MA_FM_CORE_H
+#define MAFM_MA_FM_CORE_H
+
+#include <stdint.h>
+
+/* One operator's patch. */
+struct mafm_op_patch {
+    uint8_t multi;    /* frequency multiple (0..15; 0 = x0.5) */
+    uint8_t tl;       /* total level / attenuation (0..63, 0 = loudest) */
+    uint8_t ar;       /* attack rate  (0..15) */
+    uint8_t dr;       /* decay rate   (0..15) */
+    uint8_t sr;       /* sustain rate (0..15) (aka second decay) */
+    uint8_t rr;       /* release rate (0..15) */
+    uint8_t sl;       /* sustain level (0..15) */
+    uint8_t ksl;      /* key-scale level (0..3) */
+    uint8_t ksr;      /* key-scale rate  (0..1) */
+    uint8_t wave;     /* waveform select (0..31; the YMF825/OPL wave set) */
+    uint8_t dt;       /* detune (0..7) */
+    uint8_t fb;       /* per-operator self-feedback (0..7) */
+    uint8_t am;       /* amplitude modulation (tremolo) enable (0/1) */
+    uint8_t vib;      /* vibrato enable (0/1) */
+    uint8_t eg_type;  /* 1 = sustaining (hold at SL), 0 = percussive */
+    uint8_t dvb;      /* vibrato depth (0..3) */
+    uint8_t dam;      /* tremolo depth (0..3) */
+    uint8_t xof;      /* ignore key-off (drums ring out fully) (0/1) */
+};
+
+/* A voice patch: 2-op or 4-op, one connection algorithm. */
+struct mafm_voice_patch {
+    uint8_t  four_op;      /* 0 = 2-op, 1 = 4-op */
+    uint8_t  algorithm;    /* connection algo (0..1 for 2-op, 0..7 for 4-op) */
+    uint8_t  feedback;     /* op0 self-feedback (0..7) */
+    int      note_shift;   /* basic-octave transpose in semitones (BO) */
+    float    pan_default;  /* patch panpot default, -1..+1 (0 = centre) */
+    uint8_t  lfo;          /* voice LFO rate select (0..3) */
+    struct mafm_op_patch ops[4];  /* ops[0..1] for 2-op, all four for 4-op */
+};
+
+/* Fill *v with the safe default patch (single carrier + modulator, 2-op). */
+void _WM_MAFM_DefaultPatch(struct mafm_voice_patch *v);
+
+/* The built-in, ROM-free GM approximation bank (program 0..127) and the drum
+ * approximation, for channels with no bound custom voice.  Fill *out. */
+void _WM_MAFM_GmApprox(int program, struct mafm_voice_patch *out);
+void _WM_MAFM_DrumApprox(int note, struct mafm_voice_patch *out);
+
+/* ── DSP ──────────────────────────────────────────────────────────────────── */
+
+/* Envelope generator (ADSR, exponential, chip-style discrete rates). */
+enum mafm_eg_phase {
+    MAFM_EG_IDLE = 0, MAFM_EG_ATTACK, MAFM_EG_DECAY,
+    MAFM_EG_SUSTAIN, MAFM_EG_RELEASE
+};
+
+struct mafm_env {
+    enum mafm_eg_phase phase;
+    double level;                        /* 0 (silent) .. 1 (peak), linear */
+    double atk_step, dec_step, sus_step, rel_step;
+    double sus_level;
+    int    sustaining;
+    int    xof;                          /* ignore key-off (drums ring out) */
+};
+
+/* Operator: phase generator + waveform + envelope. */
+struct mafm_operator {
+    struct mafm_op_patch patch;
+    struct mafm_env env;
+    double sample_rate;
+    double freq_hz;
+    double phase;        /* 0..1 */
+    double phase_inc;
+    double tl_gain;      /* linear gain from total-level */
+    double ksl_gain;     /* key-scale level attenuation (freq-dependent) */
+    double vib_amt;      /* vibrato depth as a phase-inc factor */
+    float  am_amt;       /* tremolo depth as a linear gain span */
+    int    ny_mute;      /* operator lands above fs/2 -> silent, no alias */
+    uint8_t wave;
+};
+
+/* A playing voice. */
+struct mafm_voice {
+    struct mafm_voice_patch patch;
+    struct mafm_operator ops[4];
+    double sample_rate;
+    float  velocity;
+    float  volume;
+    int    active;
+    int    four_op;
+    uint8_t algo;
+    uint8_t feedback;
+    uint8_t op_fb[4];                    /* per-operator feedback amount (0..7) */
+    double  fb_mem[4][2];                /* per-op feedback history */
+    double  lfo_phase, lfo_inc;          /* one LFO per voice */
+    double  lfo_sin;                     /* this sample's LFO value */
+    int     channel;                     /* owning smaf channel (for stealing) */
+    int     note;                        /* current note (for stealing) */
+};
+
+/* Voice lifecycle.  Set the sample rate once, then note-on/off and tick. */
+void  _WM_MAFM_VoiceInit(struct mafm_voice *v, double sample_rate);
+void  _WM_MAFM_VoiceNoteOn(struct mafm_voice *v, const struct mafm_voice_patch *p,
+                           double freq_hz, float velocity);
+void  _WM_MAFM_VoiceNoteOff(struct mafm_voice *v);
+void  _WM_MAFM_VoiceSetPitch(struct mafm_voice *v, double freq_hz);
+void  _WM_MAFM_VoiceSetVolume(struct mafm_voice *v, float vol);
+float _WM_MAFM_VoiceTick(struct mafm_voice *v);      /* one mono sample ~[-1,1] */
+int   _WM_MAFM_VoiceActive(const struct mafm_voice *v);
+
+#endif /* MAFM_MA_FM_CORE_H */

--- a/src/mafm/smaf_voice.c
+++ b/src/mafm/smaf_voice.c
@@ -1,0 +1,266 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * smaf_voice.c -- the VM35 / VMA exclusive -> voice patch decode.
+ *
+ * Ported to C for WildMIDI from the akustikrausch yamaha-smaf-player
+ * (https://github.com/akustikrausch/yamaha-smaf-player), Copyright (c) Andreas
+ * Wendorf, licensed under the Apache License, Version 2.0.  See NOTICE and
+ * docs/SMAF_FM.md.
+ *
+ * The tricky bit is the MA-3 "packed" form: Yamaha stole the top bit of a few
+ * fields and stashed them in two carrier bytes per operator to save room.  We
+ * un-pack those first, then both MA-3 and MA-5 share the same 3-global + 7/op
+ * layout.  The MA-1/2 (VMA) form is a smaller 2-global + 5/op layout widened
+ * into the same struct.
+ */
+
+#include "config.h"
+
+#ifndef WILDMIDI_MAFM
+
+typedef char smaf_voice20[20]; /* no empty src. */
+
+#else
+
+#include "smaf_voice.h"
+
+#include <string.h>
+
+/* basic-octave code -> semitone transpose.  BO 0 = +12, 1 = 0, 2 = -12, 3 = -24. */
+static int bo_to_semitones(int bo) {
+    switch (bo & 3) {
+    case 0:  return 12;
+    case 1:  return 0;
+    case 2:  return -12;
+    default: return -24;
+    }
+}
+
+/* panpot 0..31 -> -1..+1 (0..14 = left, 15 = centre, 16..31 = right). */
+static float panpot_to_pan(int pp) {
+    pp &= 31;
+    if (pp == 15) return 0.0f;
+    if (pp < 15)  return -(float)(15 - pp) / 15.0f;
+    return (float)(pp - 15) / 16.0f;
+}
+
+/* The FM core implements all 8 SMAF/YMF825 connection algorithms directly, so
+ * pass the real algorithm straight through.  alg 0/1 are 2-op, 2..7 are 4-op. */
+static void apply_alg(struct mafm_voice_patch *v, int alg) {
+    alg &= 7;
+    v->four_op = (alg >= 2);
+    v->algorithm = (uint8_t) alg;
+}
+
+/* operator count from the algorithm nibble (alg 0-1 = 2op, 2-7 = 4op). */
+static int op_count_from_alg(int alg) {
+    return (alg & 7) <= 1 ? 2 : 4;
+}
+
+/* Apply the shared 3-global + 7-byte/op VM35 body starting at g[0]. */
+static void apply_vm35_body(const uint8_t *g, uint32_t n, int operator_count,
+                            struct mafm_voice_patch *v) {
+    int bo, pp, pe, alg, count, i;
+    const uint8_t *op;
+
+    if (n < 3) return;
+    bo  = g[1] & 0x03;
+    pp  = (g[1] >> 3) & 0x1f;
+    pe  = (g[2] >> 5) & 1;
+    alg = g[2] & 0x07;
+    apply_alg(v, alg);
+    v->note_shift = bo_to_semitones(bo);
+    v->pan_default = pe ? panpot_to_pan(pp) : 0.0f;
+    v->lfo = (g[2] >> 6) & 0x03;            /* voice LFO rate (vm35fm Global+2) */
+
+    op = g + 3;
+    count = operator_count < 1 ? 1 : (operator_count > 4 ? 4 : operator_count);
+    for (i = 0; i < count; i++) {
+        struct mafm_op_patch *o;
+        if ((uint32_t)(op - g) + 7 > n) break;
+        o = &v->ops[i];
+        o->sr  = (op[0] >> 4) & 0x0f;
+        o->ksr =  op[0] & 0x01;
+        /* op+0 bit1 = SUS (inert on YMF825).  The sustaining-vs-percussive
+         * selector is governed by SR != 0, matching the VMA->VM35 derivation. */
+        o->eg_type = (o->sr != 0);
+        o->rr = (op[1] >> 4) & 0x0f;
+        o->dr =  op[1] & 0x0f;
+        o->ar = (op[2] >> 4) & 0x0f;
+        o->sl =  op[2] & 0x0f;
+        o->tl = (op[3] >> 2) & 0x3f;
+        o->ksl =  op[3] & 0x03;
+        o->xof = ((op[0] >> 3) & 1) != 0;   /* ignore key-off (drums ring out) */
+        o->am  = (op[4] >> 4) & 1;          /* EAM */
+        o->dam = (uint8_t)((op[4] >> 5) & 3); /* tremolo depth */
+        o->vib =  op[4] & 1;                /* EVB */
+        o->dvb = (uint8_t)((op[4] >> 1) & 3); /* vibrato depth */
+        o->multi = (op[5] >> 4) & 0x0f;
+        o->dt =  op[5] & 0x07;
+        o->wave = (op[6] >> 3) & 0x1f;
+        o->fb  =  op[6] & 0x07;             /* feedback is PER-OPERATOR on YMF825 */
+        if (i == 0) v->feedback = o->fb;    /* also expose op0's fb on the header */
+        op += 7;
+    }
+    /* 2-op voices leave ops[2..3] at defaults (harmless; core only ticks 2). */
+}
+
+/* Un-pack the MA-3 (VM3Exclusive) form into the plain VM35 body, byte-for-byte
+ * per go-smaf voice/vm35fm Read().  The packed data is 36 bytes (4 global + 8
+ * per op); carriers live at raw[op*8] (stealing SR/RR/AR/TL bit7) and at
+ * raw[8+op*8] (stealing MUL/WS bit7); raw[0] doubles as the global carrier.
+ * After restoring the stolen bits we splice out the carriers to build the
+ * standard 3-global + 7/op stream and hand it to apply_vm35_body. */
+static void apply_ma3_packed(const uint8_t *body, uint32_t n, int operator_count,
+                             struct mafm_voice_patch *v) {
+    uint8_t raw[36];
+    uint8_t fixed[3 + 7 * 4];
+    uint32_t copy, i, w;
+    int op;
+
+    memset(raw, 0, sizeof(raw));
+    copy = (n < 36) ? n : 36;
+    for (i = 0; i < copy; i++) raw[i] = body[i];
+
+    raw[2] = (uint8_t)(raw[2] | ((raw[0] << 2) & 0x80));   /* PANPOT bit7 */
+    raw[3] = (uint8_t)(raw[3] | ((raw[0] << 3) & 0x80));   /* ALG-area bit7 */
+    for (op = 0; op < 4; op++) {
+        raw[4 + op*8]  = (uint8_t)(raw[4 + op*8]  | ((raw[op*8]     << 4) & 0x80)); /* SR */
+        raw[5 + op*8]  = (uint8_t)(raw[5 + op*8]  | ((raw[op*8]     << 5) & 0x80)); /* RR */
+        raw[6 + op*8]  = (uint8_t)(raw[6 + op*8]  | ((raw[op*8]     << 6) & 0x80)); /* AR */
+        raw[7 + op*8]  = (uint8_t)(raw[7 + op*8]  | ((raw[op*8]     << 7) & 0x80)); /* TL */
+        raw[10 + op*8] = (uint8_t)(raw[10 + op*8] | ((raw[8 + op*8] << 2) & 0x80)); /* MUL */
+        raw[11 + op*8] = (uint8_t)(raw[11 + op*8] | ((raw[8 + op*8] << 3) & 0x80)); /* WS */
+    }
+    /* fixed = raw[1:4] (3 global) + per op raw[4+op*8:8+op*8] + raw[9+op*8:12+op*8] */
+    fixed[0] = raw[1]; fixed[1] = raw[2]; fixed[2] = raw[3];
+    w = 3;
+    for (op = 0; op < 4; op++) {
+        fixed[w++] = raw[4 + op*8]; fixed[w++] = raw[5 + op*8];
+        fixed[w++] = raw[6 + op*8]; fixed[w++] = raw[7 + op*8];
+        fixed[w++] = raw[9 + op*8]; fixed[w++] = raw[10 + op*8];
+        fixed[w++] = raw[11 + op*8];
+    }
+    apply_vm35_body(fixed, w, operator_count, v);
+}
+
+void _WM_MAFM_ParseVoiceExclusive(const uint8_t *p, uint32_t n,
+                                  struct mafm_parsed_voice *out) {
+    memset(out, 0, sizeof(*out));
+    _WM_MAFM_DefaultPatch(&out->patch);
+    if (!p || n < 5) return;
+    if (p[0] != 0x43) return;   /* not a Yamaha maker id */
+
+    /* MA-3 / MA-5 long form: 43 79 06|07 7F 01 [bank...] body */
+    if (n >= 11 && p[1] == 0x79 && (p[2] == 0x06 || p[2] == 0x07) &&
+        p[3] == 0x7f && p[4] == 0x01) {
+        int voice_type;
+        out->key.bank_msb = p[5];
+        out->key.bank_lsb = p[6];
+        out->key.pc = p[7];
+        out->key.drum_note = p[8];
+        voice_type = p[9];
+        if (voice_type != 0) {                       /* PCM (sampled) voice */
+            const uint8_t *b = p + 10;
+            uint32_t bn = n - 10;
+            out->is_pcm = 1;
+            if (bn >= 16) {
+                struct mafm_pcm_params *pc = &out->pcm;
+                pc->fs     = ((int)b[0] << 8) | b[1];        /* Fs, u16 BE */
+                pc->env.tl = (b[7] >> 2) & 0x3f;             /* TL */
+                pc->env.sr = (b[4] >> 4) & 0x0f;             /* SR */
+                pc->env.rr = (b[5] >> 4) & 0x0f;             /* RR */
+                pc->env.dr =  b[5] & 0x0f;                   /* DR */
+                pc->env.ar = (b[6] >> 4) & 0x0f;             /* AR */
+                pc->env.sl =  b[6] & 0x0f;                   /* SL */
+                pc->env.eg_type = (pc->env.sr != 0);
+                pc->loop_pt = ((int)b[11] << 8) | b[12];     /* LP, u16 BE */
+                pc->end_pt  = ((int)b[13] << 8) | b[14];     /* EP, u16 BE */
+                pc->loop    = (b[15] & 0x80) != 0;           /* RM flag */
+                pc->wave_id =  b[15] & 0x7f;                 /* WaveID */
+                if (pc->fs < 2000 || pc->fs > 48000) pc->fs = 8000;
+                out->valid = 1;
+            }
+            return;
+        }
+        {
+            const uint8_t *body = p + 10;
+            uint32_t bn = n - 10;
+            /* Need the algorithm to know the op count.  MA-5 DIRECT: alg in body
+             * byte 2.  MA-3 PACKED: byte 2 is still PANPOT and the alg sits in
+             * byte 3 (its low 3 bits survive the bit-steal); peek the right byte
+             * or 4-op voices truncate to 2. */
+            uint32_t alg_byte = (p[2] == 0x06) ? 3 : 2;
+            int alg = (bn > alg_byte) ? (body[alg_byte] & 0x07) : 0;
+            int ops = op_count_from_alg(alg);
+            if (p[2] == 0x06) apply_ma3_packed(body, bn, ops, &out->patch);
+            else              apply_vm35_body(body, bn, ops, &out->patch);
+            out->valid = 1;
+        }
+        return;
+    }
+
+    /* MA-5 short form: 43 05 01 [bankLSB] [pc] body */
+    if (n >= 6 && p[1] == 0x05 && p[2] == 0x01) {
+        const uint8_t *body = p + 5;
+        uint32_t bn = n - 5;
+        int alg = (bn >= 3) ? (body[2] & 0x07) : 0;
+        out->key.bank_msb = 0;
+        out->key.bank_lsb = p[3];
+        out->key.pc = p[4];
+        apply_vm35_body(body, bn, op_count_from_alg(alg), &out->patch);
+        out->valid = 1;
+        return;
+    }
+
+    /* MA-1 / MA-2 (VMA) form: 43 03 [Enigma][Bank][PC] then the voice body
+     * (2 global + 5 bytes/op).  The note stream selects the voice by (Bank, PC). */
+    if (n >= 7 && p[1] == 0x03) {
+        const uint8_t *g = p + 5;    /* body starts after the header */
+        uint32_t gn = n - 5;
+        out->key.bank_msb = 0;
+        out->key.bank_lsb = p[3] & 0x7f;  /* Bank (bit7 = drum bank, masked off) */
+        out->key.pc       = p[4];         /* PC */
+        if (gn >= 2) {
+            int fb  = (g[0] >> 3) & 0x07;
+            int alg = g[0] & 0x07;        /* g[1] = the 0x01 enigma constant */
+            int count, i;
+            const uint8_t *op;
+            apply_alg(&out->patch, alg);
+            out->patch.feedback = (uint8_t) fb;
+            out->patch.lfo = (uint8_t)((g[0] >> 6) & 3);   /* voice LFO rate */
+            count = op_count_from_alg(alg);
+            op = g + 2;
+            for (i = 0; i < count; i++) {
+                struct mafm_op_patch *o;
+                int egt;
+                if ((uint32_t)(op - g) + 5 > gn) break;
+                o = &out->patch.ops[i];
+                /* VMAFMOperator.Read: +0 MULT|VIB(b3)|EGT(b2)|SUS(b1)|KSR(b0) */
+                o->multi = (op[0] >> 4) & 0x0f;
+                o->vib   = (op[0] & 0x08) != 0;   /* VIB (bit3) */
+                egt      = (op[0] & 0x04) != 0;   /* EGT (bit2) */
+                o->ksr   = (op[0] & 0x01);
+                o->rr = (op[1] >> 4) & 0x0f; o->dr = op[1] & 0x0f;
+                o->ar = (op[2] >> 4) & 0x0f; o->sl = op[2] & 0x0f;
+                o->tl = (op[3] >> 2) & 0x3f; o->ksl = op[3] & 0x03;
+                /* +4: DVB(b7-6) | DAM(b5-4) | AM(b3) | WS(b2-0) */
+                o->am   = (op[4] & 0x08) != 0;
+                o->dvb  = (uint8_t)((op[4] >> 6) & 3);
+                o->dam  = (uint8_t)((op[4] >> 4) & 3);
+                o->wave = op[4] & 0x07;
+                /* VMAFMOperator.ToVM35: SR = EGT ? 0 : RR ; sustaining if SR!=0 */
+                o->sr = egt ? 0 : (op[1] >> 4) & 0x0f;
+                o->eg_type = (o->sr != 0);
+                if (i == 0) o->fb = (uint8_t) fb; /* VMA feedback lands on op0 */
+                op += 5;
+            }
+            out->valid = 1;
+        }
+        return;
+    }
+
+    /* unknown Yamaha sub-form: leave out->valid = 0 */
+}
+#endif /* WILDMIDI_MAFM */

--- a/src/mafm/smaf_voice.h
+++ b/src/mafm/smaf_voice.h
@@ -1,0 +1,59 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * smaf_voice.h -- decode Yamaha VM35 / VMA voice exclusives into a voice patch.
+ *
+ * Ported to C for WildMIDI from the akustikrausch yamaha-smaf-player
+ * (https://github.com/akustikrausch/yamaha-smaf-player), Copyright (c) Andreas
+ * Wendorf, licensed under the Apache License, Version 2.0.  See NOTICE and
+ * docs/SMAF_FM.md.
+ *
+ * A SMAF file that uses a custom instrument carries it as a Yamaha sysex blob in
+ * the setup chunk (Mtsu) or inline in the sequence: "43 79 06/07 7F 01 ..." for
+ * the MA-3/MA-5 form, "43 03 ..." for the MA-1/2 form.  This turns those bytes
+ * into the parameters the FM core wants.  Files that only use the chip's
+ * built-in bank carry no such blob.
+ *
+ * Byte layouts follow the go-smaf voice/{vm35fm,vmafm} reference (read as spec).
+ */
+
+#ifndef MAFM_SMAF_VOICE_H
+#define MAFM_SMAF_VOICE_H
+
+#include <stdint.h>
+#include "ma_fm_core.h"
+
+/* Which instrument slot a voice binds to (from bank-select + program-change;
+ * drum_note != 0 marks a percussion voice). */
+struct mafm_voice_key {
+    int bank_msb;
+    int bank_lsb;
+    int pc;
+    int drum_note;
+};
+
+/* PCM (sampled) voice: a drum or sampled instrument that plays an Mwa/Awa wave. */
+struct mafm_pcm_params {
+    int fs;         /* sampling rate from the body (Hz) */
+    int wave_id;    /* binds to the Mwa/Awa wave with this number */
+    int loop_pt;    /* loop point (sample index into the decoded wave) */
+    int end_pt;     /* end point  (sample index; 0 = whole wave) */
+    int loop;       /* RM flag: loop between loop_pt and end_pt (0/1) */
+    struct mafm_op_patch env;  /* AR/DR/SR/RR/SL/TL reused for the amplitude EG */
+};
+
+struct mafm_parsed_voice {
+    struct mafm_voice_key   key;
+    struct mafm_voice_patch patch;
+    struct mafm_pcm_params  pcm;    /* valid when is_pcm */
+    int is_pcm;                     /* pcm voices play a sampled wave, not FM */
+    int valid;
+};
+
+/* Parse ONE exclusive payload (the bytes between the F0 length and the trailing
+ * F7, i.e. starting at the 0x43 maker id) into *out.  Sets out->valid = 0 for
+ * anything not synthesised (unknown makers); PCM voices set out->is_pcm. */
+void _WM_MAFM_ParseVoiceExclusive(const uint8_t *p, uint32_t n,
+                                  struct mafm_parsed_voice *out);
+
+#endif /* MAFM_SMAF_VOICE_H */

--- a/src/mafm/yamaha_adpcm.c
+++ b/src/mafm/yamaha_adpcm.c
@@ -1,0 +1,81 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * yamaha_adpcm.c -- the 4-bit Yamaha ADPCM codec used by SMAF ATR / stream-PCM.
+ *
+ * Ported to C for WildMIDI from the akustikrausch yamaha-smaf-player
+ * (https://github.com/akustikrausch/yamaha-smaf-player), Copyright (c) Andreas
+ * Wendorf, licensed under the Apache License, Version 2.0.  The C translation
+ * preserves the original algorithm; see NOTICE and docs/SMAF_FM.md.
+ *
+ * This is the YM2608 (OPNA) ADPCM-B family, the same 4-bit codec Yamaha reused
+ * across their FM parts.  One nibble in, one 16-bit sample out, with an
+ * adaptive step size.  Two codes are packed per byte; MA files disagree on
+ * which nibble comes first, so the caller selects high- or low-nibble-first
+ * (high-nibble-first is the Yamaha-standard default).
+ */
+
+#include "config.h"
+
+#ifndef WILDMIDI_MAFM
+
+typedef char yamaha_adpcm20[20]; /* no empty src. */
+
+#else
+
+#include "yamaha_adpcm.h"
+
+static int adpcm_clamp16(int v) {
+    if (v < -32768) return -32768;
+    if (v >  32767) return  32767;
+    return v;
+}
+
+void _WM_MAFM_AdpcmReset(struct mafm_adpcm *a) {
+    a->last = 0;
+    a->step = 127;
+}
+
+int16_t _WM_MAFM_AdpcmDecodeNibble(struct mafm_adpcm *a, uint8_t code) {
+    int delta = a->step >> 3;
+    if (code & 1) delta += a->step >> 2;
+    if (code & 2) delta += a->step >> 1;
+    if (code & 4) delta += a->step;
+    if (code & 8) delta = -delta;
+    a->last = adpcm_clamp16(a->last + delta);
+
+    /* step adaptation (OPNA-B table, as the published ratios) */
+    switch (code & 7) {
+    case 0: case 1: case 2: case 3: a->step = a->step * 115 / 128; break;
+    case 4: a->step = a->step * 307 / 256; break;
+    case 5: a->step = a->step * 409 / 256; break;
+    case 6: a->step = a->step * 2;         break;
+    default: a->step = a->step * 307 / 128; break;   /* 7 */
+    }
+    if (a->step < 127)   a->step = 127;
+    if (a->step > 24576) a->step = 24576;
+
+    return (int16_t) a->last;
+}
+
+uint32_t _WM_MAFM_AdpcmDecodeAll(const uint8_t *data, uint32_t n,
+                                 int high_nibble_first, int16_t *out) {
+    struct mafm_adpcm a;
+    uint32_t i, w = 0;
+    _WM_MAFM_AdpcmReset(&a);
+    for (i = 0; i < n; i++) {
+        uint8_t b = data[i];
+        uint8_t hi = (uint8_t)((b >> 4) & 0x0f);
+        uint8_t lo = (uint8_t)(b & 0x0f);
+        if (high_nibble_first) {
+            out[w++] = _WM_MAFM_AdpcmDecodeNibble(&a, hi);
+            out[w++] = _WM_MAFM_AdpcmDecodeNibble(&a, lo);
+        } else {
+            out[w++] = _WM_MAFM_AdpcmDecodeNibble(&a, lo);
+            out[w++] = _WM_MAFM_AdpcmDecodeNibble(&a, hi);
+        }
+    }
+    return w;
+}
+
+#endif /* WILDMIDI_MAFM */

--- a/src/mafm/yamaha_adpcm.h
+++ b/src/mafm/yamaha_adpcm.h
@@ -1,0 +1,35 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * yamaha_adpcm.h -- the 4-bit Yamaha ADPCM codec used by SMAF ATR / stream-PCM.
+ *
+ * Ported to C for WildMIDI from the akustikrausch yamaha-smaf-player
+ * (https://github.com/akustikrausch/yamaha-smaf-player), Copyright (c) Andreas
+ * Wendorf, licensed under the Apache License, Version 2.0.  See NOTICE and
+ * docs/SMAF_FM.md.
+ */
+
+#ifndef MAFM_YAMAHA_ADPCM_H
+#define MAFM_YAMAHA_ADPCM_H
+
+#include <stdint.h>
+
+/* Decoder state.  Reset before decoding an independent block. */
+struct mafm_adpcm {
+    int last;   /* last output sample */
+    int step;   /* adaptive step size */
+};
+
+/* Reset the running state (last=0, step=127). */
+void _WM_MAFM_AdpcmReset(struct mafm_adpcm *a);
+
+/* Decode one 4-bit code to a 16-bit PCM sample, advancing the state. */
+int16_t _WM_MAFM_AdpcmDecodeNibble(struct mafm_adpcm *a, uint8_t code);
+
+/* Decode a packed buffer of n bytes (two codes each) to 16-bit PCM.
+ * high_nibble_first selects which nibble of each byte is decoded first.
+ * Writes 2*n samples into out (which must have room); returns the count. */
+uint32_t _WM_MAFM_AdpcmDecodeAll(const uint8_t *data, uint32_t n,
+                                 int high_nibble_first, int16_t *out);
+
+#endif /* MAFM_YAMAHA_ADPCM_H */

--- a/src/player/playlist.c
+++ b/src/player/playlist.c
@@ -71,7 +71,7 @@
  * the command line bypass this: the library sniffs content, not names, so a
  * deliberately named file still plays.  */
 static const char *const midi_extensions[] = {
-    "mid", "midi", "rmi", "kar", "mus", "xmi", "hmp", "hmi", NULL
+    "mid", "midi", "rmi", "kar", "mus", "xmi", "hmp", "hmi", "mmf", NULL
 };
 
 static int has_midi_extension(const char *name) {

--- a/src/root.zig
+++ b/src/root.zig
@@ -17,6 +17,7 @@ pub const WildMidiError = error{
     UnableToConvert,
     NotAMusFile,
     NotAnXmiFile,
+    NotASmafFile,
     InvalidErrorCode,
 };
 
@@ -40,6 +41,7 @@ fn handleError(error_status: c_int) WildMidiError!void {
         wm_error.WM_ERR_CONVERT => error.UnableToConvert,
         wm_error.WM_ERR_NOT_MUS => error.NotAMusFile,
         wm_error.WM_ERR_NOT_XMI => error.NotAnXmiFile,
+        wm_error.WM_ERR_NOT_SMAF => error.NotASmafFile,
         else => error.InvalidErrorCode,
     };
 }

--- a/src/smaf2mid.c
+++ b/src/smaf2mid.c
@@ -131,9 +131,13 @@ static uint32_t getdstpos(struct smaf_ctx *ctx) {
 }
 
 static void seekdst(struct smaf_ctx *ctx, uint32_t pos) {
-    ctx->dst_ptr = ctx->dst + pos;
+    /* Grow first: resize_dst() reallocs, so dst_ptr must only be derived from
+     * ctx->dst once the buffer is final.  Setting it up front would also form
+     * an out-of-bounds pointer whenever pos is past the current end - which is
+     * exactly the case that needs the growth. */
     while (ctx->dstsize < pos)
         if (resize_dst(ctx)) { ctx->oom = 1; return; }
+    ctx->dst_ptr = ctx->dst + pos;
     ctx->dstrem = ctx->dstsize - pos;
 }
 

--- a/src/smaf2mid.c
+++ b/src/smaf2mid.c
@@ -173,7 +173,13 @@ static uint32_t timebase_ms(uint8_t code) {
 /* Write a channel-voice event at absolute time at_ms, emitting the delta. */
 static void write_event(struct smaf_ctx *ctx, uint32_t at_ms,
                         uint8_t status, uint8_t d1, uint8_t d2, int have_d2) {
-    uint32_t delta = at_ms - ctx->last_event_ms;
+    uint32_t delta;
+    /* A malformed file can wrap cur_ms (durations and gate times are
+     * attacker-controlled VLQs), putting an event before the previous one.
+     * The unsigned subtraction would then yield a delta near UINT32_MAX -
+     * about 46 days of silence at 1 tick == 1 ms.  Clamp instead. */
+    if (at_ms < ctx->last_event_ms) at_ms = ctx->last_event_ms;
+    delta = at_ms - ctx->last_event_ms;
     write_varlen(ctx, delta);
     write1(ctx, status);
     write1(ctx, d1);
@@ -552,6 +558,16 @@ static int hp_pitch(uint8_t octave, uint8_t note, uint8_t oct_shift) {
 /* Default velocity for HandyPhone notes, which carry no velocity byte. */
 #define HP_NOTE_VELOCITY 100
 
+/* Map a track's SMAF channel to a MIDI channel for a MELODIC voice.
+ * MIDI channel 9 is the GM rhythm channel, so a melodic voice landing there
+ * (track 2 channel 1 with base_ch 8, for instance) would be rendered as drums
+ * and would also collide with the percussion reroute target.  Skip over 9;
+ * four tracks of four channels still fit in the remaining 15 channels. */
+static uint8_t hp_melodic_channel(uint8_t base_ch, uint8_t ch) {
+    uint8_t c = (uint8_t)(base_ch + ch);
+    return (uint8_t)((c >= 9) ? ((c + 1) & 0x0f) : c);
+}
+
 /* Decode one HandyPhone track's Mtsq into the shared event list.
  *   base_ch  : MIDI channel for this track's SMAF channel 0 (0,4,8,12).
  *   perc_mask: bit c set => SMAF channel c is a percussion channel and is
@@ -610,7 +626,8 @@ static int decode_handyphone(struct hp_events *e, const uint8_t *seq,
                 uint8_t val, midi_ch;
                 if (p >= seqlen) break;
                 val = seq[p++];
-                midi_ch = (perc_mask & (1 << ch)) ? 9 : (base_ch + ch);
+                midi_ch = (perc_mask & (1 << ch))
+                        ? 9 : hp_melodic_channel(base_ch, ch);
                 switch (data) {
                 case 0x0:                       /* program change */
                     program[ch] = val & 0x7f;
@@ -671,7 +688,7 @@ static int decode_handyphone(struct hp_events *e, const uint8_t *seq,
                 midi_ch = 9;
                 pitch = program[ch] & 0x7f;
             } else {
-                midi_ch = base_ch + ch;
+                midi_ch = hp_melodic_channel(base_ch, ch);
                 pitch = hp_pitch(octave, note, oct_shift[ch]);
             }
             if (hp_push(e, cur_ms, 0x90 | midi_ch,

--- a/src/smaf2mid.c
+++ b/src/smaf2mid.c
@@ -1,0 +1,895 @@
+/*
+ * SMAF2MIDI: Yamaha SMAF (MMF) to MIDI Library
+ *
+ * Copyright (C) WildMIDI Developers 2026
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public
+ * License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+ * Boston, MA  02110-1301, USA.
+ */
+
+/*
+ * Converts Yamaha SMAF ("MMF") Mobile Standard score tracks into a Standard
+ * MIDI File.  Only the score track SEQUENCE (Mtsq) is converted; embedded
+ * PCM/ADPCM audio (Mtsp/ATR) and custom FM voice banks (Mtsu) are ignored, so
+ * playback falls back to the General MIDI patch set.
+ *
+ * See docs/formats/SmafFileFormat.txt for the format description.
+ */
+
+#define __STDC_LIMIT_MACROS
+#include "config.h"
+
+#include <stddef.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+#include "smaf2mid.h"
+#include "wm_error.h"
+
+/* SMAF ticks are given in milliseconds; we render the MIDI at a fixed 1 tick =
+ * 1 ms by choosing a tempo of 1000 us/quarter-note against a division that
+ * makes a quarter note 1000 ticks.  In practice we set the division to a
+ * convenient PPQN and a matching tempo so that one SMAF millisecond maps to one
+ * MIDI delta tick.  Using 1000 us per quarter and division 1000 gives exactly
+ * 1 tick == 1 microsecond-quarter... instead we keep it simple: 1 MIDI tick ==
+ * 1 ms via tempo 1,000,000 us/qn and division 1000 (1000 ticks per second). */
+#define SMAF_DIVISION   1000            /* ticks per quarter note */
+#define SMAF_TEMPO      1000000         /* microseconds per quarter note */
+/* => 1000 ticks per quarter note, 1 quarter note per second => 1 tick == 1 ms */
+
+#define MIDI_MAXCHANNELS 16
+
+/* A note scheduled to be turned off at an absolute time (in ms). */
+struct pending_off {
+    uint32_t at_ms;     /* absolute time to send the note off */
+    uint8_t channel;
+    uint8_t note;
+};
+
+struct smaf_ctx {
+    const uint8_t *src;
+    uint32_t srcsize;
+
+    uint8_t *dst, *dst_ptr;
+    uint32_t dstsize, dstrem;
+
+    /* pending note-offs, kept sorted by at_ms */
+    struct pending_off *offs;
+    uint32_t offs_count;
+    uint32_t offs_alloc;
+
+    uint32_t last_event_ms;     /* absolute time of the last written event */
+
+    /* Sticky out-of-memory flag.  The write helpers below return void, so a
+     * failed resize_dst() would otherwise silently drop output and leave the
+     * caller reporting success with a truncated (invalid) MIDI buffer. */
+    int oom;
+};
+
+#define DST_CHUNK 8192
+static int resize_dst(struct smaf_ctx *ctx) {
+    uint32_t pos = (uint32_t)(ctx->dst_ptr - ctx->dst);
+    uint8_t *n = (uint8_t *) realloc(ctx->dst, ctx->dstsize + DST_CHUNK);
+    if (!n) return -1;
+    ctx->dst = n;
+    ctx->dstsize += DST_CHUNK;
+    ctx->dstrem += DST_CHUNK;
+    ctx->dst_ptr = ctx->dst + pos;
+    return 0;
+}
+
+static void write1(struct smaf_ctx *ctx, uint32_t val) {
+    if (ctx->dstrem < 1) { if (resize_dst(ctx)) { ctx->oom = 1; return; } }
+    *ctx->dst_ptr++ = val & 0xff;
+    ctx->dstrem--;
+}
+
+static void write2(struct smaf_ctx *ctx, uint32_t val) {
+    if (ctx->dstrem < 2) { if (resize_dst(ctx)) { ctx->oom = 1; return; } }
+    *ctx->dst_ptr++ = (val >> 8) & 0xff;
+    *ctx->dst_ptr++ = val & 0xff;
+    ctx->dstrem -= 2;
+}
+
+static void write4(struct smaf_ctx *ctx, uint32_t val) {
+    if (ctx->dstrem < 4) { if (resize_dst(ctx)) { ctx->oom = 1; return; } }
+    *ctx->dst_ptr++ = (val >> 24) & 0xff;
+    *ctx->dst_ptr++ = (val >> 16) & 0xff;
+    *ctx->dst_ptr++ = (val >> 8) & 0xff;
+    *ctx->dst_ptr++ = val & 0xff;
+    ctx->dstrem -= 4;
+}
+
+/* write a MIDI variable-length delta time */
+static void write_varlen(struct smaf_ctx *ctx, uint32_t value) {
+    uint8_t buf[5];
+    int n = 0;
+    buf[n++] = value & 0x7f;
+    while ((value >>= 7)) {
+        buf[n++] = 0x80 | (value & 0x7f);
+    }
+    /* buf holds least-significant chunk first; emit most-significant first */
+    while (n--) {
+        write1(ctx, buf[n]);
+    }
+}
+
+static uint32_t getdstpos(struct smaf_ctx *ctx) {
+    return (uint32_t)(ctx->dst_ptr - ctx->dst);
+}
+
+static void seekdst(struct smaf_ctx *ctx, uint32_t pos) {
+    ctx->dst_ptr = ctx->dst + pos;
+    while (ctx->dstsize < pos)
+        if (resize_dst(ctx)) { ctx->oom = 1; return; }
+    ctx->dstrem = ctx->dstsize - pos;
+}
+
+/* ------------------------------------------------------------------------- */
+
+/* big-endian 32-bit read */
+#define BE32(p) (((uint32_t)(p)[0] << 24) | ((uint32_t)(p)[1] << 16) | \
+                 ((uint32_t)(p)[2] << 8)  |  (uint32_t)(p)[3])
+
+/* SMAF variable-length quantity (MIDI-style: 7 bits/byte, high bit = more).
+ * Reads from seq[*pp], advancing *pp, never past end. */
+static uint32_t read_vlq(const uint8_t *seq, uint32_t *pp, uint32_t end) {
+    uint32_t val = 0;
+    uint32_t p = *pp;
+    while (p < end) {
+        uint8_t b = seq[p++];
+        val = (val << 7) | (b & 0x7f);
+        if (!(b & 0x80)) break;
+    }
+    *pp = p;
+    return val;
+}
+
+/* timebase code -> milliseconds per tick */
+static uint32_t timebase_ms(uint8_t code) {
+    switch (code) {
+    case 0x00: case 0x10: return 1;
+    case 0x01: case 0x11: return 2;
+    case 0x02: case 0x12: return 4;
+    case 0x03: case 0x13: return 5;
+    default:              return 4;   /* sensible default */
+    }
+}
+
+/* ------------------------------------------------------------------------- */
+
+/* Write a channel-voice event at absolute time at_ms, emitting the delta. */
+static void write_event(struct smaf_ctx *ctx, uint32_t at_ms,
+                        uint8_t status, uint8_t d1, uint8_t d2, int have_d2) {
+    uint32_t delta = at_ms - ctx->last_event_ms;
+    write_varlen(ctx, delta);
+    write1(ctx, status);
+    write1(ctx, d1);
+    if (have_d2) write1(ctx, d2);
+    ctx->last_event_ms = at_ms;
+}
+
+/* Queue a note-off to be flushed when the timeline reaches off_ms. */
+static int schedule_off(struct smaf_ctx *ctx, uint32_t off_ms,
+                        uint8_t channel, uint8_t note) {
+    uint32_t i;
+    if (ctx->offs_count == ctx->offs_alloc) {
+        uint32_t na;
+        struct pending_off *n;
+        if (ctx->offs_alloc > (UINT32_MAX / (2 * sizeof(struct pending_off))))
+            return -1;
+        na = ctx->offs_alloc ? ctx->offs_alloc * 2 : 64;
+        n = (struct pending_off *)
+            realloc(ctx->offs, na * sizeof(struct pending_off));
+        if (!n) return -1;
+        ctx->offs = n;
+        ctx->offs_alloc = na;
+    }
+    /* insert keeping the list sorted by at_ms (ascending) */
+    i = ctx->offs_count;
+    while (i > 0 && ctx->offs[i - 1].at_ms > off_ms) {
+        ctx->offs[i] = ctx->offs[i - 1];
+        i--;
+    }
+    ctx->offs[i].at_ms = off_ms;
+    ctx->offs[i].channel = channel;
+    ctx->offs[i].note = note;
+    ctx->offs_count++;
+    return 0;
+}
+
+/* Flush every pending note-off whose time is <= up_to_ms. */
+static void flush_offs(struct smaf_ctx *ctx, uint32_t up_to_ms) {
+    uint32_t i = 0;
+    while (i < ctx->offs_count && ctx->offs[i].at_ms <= up_to_ms) {
+        write_event(ctx, ctx->offs[i].at_ms,
+                    0x80 | (ctx->offs[i].channel & 0x0f),
+                    ctx->offs[i].note & 0x7f, 0x40, 1);
+        i++;
+    }
+    if (i) {
+        memmove(ctx->offs, ctx->offs + i,
+                (ctx->offs_count - i) * sizeof(struct pending_off));
+        ctx->offs_count -= i;
+    }
+}
+
+/* Flush all remaining note-offs regardless of time. */
+static void flush_all_offs(struct smaf_ctx *ctx) {
+    uint32_t i;
+    for (i = 0; i < ctx->offs_count; i++) {
+        write_event(ctx, ctx->offs[i].at_ms,
+                    0x80 | (ctx->offs[i].channel & 0x0f),
+                    ctx->offs[i].note & 0x7f, 0x40, 1);
+    }
+    ctx->offs_count = 0;
+}
+
+/* ------------------------------------------------------------------------- */
+
+/* Locate the first score track (MTR*) and its Mtsq sequence chunk.
+ * Returns 0 on success and fills *seq / *seqlen / *tb_dur / *tb_gate. */
+static int find_sequence(const uint8_t *in, uint32_t insize,
+                         const uint8_t **seq, uint32_t *seqlen,
+                         uint8_t *tb_dur, uint8_t *tb_gate, uint8_t *fmt_out) {
+    uint32_t pos = 8;               /* skip MMMD + size */
+    uint32_t end = insize;
+
+    if (insize >= 8) {
+        uint32_t declared = BE32(in + 4);
+        /* payload excludes the CRC trailer; never trust it past the buffer */
+        if ((uint64_t)8 + declared <= insize)
+            end = 8 + declared;
+    }
+
+    while (pos + 8 <= end) {
+        const uint8_t *c = in + pos;
+        uint32_t sz = BE32(c + 4);
+        uint32_t body = pos + 8;
+        uint8_t fmt, chlen, hdr;
+        uint32_t p, tend;
+
+        if ((uint64_t)body + sz > insize)
+            sz = insize - body;         /* clamp to real bytes */
+
+        if (memcmp(c, "MTR", 3) != 0) {
+            pos = body + sz;
+            if (sz == 0) pos++;         /* never spin on a zero-size chunk */
+            continue;
+        }
+
+        /* score track: parse the fixed header, then find Mtsq */
+        if (sz < 4) return -1;
+        fmt = c[8];
+        *tb_dur = c[10];
+        *tb_gate = c[11];
+        chlen = (fmt == 0x00) ? 2 : (fmt == 0x03) ? 32 : 16;
+        hdr = 4 + chlen;
+        if (hdr > sz) return -1;
+
+        p = body + hdr;
+        tend = body + sz;
+        while (p + 8 <= tend) {
+            const uint8_t *s = in + p;
+            uint32_t ssz = BE32(s + 4);
+            uint32_t sbody = p + 8;
+            if ((uint64_t)sbody + ssz > insize)
+                ssz = insize - sbody;
+            if (memcmp(s, "Mtsq", 4) == 0) {
+                *seq = in + sbody;
+                *seqlen = ssz;
+                *fmt_out = fmt;
+                return 0;
+            }
+            p = sbody + ssz;
+            if (ssz == 0) p++;
+        }
+        /* MTR without an Mtsq: keep scanning for another track */
+        pos = body + sz;
+        if (sz == 0) pos++;
+    }
+    return -1;
+}
+
+/* ------------------------------------------------------------------------- */
+
+/* Decode a Mobile Standard (format 0x01/0x02) sequence into MIDI events.
+ * Returns 0 on success, -1 on allocation failure. */
+static int decode_mobile(struct smaf_ctx *ctx, const uint8_t *seq,
+                         uint32_t seqlen, uint32_t ms_dur, uint32_t ms_gate) {
+    uint8_t run_vel[MIDI_MAXCHANNELS];
+    uint8_t run_status = 0;
+    uint32_t p = 0, cur_ms = 0;
+    int i;
+
+    for (i = 0; i < MIDI_MAXCHANNELS; i++)
+        run_vel[i] = 64;
+
+    while (p < seqlen) {
+        uint32_t dur;
+        uint8_t s, ch;
+
+        /* A duration is a VLQ, whose bytes are always < 0x80 except for the
+         * "more" continuation bit.  A real 0xFF here is not a duration but the
+         * meta/NOP/End-Of-Sequence trailer that follows the last event
+         * (e.g. "ff 00 00  ff 2f 00"): stop rather than misread it as a huge
+         * delay. */
+        if (seq[p] == 0xff)
+            break;
+
+        dur = read_vlq(seq, &p, seqlen);
+        cur_ms += dur * ms_dur;
+        if (p >= seqlen) break;
+
+        /* emit any note-offs that fall due before this event */
+        flush_offs(ctx, cur_ms);
+
+        s = seq[p];
+        if (s & 0x80) {
+            p++;
+            run_status = s;
+        } else if (run_status) {
+            /* running status: reuse the previous status byte */
+            s = run_status;
+        } else {
+            p++;
+            continue;               /* no status established: stray data */
+        }
+        ch = s & 0x0f;
+
+        switch (s & 0xf0) {
+        case 0x80:                  /* note, reuse running velocity */
+        case 0x90: {                /* note, explicit velocity */
+            uint8_t note, vel;
+            uint32_t gate;
+            if (p >= seqlen) { p = seqlen; break; }
+            note = seq[p++];
+            if ((s & 0xf0) == 0x90) {
+                if (p >= seqlen) { p = seqlen; break; }
+                vel = seq[p++] & 0x7f;
+                run_vel[ch] = vel;
+            } else {
+                vel = run_vel[ch];
+            }
+            gate = read_vlq(seq, &p, seqlen);
+            if (gate == 0)
+                break;
+            write_event(ctx, cur_ms, 0x90 | ch, note & 0x7f, vel, 1);
+            if (schedule_off(ctx, cur_ms + gate * ms_gate, ch, note) < 0)
+                return -1;
+        } break;
+
+        case 0xa0:                  /* reserved: 2 data bytes */
+            p += 2;
+            break;
+
+        case 0xb0: {                /* control change */
+            uint8_t cc, val;
+            if (p + 1 >= seqlen) { p = seqlen; break; }
+            cc = seq[p++];
+            val = seq[p++];
+            switch (cc) {
+            case 0x00:              /* bank MSB */
+            case 0x20:              /* bank LSB */
+                /* Voice-exclusives in Mtsu key on bank_lsb (see mafm.c
+                 * mafm_parse_mtsu -> mafm_bank_entry.bank).  wildmidi's
+                 * MIDI parser only tracks one bank byte via CC 0x00, so
+                 * forward both SMAF bank bytes there; the LSB arriving
+                 * after the MSB wins and MAFM matches the voice. */
+                write_event(ctx, cur_ms, 0xb0 | ch, 0x00, val & 0x7f, 1);
+                break;
+            case 0x07:              /* volume */
+            case 0x0a:              /* pan */
+            case 0x0b:              /* expression */
+            case 0x01:              /* modulation */
+                write_event(ctx, cur_ms, 0xb0 | ch, cc, val & 0x7f, 1);
+                break;
+            default:
+                break;
+            }
+        } break;
+
+        case 0xc0: {                /* program change */
+            uint8_t pc;
+            if (p >= seqlen) { p = seqlen; break; }
+            pc = seq[p++];
+            write_event(ctx, cur_ms, 0xc0 | ch, pc & 0x7f, 0, 0);
+        } break;
+
+        case 0xd0:                  /* reserved: 1 data byte */
+            p += 1;
+            break;
+
+        case 0xe0: {                /* pitch bend: lsb, msb */
+            uint8_t lsb, msb;
+            if (p + 1 >= seqlen) { p = seqlen; break; }
+            lsb = seq[p++];
+            msb = seq[p++];
+            write_event(ctx, cur_ms, 0xe0 | ch, lsb & 0x7f, msb & 0x7f, 1);
+        } break;
+
+        case 0xf0:
+            run_status = 0;         /* system messages cancel running status */
+            if (s == 0xf0) {        /* exclusive: skip len bytes */
+                uint32_t len = read_vlq(seq, &p, seqlen);
+                if ((uint64_t)p + len > seqlen) { p = seqlen; break; }
+                p += len;
+            } else {                /* 0xff: meta */
+                uint8_t m;
+                if (p >= seqlen) { p = seqlen; break; }
+                m = seq[p++];
+                if (m == 0x00)
+                    break;          /* NOP */
+                if (m == 0x2f) {    /* end of sequence */
+                    p = seqlen;
+                    break;
+                }
+                if (p < seqlen) {
+                    uint8_t len = seq[p++];
+                    if ((uint32_t)p + len > seqlen) p = seqlen;
+                    else p += len;
+                }
+            }
+            break;
+
+        default:
+            break;
+        }
+    }
+    return 0;
+}
+
+/* ------------------------------------------------------------------------- */
+/* HandyPhone Standard (format_type 0x00)                                    */
+/*                                                                           */
+/* HandyPhone score data differs from Mobile Standard: it uses a 1-or-2 byte */
+/* VLQ, packs notes as channel/octave/note nibbles with no velocity, and     */
+/* splits a song across up to four MTR* tracks of four channels each.  Those  */
+/* tracks share one timeline, so we cannot stream each straight into the      */
+/* output the way decode_mobile() does (that requires monotonically          */
+/* increasing event times).  Instead every track is decoded into a shared    */
+/* list of absolute-timed MIDI events, which is then sorted and emitted.      */
+/* See docs/formats/SmafFileFormat.txt for the encoding.                     */
+
+/* One fully-formed MIDI channel event at an absolute time (in ms). */
+struct hp_event {
+    uint32_t at_ms;
+    uint32_t seq;               /* insertion order, for a stable sort */
+    uint8_t status, d1, d2;
+    uint8_t have_d2;
+};
+
+struct hp_events {
+    struct hp_event *ev;
+    uint32_t count, alloc;
+};
+
+static int hp_push(struct hp_events *e, uint32_t at_ms, uint8_t status,
+                   uint8_t d1, uint8_t d2, int have_d2) {
+    if (e->count == e->alloc) {
+        uint32_t na;
+        struct hp_event *n;
+        if (e->alloc > (UINT32_MAX / (2 * sizeof(struct hp_event))))
+            return -1;
+        na = e->alloc ? e->alloc * 2 : 256;
+        n = (struct hp_event *)
+            realloc(e->ev, na * sizeof(struct hp_event));
+        if (!n) return -1;
+        e->ev = n;
+        e->alloc = na;
+    }
+    e->ev[e->count].at_ms = at_ms;
+    e->ev[e->count].seq = e->count;
+    e->ev[e->count].status = status;
+    e->ev[e->count].d1 = d1;
+    e->ev[e->count].d2 = d2;
+    e->ev[e->count].have_d2 = (uint8_t)(have_d2 != 0);
+    e->count++;
+    return 0;
+}
+
+/* Order by time, then by insertion order so a note-on never sorts after a
+ * note-off queued at the same millisecond. */
+static int hp_cmp(const void *a, const void *b) {
+    const struct hp_event *x = (const struct hp_event *)a;
+    const struct hp_event *y = (const struct hp_event *)b;
+    if (x->at_ms != y->at_ms) return x->at_ms < y->at_ms ? -1 : 1;
+    if (x->seq != y->seq)     return x->seq   < y->seq   ? -1 : 1;
+    return 0;
+}
+
+/* HandyPhone VLQ: one byte < 0x80 is the value; otherwise the value is
+ * (((b & 0x7F) + 1) << 7) | next.  Distinct from the Mobile-standard VLQ. */
+static uint32_t hp_read_vlq(const uint8_t *seq, uint32_t *pp, uint32_t end) {
+    uint32_t p = *pp;
+    uint8_t b;
+    uint32_t val;
+    if (p >= end) { *pp = end; return 0; }
+    b = seq[p++];
+    if (b & 0x80) {
+        if (p >= end) { *pp = end; return 0; }
+        val = (((uint32_t)(b & 0x7f) + 1) << 7) | seq[p++];
+    } else {
+        val = b;
+    }
+    *pp = p;
+    return val;
+}
+
+/* Map a HandyPhone note (octave/note nibbles) to a GM pitch, honouring the
+ * per-channel octave shift.  Mirrors vavi-sound MidiContext.retrievePitch:
+ * a +36 base, then the octave-shift offset. */
+static int hp_pitch(uint8_t octave, uint8_t note, uint8_t oct_shift) {
+    int pitch = (int)note + (int)octave * 12 + 36;
+    switch (oct_shift) {
+    case 1: pitch += 12; break;
+    case 2: pitch += 24; break;
+    case 3: pitch += 36; break;
+    case 4: pitch += 48; break;
+    case 0x81: pitch -= 12; break;
+    case 0x82: pitch -= 24; break;
+    case 0x83: pitch -= 36; break;
+    case 0x84: pitch -= 48; break;
+    default: break;
+    }
+    if (pitch < 0) pitch = 0;
+    if (pitch > 127) pitch = 127;
+    return pitch;
+}
+
+/* Default velocity for HandyPhone notes, which carry no velocity byte. */
+#define HP_NOTE_VELOCITY 100
+
+/* Decode one HandyPhone track's Mtsq into the shared event list.
+ *   base_ch  : MIDI channel for this track's SMAF channel 0 (0,4,8,12).
+ *   perc_mask: bit c set => SMAF channel c is a percussion channel and is
+ *              rerouted to MIDI channel 9 (its notes taken from the program). */
+static int decode_handyphone(struct hp_events *e, const uint8_t *seq,
+                             uint32_t seqlen, uint32_t ms_dur, uint32_t ms_gate,
+                             uint8_t base_ch, uint8_t perc_mask) {
+    uint32_t p = 0, cur_ms = 0;
+    uint8_t oct_shift[4] = { 0, 0, 0, 0 };
+    uint8_t program[4]   = { 0, 0, 0, 0 };
+
+    while (p < seqlen) {
+        uint32_t dur;
+        uint8_t e1;
+
+        dur = hp_read_vlq(seq, &p, seqlen);
+        cur_ms += dur * ms_dur;
+        if (p >= seqlen) break;
+
+        e1 = seq[p++];
+
+        if (e1 == 0xff) {                       /* meta / exclusive / NOP */
+            uint8_t e2;
+            if (p >= seqlen) break;
+            e2 = seq[p++];
+            if (e2 == 0x00) {                   /* NOP */
+                continue;
+            } else if (e2 == 0x2f || e2 == 0x51 || e2 == 0x58) {
+                uint8_t len;                    /* meta: length + payload */
+                if (p >= seqlen) break;
+                len = seq[p++];
+                if ((uint32_t)p + len > seqlen) { p = seqlen; break; }
+                p += len;                       /* dropped (GM tempo is fixed) */
+            } else if (e2 == 0xf0) {            /* exclusive: length + payload */
+                uint8_t len;
+                if (p >= seqlen) break;
+                len = seq[p++];
+                if ((uint32_t)p + len > seqlen) { p = seqlen; break; }
+                p += len;
+            }
+            /* other 0xff e2: no payload, ignore */
+        } else if (e1 == 0x00) {                /* control event */
+            uint8_t e2, ch, event, data;
+            if (p >= seqlen) break;
+            e2 = seq[p++];
+            if (e2 == 0x00) {                   /* 00 00 xx */
+                if (p >= seqlen) break;
+                if (seq[p++] == 0x00)           /* 00 00 00 = end of sequence */
+                    break;
+                continue;                       /* 00 00 nonzero: undefined */
+            }
+            ch    = (e2 & 0xc0) >> 6;
+            event = (e2 & 0x30) >> 4;
+            data  =  e2 & 0x0f;
+            if (event == 3) {                   /* long control: value byte */
+                uint8_t val, midi_ch;
+                if (p >= seqlen) break;
+                val = seq[p++];
+                midi_ch = (perc_mask & (1 << ch)) ? 9 : (base_ch + ch);
+                switch (data) {
+                case 0x0:                       /* program change */
+                    program[ch] = val & 0x7f;
+                    /* On a percussion channel the program byte selects the
+                     * drum-note pitch (used by the note handler), not a GM
+                     * patch: suppress the program-change event itself, matching
+                     * vavi-sound ProgramChangeMessage.getMidiEvents. */
+                    if (!(perc_mask & (1 << ch)))
+                        if (hp_push(e, cur_ms, 0xc0 | midi_ch, val & 0x7f, 0, 0) < 0)
+                            return -1;
+                    break;
+                case 0x1:                       /* bank select */
+                    /* Forward as MIDI CC 0x00 so the MAFM path can key
+                     * voice-bank entries by it (see decode_mobile). */
+                    if (hp_push(e, cur_ms, 0xb0 | midi_ch, 0x00, val & 0x7f, 1) < 0)
+                        return -1;
+                    break;
+                case 0x2:                       /* octave shift */
+                    oct_shift[ch] = val;
+                    break;
+                case 0x3:                       /* modulation */
+                    if (hp_push(e, cur_ms, 0xb0 | midi_ch, 0x01, val & 0x7f, 1) < 0)
+                        return -1;
+                    break;
+                case 0x4:                       /* pitch bend (7-bit -> 14) */
+                    if (hp_push(e, cur_ms, 0xe0 | midi_ch, 0x00, val & 0x7f, 1) < 0)
+                        return -1;
+                    break;
+                case 0x7:                       /* volume */
+                    if (hp_push(e, cur_ms, 0xb0 | midi_ch, 0x07, val & 0x7f, 1) < 0)
+                        return -1;
+                    break;
+                case 0xa:                       /* pan */
+                    if (hp_push(e, cur_ms, 0xb0 | midi_ch, 0x0a, val & 0x7f, 1) < 0)
+                        return -1;
+                    break;
+                case 0xb:                       /* expression */
+                    if (hp_push(e, cur_ms, 0xb0 | midi_ch, 0x0b, val & 0x7f, 1) < 0)
+                        return -1;
+                    break;
+                default:
+                    break;
+                }
+            }
+            /* event 0/1/2 are short expression/pitch-bend/modulation; the
+             * nibble is the value and there is no extra byte.  They are minor
+             * expressive controls and are dropped for the GM conversion. */
+        } else {                                /* note */
+            uint8_t ch = (e1 & 0xc0) >> 6;
+            uint8_t octave = (e1 & 0x30) >> 4;
+            uint8_t note = e1 & 0x0f;
+            uint32_t gate = hp_read_vlq(seq, &p, seqlen);
+            uint8_t midi_ch;
+            int pitch;
+            if (gate == 0)
+                continue;
+            if (perc_mask & (1 << ch)) {        /* percussion: pitch = program */
+                midi_ch = 9;
+                pitch = program[ch] & 0x7f;
+            } else {
+                midi_ch = base_ch + ch;
+                pitch = hp_pitch(octave, note, oct_shift[ch]);
+            }
+            if (hp_push(e, cur_ms, 0x90 | midi_ch,
+                        (uint8_t)pitch, HP_NOTE_VELOCITY, 1) < 0)
+                return -1;
+            if (hp_push(e, cur_ms + gate * ms_gate, 0x80 | midi_ch,
+                        (uint8_t)pitch, 0x40, 1) < 0)
+                return -1;
+        }
+    }
+    return 0;
+}
+
+/* Emit the sorted HandyPhone event list into ctx as MIDI delta events. */
+static void hp_emit(struct smaf_ctx *ctx, struct hp_events *e) {
+    uint32_t i;
+    qsort(e->ev, e->count, sizeof(struct hp_event), hp_cmp);
+    for (i = 0; i < e->count; i++) {
+        write_event(ctx, e->ev[i].at_ms, e->ev[i].status,
+                    e->ev[i].d1, e->ev[i].d2, e->ev[i].have_d2);
+    }
+}
+
+/* Walk every MTR* score track and, for each HandyPhone (format 0x00) track,
+ * decode its Mtsq into the shared event list.  Returns the number of tracks
+ * decoded, or -1 on allocation failure. */
+static int decode_all_handyphone(struct hp_events *e, const uint8_t *in,
+                                  uint32_t insize, uint32_t ms_dur,
+                                  uint32_t ms_gate) {
+    uint32_t pos = 8, end = insize;
+    int track_no = 0;
+
+    if (insize >= 8) {
+        uint32_t declared = BE32(in + 4);
+        if ((uint64_t)8 + declared <= insize)
+            end = 8 + declared;
+    }
+
+    while (pos + 8 <= end && track_no < 4) {
+        const uint8_t *c = in + pos;
+        uint32_t sz = BE32(c + 4);
+        uint32_t body = pos + 8;
+
+        if ((uint64_t)body + sz > insize)
+            sz = insize - body;
+
+        if (memcmp(c, "MTR", 3) == 0 && sz >= 6 && c[8] == 0x00) {
+            /* The 2-byte channel-status field packs a 4-bit value per channel
+             * (2 bytes -> 4 channels), whose low 2 bits are the channel "type":
+             * 0 NoCare, 1 Melody, 2 NoMelody, 3 Rhythm.  A Rhythm channel is
+             * percussion: its notes are rerouted to MIDI channel 9 with the
+             * program byte as the drum-note pitch (see decode_handyphone),
+             * matching vavi-sound. */
+            uint8_t perc_mask = 0;
+            uint32_t p, tend;
+            int i;
+
+            for (i = 0; i < 4; i++) {
+                uint8_t nib = (i < 2) ? ((c[12] >> (4 * (1 - i))) & 0x0f)
+                                      : ((c[13] >> (4 * (3 - i))) & 0x0f);
+                if ((nib & 0x03) == 3)  /* Rhythm */
+                    perc_mask |= (uint8_t)(1 << i);
+            }
+            p = body + 6;               /* header = 4 + 2-byte channel status */
+            tend = body + sz;
+            while (p + 8 <= tend) {
+                const uint8_t *s = in + p;
+                uint32_t ssz = BE32(s + 4);
+                uint32_t sbody = p + 8;
+                if ((uint64_t)sbody + ssz > insize)
+                    ssz = insize - sbody;
+                if (memcmp(s, "Mtsq", 4) == 0) {
+                    if (decode_handyphone(e, in + sbody, ssz, ms_dur, ms_gate,
+                                          (uint8_t)(track_no * 4), perc_mask) < 0)
+                        return -1;
+                    track_no++;
+                    break;
+                }
+                p = sbody + ssz;
+                if (ssz == 0) p++;
+            }
+        }
+        pos = body + sz;
+        if (sz == 0) pos++;
+    }
+    return track_no;
+}
+
+/* ------------------------------------------------------------------------- */
+
+int _WM_smaf2midi(const uint8_t *in, uint32_t insize,
+                  uint8_t **out, uint32_t *outsize) {
+    struct smaf_ctx ctx;
+    const uint8_t *seq = NULL;
+    uint32_t seqlen = 0;
+    uint8_t tb_dur = 0x02, tb_gate = 0x02;
+    uint32_t ms_dur, ms_gate;
+    uint32_t track_size_pos, begin_track_pos, current_pos;
+    uint8_t fmt = 0x02;
+    int ret = -1;
+
+    if (!out || !outsize) {
+        _WM_GLOBAL_ERROR(WM_ERR_INVALID_ARG, "(NULL params)", 0);
+        return -1;
+    }
+    *out = NULL;
+    *outsize = 0;
+
+    if (insize < 8 || memcmp(in, "MMMD", 4) != 0) {
+        _WM_GLOBAL_ERROR(WM_ERR_NOT_SMAF, NULL, 0);
+        return -1;
+    }
+
+    if (find_sequence(in, insize, &seq, &seqlen, &tb_dur, &tb_gate, &fmt) < 0) {
+        _WM_GLOBAL_ERROR(WM_ERR_NOT_SMAF, "(no score track)", 0);
+        return -1;
+    }
+
+    /* Supported score-track formats: Mobile Standard (0x01/0x02) and HandyPhone
+     * Standard (0x00).  The MA-7 "SEQU" variant (0x03) is a different,
+     * compressed encoding that has not been decoded (see
+     * docs/formats/SmafFileFormat.txt); decline it rather than emit a mangled
+     * conversion. */
+    if (fmt != 0x00 && fmt != 0x01 && fmt != 0x02) {
+        _WM_GLOBAL_ERROR(WM_ERR_NOT_SMAF, "(unsupported SMAF track format)", 0);
+        return -1;
+    }
+
+    ms_dur = timebase_ms(tb_dur);
+    ms_gate = timebase_ms(tb_gate);
+
+    memset(&ctx, 0, sizeof(ctx));
+    ctx.src = in;
+    ctx.srcsize = insize;
+    ctx.dst = (uint8_t *) calloc(DST_CHUNK, 1);
+    if (!ctx.dst) {
+        _WM_GLOBAL_ERROR(WM_ERR_MEM, NULL, 0);
+        return -1;
+    }
+    ctx.dst_ptr = ctx.dst;
+    ctx.dstsize = DST_CHUNK;
+    ctx.dstrem = DST_CHUNK;
+
+    /* MThd */
+    write1(&ctx, 'M'); write1(&ctx, 'T'); write1(&ctx, 'h'); write1(&ctx, 'd');
+    write4(&ctx, 6);
+    write2(&ctx, 0);                /* format 0 */
+    write2(&ctx, 1);                /* one track */
+    write2(&ctx, SMAF_DIVISION);
+
+    /* MTrk */
+    begin_track_pos = getdstpos(&ctx);
+    write1(&ctx, 'M'); write1(&ctx, 'T'); write1(&ctx, 'r'); write1(&ctx, 'k');
+    track_size_pos = getdstpos(&ctx);
+    write4(&ctx, 0);                /* placeholder; patched at the end */
+
+    /* tempo meta so that 1 tick == 1 ms */
+    write1(&ctx, 0x00);
+    write1(&ctx, 0xff);
+    write1(&ctx, 0x51);
+    write1(&ctx, 0x03);
+    write1(&ctx, (SMAF_TEMPO >> 16) & 0xff);
+    write1(&ctx, (SMAF_TEMPO >> 8) & 0xff);
+    write1(&ctx, SMAF_TEMPO & 0xff);
+
+    /* ---- decode the sequence according to its format ---- */
+    if (fmt == 0x00) {
+        /* HandyPhone: merge every score track onto one timeline. */
+        struct hp_events hev;
+        int ntracks;
+        memset(&hev, 0, sizeof(hev));
+        ntracks = decode_all_handyphone(&hev, in, insize, ms_dur, ms_gate);
+        if (ntracks < 0) {
+            free(hev.ev);
+            _WM_GLOBAL_ERROR(WM_ERR_MEM, NULL, 0);
+            goto _end;
+        }
+        hp_emit(&ctx, &hev);
+        free(hev.ev);
+    } else {
+        if (decode_mobile(&ctx, seq, seqlen, ms_dur, ms_gate) < 0) {
+            _WM_GLOBAL_ERROR(WM_ERR_MEM, NULL, 0);
+            goto _end;
+        }
+        /* flush any notes still held down */
+        flush_all_offs(&ctx);
+    }
+
+    /* End Of Track */
+    write1(&ctx, 0x00);
+    write1(&ctx, 0xff);
+    write1(&ctx, 0x2f);
+    write1(&ctx, 0x00);
+
+    /* patch the MTrk length */
+    current_pos = getdstpos(&ctx);
+    seekdst(&ctx, track_size_pos);
+    write4(&ctx, current_pos - begin_track_pos - 8);
+    seekdst(&ctx, current_pos);
+
+    /* An allocation failure anywhere in the write helpers leaves a truncated,
+     * structurally invalid MIDI buffer; fail rather than hand it back. */
+    if (ctx.oom) {
+        _WM_GLOBAL_ERROR(WM_ERR_MEM, NULL, 0);
+        goto _end;
+    }
+
+    *out = ctx.dst;
+    *outsize = ctx.dstsize - ctx.dstrem;
+    ctx.dst = NULL;                 /* ownership transferred */
+    ret = 0;
+
+_end:
+    free(ctx.offs);
+    if (ret < 0) {
+        free(ctx.dst);
+        *out = NULL;
+        *outsize = 0;
+    }
+    return ret;
+}

--- a/src/wildmidi_lib.c
+++ b/src/wildmidi_lib.c
@@ -22,6 +22,7 @@
  */
 
 #define _WILDMIDI_LIB_C
+#define __STDC_LIMIT_MACROS
 
 #include "config.h"
 
@@ -47,6 +48,7 @@
 #include "f_midi.h"
 #include "f_mus.h"
 #include "f_xmidi.h"
+#include "f_smaf.h"
 #include "patches.h"
 #include "sample.h"
 #include "synth.h"
@@ -54,8 +56,12 @@
 #include "xmi2mid.h"
 #include "hmp2mid.h"
 #include "hmi2mid.h"
+#include "smaf2mid.h"
 #ifdef WILDMIDI_SF2
 #include "sf2.h"
+#endif
+#ifdef WILDMIDI_MAFM
+#include "mafm.h"
 #endif
 
 /*
@@ -954,7 +960,13 @@ static int WM_GetOutput_Linear(midi * handle, int8_t *buffer, uint32_t size) {
     if ( (size / 2) > mdi->mix_buffer_size) {
         uint32_t new_size = ((size / 2) <= (mdi->mix_buffer_size * 2))
             ? mdi->mix_buffer_size + MEM_CHUNK : size / 2;
-        int32_t *new_buf = (int32_t *) realloc(mdi->mix_buffer, new_size * sizeof(int32_t));
+        int32_t *new_buf;
+        if (new_size > (UINT32_MAX / sizeof(int32_t))) {
+            _WM_GLOBAL_ERROR(WM_ERR_MEM, NULL, 0);
+            _WM_Unlock(&mdi->lock);
+            return (-1);
+        }
+        new_buf = (int32_t *) realloc(mdi->mix_buffer, new_size * sizeof(int32_t));
         if (new_buf == NULL) {
             _WM_GLOBAL_ERROR(WM_ERR_MEM, NULL, errno);
             _WM_Unlock(&mdi->lock);
@@ -1288,7 +1300,13 @@ static int WM_GetOutput_Gauss(midi * handle, int8_t *buffer, uint32_t size) {
     if ( (size / 2) > mdi->mix_buffer_size) {
         uint32_t new_size = ((size / 2) <= (mdi->mix_buffer_size * 2))
             ? mdi->mix_buffer_size + MEM_CHUNK : size / 2;
-        int32_t *new_buf = (int32_t *) realloc(mdi->mix_buffer, new_size * sizeof(int32_t));
+        int32_t *new_buf;
+        if (new_size > (UINT32_MAX / sizeof(int32_t))) {
+            _WM_GLOBAL_ERROR(WM_ERR_MEM, NULL, 0);
+            _WM_Unlock(&mdi->lock);
+            return (-1);
+        }
+        new_buf = (int32_t *) realloc(mdi->mix_buffer, new_size * sizeof(int32_t));
         if (new_buf == NULL) {
             _WM_GLOBAL_ERROR(WM_ERR_MEM, NULL, errno);
             _WM_Unlock(&mdi->lock);
@@ -1681,6 +1699,11 @@ WM_SYMBOL int WildMidi_ConvertBufferToMidi (const uint8_t *in, uint32_t insize,
             return (-1);
         }
     }
+    else if (insize >= 8 && !memcmp(in, "MMMD", 4)) {
+        if (_WM_smaf2midi(in, insize, out, outsize) < 0) {
+            return (-1);
+        }
+    }
     else if (!memcmp(in, "MThd", 4)) {
         _WM_GLOBAL_ERROR(0, "Already a midi file", 0);
         return (-1);
@@ -1919,6 +1942,8 @@ static midi *parse_midi_buffer(const uint8_t *mididata, uint32_t midisize) {
         ret = (void *) _WM_ParseNewMus(mididata, midisize);
     } else if (memcmp(mididata, xmi_hdr, 4) == 0) {
         ret = (void *) _WM_ParseNewXmi(mididata, midisize);
+    } else if (memcmp(mididata, "MMMD", 4) == 0) {
+        ret = (void *) _WM_ParseNewSmaf(mididata, midisize);
     } else {
         ret = (void *) _WM_ParseNewMidi(mididata, midisize);
     }
@@ -2040,6 +2065,11 @@ WM_SYMBOL int WildMidi_FastSeek(midi * handle, unsigned long int *sample_pos) {
             _WM_SF2_Reset(mdi->sf2_synth);
         }
 #endif
+#ifdef WILDMIDI_MAFM
+        if (mdi->mafm_synth) {
+            _WM_MAFM_Reset(mdi->mafm_synth);
+        }
+#endif
     }
 
     if ((mdi->extra_info.current_sample + mdi->samples_to_mix) > *sample_pos) {
@@ -2055,6 +2085,14 @@ WM_SYMBOL int WildMidi_FastSeek(midi * handle, unsigned long int *sample_pos) {
                the seek get no note-off (hang) and later note-ons pile on. */
             if (mdi->sf2_synth) {
                 _WM_SF2_Event(mdi->sf2_synth, mdi, event);
+            }
+#endif
+#ifdef WILDMIDI_MAFM
+            /* Same reason: the FM synth keeps its own voice/channel state,
+               so any note-off skipped over during seek would leave the
+               matching note-on ringing forever. */
+            if (mdi->mafm_synth) {
+                _WM_MAFM_Event(mdi->mafm_synth, mdi, event);
             }
 #endif
             event->do_event(mdi, &event->event_data);
@@ -2153,6 +2191,9 @@ WM_SYMBOL int WildMidi_SongSeek (midi * handle, int8_t nextsong) {
 #ifdef WILDMIDI_SF2
         if (mdi->sf2_synth) _WM_SF2_Reset(mdi->sf2_synth);
 #endif
+#ifdef WILDMIDI_MAFM
+        if (mdi->mafm_synth) _WM_MAFM_Reset(mdi->mafm_synth);
+#endif
 
     } else if (nextsong == 1) {
         /* goto start of next song */
@@ -2187,11 +2228,17 @@ WM_SYMBOL int WildMidi_SongSeek (midi * handle, int8_t nextsong) {
 #ifdef WILDMIDI_SF2
         if (mdi->sf2_synth) _WM_SF2_Reset(mdi->sf2_synth);
 #endif
+#ifdef WILDMIDI_MAFM
+        if (mdi->mafm_synth) _WM_MAFM_Reset(mdi->mafm_synth);
+#endif
     }
 
     while (event != event_new) {
 #ifdef WILDMIDI_SF2
         if (mdi->sf2_synth) _WM_SF2_Event(mdi->sf2_synth, mdi, event);
+#endif
+#ifdef WILDMIDI_MAFM
+        if (mdi->mafm_synth) _WM_MAFM_Event(mdi->mafm_synth, mdi, event);
 #endif
         event->do_event(mdi, &event->event_data);
         mdi->extra_info.current_sample += event->samples_to_next;
@@ -2236,7 +2283,13 @@ static int WM_GetOutput_SF2(midi * handle, int8_t *buffer, uint32_t size) {
     if ( (size / 2) > mdi->mix_buffer_size) {
         uint32_t new_size = ((size / 2) <= (mdi->mix_buffer_size * 2))
             ? mdi->mix_buffer_size + MEM_CHUNK : size / 2;
-        int32_t *new_buf = (int32_t *) realloc(mdi->mix_buffer, new_size * sizeof(int32_t));
+        int32_t *new_buf;
+        if (new_size > (UINT32_MAX / sizeof(int32_t))) {
+            _WM_GLOBAL_ERROR(WM_ERR_MEM, NULL, 0);
+            _WM_Unlock(&mdi->lock);
+            return (-1);
+        }
+        new_buf = (int32_t *) realloc(mdi->mix_buffer, new_size * sizeof(int32_t));
         if (new_buf == NULL) {
             _WM_GLOBAL_ERROR(WM_ERR_MEM, NULL, errno);
             _WM_Unlock(&mdi->lock);
@@ -2349,6 +2402,136 @@ static int WM_GetOutput_SF2(midi * handle, int8_t *buffer, uint32_t size) {
 }
 #endif /* WILDMIDI_SF2 */
 
+#ifdef WILDMIDI_MAFM
+/* Yamaha FM output path.  Structurally identical to WM_GetOutput_SF2: the
+ * event list keeps channel/meta state in sync while the FM synth generates the
+ * sound and renders PCM into the mix buffer. */
+static int WM_GetOutput_MAFM(midi * handle, int8_t *buffer, uint32_t size) {
+    uint32_t buffer_used = 0;
+    uint32_t i;
+    struct _mdi *mdi = (struct _mdi *) handle;
+    uint32_t real_samples_to_mix = 0;
+    int32_t left_mix, right_mix;
+    struct _event *event;
+    int32_t *tmp_buffer;
+    int32_t *out_buffer;
+    int end_encountered;
+
+    _WM_Lock(&mdi->lock);
+    event = mdi->current_event;
+
+    memset(buffer, 0, size);
+
+    if ( (size / 2) > mdi->mix_buffer_size) {
+        uint32_t new_size = ((size / 2) <= (mdi->mix_buffer_size * 2))
+            ? mdi->mix_buffer_size + MEM_CHUNK : size / 2;
+        int32_t *new_buf;
+        if (new_size > (UINT32_MAX / sizeof(int32_t))) {
+            _WM_GLOBAL_ERROR(WM_ERR_MEM, NULL, 0);
+            _WM_Unlock(&mdi->lock);
+            return (-1);
+        }
+        new_buf = (int32_t *) realloc(mdi->mix_buffer, new_size * sizeof(int32_t));
+        if (new_buf == NULL) {
+            _WM_GLOBAL_ERROR(WM_ERR_MEM, NULL, errno);
+            _WM_Unlock(&mdi->lock);
+            return (-1);
+        }
+        mdi->mix_buffer = new_buf;
+        mdi->mix_buffer_size = new_size;
+    }
+
+    tmp_buffer = mdi->mix_buffer;
+
+    memset(tmp_buffer, 0, ((size / 2) * sizeof(int32_t)));
+    out_buffer = tmp_buffer;
+
+    do {
+        if (__builtin_expect((!mdi->samples_to_mix), 0)) {
+            end_encountered = 0;
+            while ((!mdi->samples_to_mix) && (event->do_event)) {
+                _WM_MAFM_Event(mdi->mafm_synth, mdi, event);
+                event->do_event(mdi, &event->event_data);
+                if ((mdi->extra_info.mixer_options & WM_MO_LOOP) && (event[0].evtype == ev_meta_endoftrack) && !end_encountered) {
+                    end_encountered = 1;
+                    _WM_MAFM_Reset(mdi->mafm_synth);
+                    _WM_ResetToStart(mdi);
+                    event = mdi->current_event;
+                } else {
+                    mdi->samples_to_mix += event->samples_to_next;
+                    event++;
+                    mdi->current_event = event;
+                }
+            }
+
+            if (__builtin_expect((!mdi->samples_to_mix), 0)) {
+                if (mdi->extra_info.current_sample >= mdi->extra_info.approx_total_samples) {
+                    if ((!_WM_MAFM_ActiveVoices(mdi->mafm_synth))
+                        || ((mdi->extra_info.current_sample - mdi->extra_info.approx_total_samples)
+                             > ((uint32_t)_WM_SampleRate * 10))) {
+                        break;
+                    }
+                    mdi->samples_to_mix = size >> 2;
+                } else if ((mdi->extra_info.approx_total_samples
+                             - mdi->extra_info.current_sample) > (size >> 2)) {
+                    mdi->samples_to_mix = size >> 2;
+                } else {
+                    mdi->samples_to_mix = mdi->extra_info.approx_total_samples
+                                           - mdi->extra_info.current_sample;
+                }
+            }
+        }
+        if (__builtin_expect((mdi->samples_to_mix > (size >> 2)), 1)) {
+            real_samples_to_mix = size >> 2;
+        } else {
+            real_samples_to_mix = mdi->samples_to_mix;
+            if (real_samples_to_mix == 0) {
+                continue;
+            }
+        }
+
+        _WM_MAFM_Render(mdi->mafm_synth, tmp_buffer, real_samples_to_mix);
+        tmp_buffer += real_samples_to_mix * 2;
+
+        buffer_used += real_samples_to_mix * 4;
+        size -= (real_samples_to_mix << 2);
+        mdi->extra_info.current_sample += real_samples_to_mix;
+        mdi->samples_to_mix -= real_samples_to_mix;
+    } while (size);
+
+    tmp_buffer = out_buffer;
+
+    if (mdi->extra_info.mixer_options & WM_MO_REVERB) {
+        _WM_do_reverb(mdi->reverb, tmp_buffer, (buffer_used / 2));
+    }
+
+    for (i = 0; i < buffer_used; i += 4) {
+        left_mix = *tmp_buffer++;
+        right_mix = *tmp_buffer++;
+
+        if (left_mix > 32767) left_mix = 32767;
+        else if (left_mix < -32768) left_mix = -32768;
+        if (right_mix > 32767) right_mix = 32767;
+        else if (right_mix < -32768) right_mix = -32768;
+
+#ifdef WORDS_BIGENDIAN
+        (*buffer++) = ((left_mix >> 8) & 0x7f) | ((left_mix >> 24) & 0x80);
+        (*buffer++) = left_mix & 0xff;
+        (*buffer++) = ((right_mix >> 8) & 0x7f) | ((right_mix >> 24) & 0x80);
+        (*buffer++) = right_mix & 0xff;
+#else
+        (*buffer++) = left_mix & 0xff;
+        (*buffer++) = ((left_mix >> 8) & 0x7f) | ((left_mix >> 24) & 0x80);
+        (*buffer++) = right_mix & 0xff;
+        (*buffer++) = ((right_mix >> 8) & 0x7f) | ((right_mix >> 24) & 0x80);
+#endif
+    }
+
+    _WM_Unlock(&mdi->lock);
+    return (buffer_used);
+}
+#endif /* WILDMIDI_MAFM */
+
 WM_SYMBOL int WildMidi_GetOutput(midi * handle, int8_t *buffer, uint32_t size) {
     if (__builtin_expect((!WM_Initialized), 0)) {
         _WM_GLOBAL_ERROR(WM_ERR_NOT_INIT, NULL, 0);
@@ -2370,6 +2553,11 @@ WM_SYMBOL int WildMidi_GetOutput(midi * handle, int8_t *buffer, uint32_t size) {
         return (-1);
     }
 
+#ifdef WILDMIDI_MAFM
+    if (((struct _mdi *) handle)->mafm_synth) {
+        return (WM_GetOutput_MAFM(handle, buffer, size));
+    }
+#endif
 #ifdef WILDMIDI_SF2
     if (((struct _mdi *) handle)->sf2_synth) {
         return (WM_GetOutput_SF2(handle, buffer, size));

--- a/src/wm_error.c
+++ b/src/wm_error.c
@@ -58,6 +58,7 @@ static const char *errors[WM_ERR_MAX+1] = {
     "Unable to convert",
     "Not a mus file",
     "Not an xmi file",
+    "Not a smaf file",
 
     "Invalid error code"
 };

--- a/win32wat/config.h
+++ b/win32wat/config.h
@@ -20,6 +20,7 @@
 /* #undef HAVE_SQRTF */
 /* #undef HAVE_POWF */
 
+#define WILDMIDI_MAFM 1
 #define WILDMIDI_SF2 1
 
 /* #undef AUDIODRV_OPENAL */

--- a/win32wat/makefile
+++ b/win32wat/makefile
@@ -40,7 +40,7 @@ BLD_TARGET=$(DLLNAME) $(PLAYER)
 INCPATH=-I"$(%WATCOM)/h/nt" -I"$(%WATCOM)/h"
 INCLUDES=$(INCPATH) -I. -I"../include"
 
-OBJ=wm_error.obj file_io.obj lock.obj wildmidi_lib.obj reverb.obj gus_pat.obj f_xmidi.obj f_mus.obj f_hmp.obj f_midi.obj f_hmi.obj mus2mid.obj xmi2mid.obj hmp2mid.obj hmi2mid.obj internal_midi.obj patches.obj sample.obj sf2.obj synth.obj opl3.obj
+OBJ=wm_error.obj file_io.obj lock.obj wildmidi_lib.obj reverb.obj gus_pat.obj f_xmidi.obj f_mus.obj f_hmp.obj f_midi.obj f_hmi.obj f_smaf.obj mus2mid.obj xmi2mid.obj hmp2mid.obj hmi2mid.obj smaf2mid.obj internal_midi.obj patches.obj sample.obj sf2.obj mafm.obj ma_fm_core.obj smaf_voice.obj yamaha_adpcm.obj synth.obj opl3.obj
 PLAYER_OBJ=wm_tty.obj playlist.obj msleep.obj getopt_long.obj out_none.obj out_wave.obj out_openal.obj out_win32mm.obj wildmidi.obj
 
 all: $(BLD_TARGET)
@@ -60,7 +60,7 @@ $(PLAYER_STATIC): $(LIBSTATIC) $(PLAYER_OBJ)
 	wlink N $@ SYS NT OP q LIBR {$(LIBSTATIC) $(PLAYER_LIBS)} F {$(PLAYER_OBJ)}
 
 # rules for library objs:
-.c: ../src;../src/player
+.c: ../src;../src/player;../src/mafm
 .c.obj:
 	wcc386 $(CFLAGS_LIB) $(INCLUDES) -fo=$^@ $<
 #silence unused function tsf_xx() warnings in sf2.c


### PR DESCRIPTION
Decode the HandyPhone Standard score format (format_type 0x00, MA-1/MA-2) in smaf2mid.c, merging its multi-track streams to MIDI.

Add an optional FM synthesis engine (WANT_MAFM) so SMAF files play with their real Yamaha voices instead of the GM approximation: port the FM core, voice-exclusive decoder, and ADPCM codec to C from the (Apache-2.0) akustikrausch/yamaha-smaf-player, wrapped in src/mafm.c and wired into the render loop like the SF2 path (per-mdi mafm_synth). Embedded ATR/Awa ADPCM samples play as scheduled drums alongside the FM voices.

Also document the MFi (.mld) format and update SmafFileFormat.txt.
[SMAF_handyphone_test files.zip](https://github.com/user-attachments/files/30298693/SMAF_handyphone_test.files.zip)

<img width="1337" height="426" alt="Screenshot From 2026-07-23 10-23-22" src="https://github.com/user-attachments/assets/084e6147-f853-4e46-b14f-d71f9db6671d" />

[SolidSoda.mp3 (older version)](https://github.com/user-attachments/files/30298831/SolidSoda.mp3)

[SolidSoda.mp3 (latest version)](https://github.com/user-attachments/files/30371905/SolidSoda.mp3)