### PR TITLE
add playlist support with shuffle and playlist repeat

### DIFF
--- a/.ci/Dockerfile
+++ b/.ci/Dockerfile
@@ -1,0 +1,124 @@
+# Toolchain image for ci-local.sh -- reproduces the compilers used by the
+# GitHub workflows so changes can be validated without pushing.
+#
+# Covers: native gcc/clang, MinGW-w64 (i686 + x86_64), DJGPP, OS/2 EMX,
+#         OpenWatcom (OS/2 + Win32), Zig.
+#
+# The AmigaOS m68k toolchain is not installed here: upstream CI runs that job
+# in the amigadev/crosstools container, and ci-local.sh uses the same image.
+#
+# Build with:  ./ci-local.sh --docker-build      (or docker build -f .ci/Dockerfile)
+
+FROM ubuntu:24.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Native toolchains + the bits the cross toolchains need at runtime.
+# libfl2 is required by DJGPP, exactly as in cross.yml.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        build-essential \
+        clang \
+        cmake \
+        make \
+        git \
+        ca-certificates \
+        curl \
+        xz-utils \
+        bzip2 \
+        unzip \
+        file \
+        libfl2 \
+        libasound2-dev \
+        libopenal-dev \
+        gcc-mingw-w64 \
+        binutils-mingw-w64 \
+    && rm -rf /var/lib/apt/lists/*
+
+# --- DJGPP (DOS) ------------------------------------------------------------
+# Same release and checksum as .github/workflows/cross.yml.
+ARG DJGPP_URL=https://github.com/andrewwutw/build-djgpp/releases/download/v3.4/djgpp-linux64-gcc1220.tar.bz2
+ARG DJGPP_SHA=8464f17017d6ab1b2bb2df4ed82357b5bf692e6e2b7fee37e315638f3d505f00
+RUN curl -fsL "$DJGPP_URL" -o /tmp/djgpp.tar.bz2 \
+    && echo "$DJGPP_SHA  /tmp/djgpp.tar.bz2" | sha256sum -c - \
+    && tar xj -C /opt -f /tmp/djgpp.tar.bz2 \
+    && rm /tmp/djgpp.tar.bz2
+
+# --- OS/2 EMX ---------------------------------------------------------------
+# What komh/setup-cross-os2emx installs in CI.
+ARG OS2EMX_VER=1.4.0
+RUN curl -fsL "https://github.com/komh/cross-os2emx/releases/download/${OS2EMX_VER}/cross-os2emx-${OS2EMX_VER}-linux-x64.tar.gz" \
+        -o /tmp/os2emx.tar.gz \
+    && mkdir -p /opt/cross-os2emx \
+    && tar xz -C /opt/cross-os2emx --strip-components=1 -f /tmp/os2emx.tar.gz \
+    && rm /tmp/os2emx.tar.gz
+
+# The base toolchain has no OS/2 Toolkit headers, so out_dart.c (MMPM/2 DART
+# output) cannot build.  setup-cross-os2emx installs these by default; do the
+# same, then point gcc at them exactly as the action's GCCOPT does.
+RUN cd /tmp \
+    && PATH=/opt/cross-os2emx/opt/os2emx/bin:$PATH \
+       installrpmzip pthread os2tk45 \
+    && rm -rf /tmp/installrpmzip.zip*
+
+# --- OpenWatcom (OS/2 + Win32) ---------------------------------------------
+# The open-watcom/setup-watcom action installs this snapshot.
+RUN curl -fsL https://github.com/open-watcom/open-watcom-v2/releases/download/Current-build/ow-snapshot.tar.xz \
+        -o /tmp/ow.tar.xz \
+    && mkdir -p /opt/watcom \
+    && tar xJ -C /opt/watcom -f /tmp/ow.tar.xz \
+    && rm /tmp/ow.tar.xz \
+    && chmod -R +x /opt/watcom/binl64 /opt/watcom/binl 2>/dev/null || true
+
+# --- Android NDK ------------------------------------------------------------
+# cross.yml uses $ANDROID_NDK_LATEST_HOME, which on the ubuntu-24.04 runner
+# image is r29.  Only the linux-x86_64 host toolchain is kept; the prebuilt
+# toolchains for darwin/windows hosts are dead weight here and roughly halve
+# the unpacked size when removed.
+ARG NDK_VER=r29
+RUN curl -fsL "https://dl.google.com/android/repository/android-ndk-${NDK_VER}-linux.zip" \
+        -o /tmp/ndk.zip \
+    && mkdir -p /opt/android \
+    && unzip -q /tmp/ndk.zip -d /opt/android \
+    && mv "/opt/android/android-ndk-${NDK_VER}" /opt/android/ndk \
+    && rm /tmp/ndk.zip \
+    && rm -rf /opt/android/ndk/toolchains/llvm/prebuilt/darwin-x86_64 \
+              /opt/android/ndk/toolchains/llvm/prebuilt/windows-x86_64 \
+              /opt/android/ndk/simpleperf \
+              /opt/android/ndk/shader-tools \
+              /opt/android/ndk/toolchains/llvm/prebuilt/linux-x86_64/musl \
+    && ndkbin=/opt/android/ndk/toolchains/llvm/prebuilt/linux-x86_64/bin \
+    && rm -f "$ndkbin"/clangd "$ndkbin"/clang-tidy "$ndkbin"/clang-check \
+             "$ndkbin"/clang-scan-deps "$ndkbin"/llvm-bolt "$ndkbin"/*-bolt* \
+             "$ndkbin"/clang-format "$ndkbin"/clang-refactor \
+    && /opt/android/ndk/ndk-build --version >/dev/null
+
+# --- Zig --------------------------------------------------------------------
+# build.zig.zon requires >= 0.16.0, newer than any apt package.
+ARG ZIG_VER=0.16.0
+RUN set -eux; \
+    for base in \
+        "https://ziglang.org/download/${ZIG_VER}/zig-x86_64-linux-${ZIG_VER}.tar.xz" \
+        "https://ziglang.org/download/${ZIG_VER}/zig-linux-x86_64-${ZIG_VER}.tar.xz" ; do \
+        if curl -fsL "$base" -o /tmp/zig.tar.xz; then break; fi; \
+    done; \
+    mkdir -p /opt/zig; \
+    tar xJ -C /opt/zig --strip-components=1 -f /tmp/zig.tar.xz; \
+    rm /tmp/zig.tar.xz
+
+ENV WATCOM=/opt/watcom \
+    EDPATH=/opt/watcom/eddat \
+    WIPFC=/opt/watcom/wipfc \
+    DJGPP_DIR=/opt/djgpp \
+    GCCOPT="-idirafter /opt/cross-os2emx/opt/os2emx/i686-pc-os2-emx/include/os2tk45" \
+    NDK=/opt/android/ndk \
+    ANDROID_NDK_LATEST_HOME=/opt/android/ndk
+
+# Order matters: /usr/bin must win for plain "gcc"/"g++", otherwise the DJGPP
+# and OS/2 sysroots shadow the native compiler and the native job silently
+# cross-compiles.  Each cross toolchain is reached through its prefixed name,
+# so only the prefixed binaries need to be on PATH -- and djgpp's own
+# unprefixed bin directory is deliberately left off.
+ENV PATH=/usr/local/bin:/usr/bin:/bin:/opt/watcom/binl64:/opt/watcom/binl:/opt/djgpp/bin:/opt/cross-os2emx/opt/os2emx/bin:/opt/zig:/usr/local/sbin:/usr/sbin:/sbin
+
+# Building as an arbitrary uid keeps output files owned by the caller.
+WORKDIR /src

--- a/.ci/bsd-vm.sh
+++ b/.ci/bsd-vm.sh
@@ -1,0 +1,285 @@
+#!/bin/sh
+#
+# bsd-vm.sh -- build WildMIDI inside a BSD VM under QEMU/KVM.
+#
+# This is the local equivalent of the bsd.yml workflow, which uses
+# cross-platform-actions/action.  That action also runs QEMU on a plain Linux
+# runner, so the mechanism here is the same: boot the same disk image the
+# action uses, hand the guest an ssh key through a small FAT disk, rsync the
+# work tree in, and run the build over ssh.
+#
+# Usage: bsd-vm.sh <freebsd|openbsd|netbsd> <repo-dir> <ssh-port> <cache-dir>
+#                  [--fetch-only|--refresh]
+#
+# --fetch-only downloads the disk image and stops, so that several VMs can be
+# started afterwards without competing for bandwidth.
+# --refresh discards the cached "prepared" image (the one with cmake already
+# installed) and builds it again, e.g. to pick up newer packages.
+#
+# This file is part of WildMIDI and shares its license.
+
+set -u
+
+OS=${1:?usage: bsd-vm.sh <os> <repo> <port> <cache>}
+REPO=${2:?}
+PORT=${3:?}
+CACHE=${4:?}
+MODE=${5:-}
+
+# Image versions.  Each builder repo has its own release tag, so these do not
+# share a version -- check the builder's releases when bumping an OS version.
+case $OS in
+freebsd)
+    OSVER=14.4
+    BUILDER_TAG=v0.15.0
+    CMAKE_OPTS="-DWANT_OSS=ON"
+    SETUP_CMD="sudo pkg update -q"
+    INSTALL_CMD="sudo pkg install -y cmake"
+    ;;
+openbsd)
+    OSVER=7.9
+    BUILDER_TAG=v0.13.0
+    CMAKE_OPTS="-DWANT_SNDIO=ON"
+    SETUP_CMD="sudo pkg_add -u"
+    INSTALL_CMD="sudo pkg_add cmake"
+    ;;
+netbsd)
+    OSVER=10.1
+    BUILDER_TAG=v0.6.0
+    CMAKE_OPTS="-DWANT_NETBSD=ON"
+    # Mirrors bsd.yml: pkgin needs PKG_PATH, and the build needs ASLR off.
+    SETUP_CMD='export PATH="/usr/pkg/sbin:/usr/pkg/bin:/sbin:$PATH";
+               export PKG_PATH="https://cdn.netBSD.org/pub/pkgsrc/packages/NetBSD/$(uname -p)/$(uname -r|cut -f "1 2" -d.)/All/";
+               sudo -E sysctl -w security.pax.aslr.enabled=0 >/dev/null;
+               sudo -E sysctl -w security.pax.aslr.global=0 >/dev/null;
+               sudo -E pkgin -y update'
+    INSTALL_CMD='export PATH="/usr/pkg/sbin:/usr/pkg/bin:/sbin:$PATH";
+                 export PKG_PATH="https://cdn.netBSD.org/pub/pkgsrc/packages/NetBSD/$(uname -p)/$(uname -r|cut -f "1 2" -d.)/All/";
+                 sudo -E pkgin -y install cmake'
+    ;;
+*)
+    echo "bsd-vm.sh: unknown os '$OS'" >&2
+    exit 2
+    ;;
+esac
+
+IMAGE=$OS-$OSVER-x86-64.qcow2
+IMAGE_URL=https://github.com/cross-platform-actions/$OS-builder/releases/download/$BUILDER_TAG/$IMAGE
+
+WORK=$(mktemp -d "${TMPDIR:-/tmp}/wm-$OS-XXXXXX") || exit 1
+QEMU_PID=
+
+cleanup() {
+    [ -n "$QEMU_PID" ] && kill "$QEMU_PID" 2>/dev/null
+    # Give qemu a moment to release the disks before the directory goes.
+    [ -n "$QEMU_PID" ] && { sleep 2; kill -9 "$QEMU_PID" 2>/dev/null; }
+    rm -rf "$WORK"
+}
+trap cleanup EXIT INT TERM
+
+say() { echo "[$OS] $*"; }
+
+# --- image ------------------------------------------------------------------
+mkdir -p "$CACHE"
+if [ ! -f "$CACHE/$IMAGE" ]; then
+    say "downloading $IMAGE"
+    curl -fsSL --retry 3 -o "$CACHE/$IMAGE.part" "$IMAGE_URL" || exit 1
+    mv "$CACHE/$IMAGE.part" "$CACHE/$IMAGE"
+fi
+
+[ "$MODE" = "--fetch-only" ] && exit 0
+
+# Installing cmake in the guest is by far the slowest part of a run -- around
+# a minute on NetBSD, whose pkgin pulls in eight packages and upgrades a few
+# of the base ones on the way.  So do it once and keep the result: PREPARED is
+# a copy of the pristine image with cmake already in it, and normal runs
+# overlay that instead.  Delete it (or pass --refresh) to rebuild.
+PRISTINE=$(cd "$CACHE" && pwd)/$IMAGE
+PREPARED=$(cd "$CACHE" && pwd)/$OS-$OSVER-prepared.qcow2
+
+[ "$MODE" = "--refresh" ] && rm -f "$PREPARED"
+
+if [ -f "$PREPARED" ]; then
+    BASE=$PREPARED
+    NEED_PACKAGES=0
+else
+    BASE=$PRISTINE
+    NEED_PACKAGES=1
+fi
+
+# A qcow2 overlay keeps the base image pristine and makes this run throwaway,
+# which also means parallel runs cannot corrupt each other.
+say "preparing disk"
+if [ "$NEED_PACKAGES" = 1 ]; then
+    # First run for this OS: build the prepared image in place, so what we
+    # install now survives for later runs.
+    qemu-img create -q -f qcow2 -F qcow2 -b "$PRISTINE" "$WORK/disk.qcow2" >/dev/null || exit 1
+else
+    qemu-img create -q -f qcow2 -F qcow2 -b "$BASE" "$WORK/disk.qcow2" >/dev/null || exit 1
+fi
+
+# --- ssh key, handed over on a small FAT disk -------------------------------
+# The action does this with losetup+mkfs.fat+mount, which needs root; mtools
+# writes the same filesystem without it.
+#
+# The layout differs per guest, matching what the action passes to losetup:
+# FreeBSD reads a partitioned disk (offset 1MiB), while OpenBSD and NetBSD
+# expect the filesystem to start at sector 0 with no partition table.  Get
+# this wrong and the guest boots fine but never installs the key, so the only
+# symptom is ssh refusing the key forever.
+ssh-keygen -t ed25519 -f "$WORK/key" -q -N "" || exit 1
+truncate -s 40m "$WORK/res.raw" || exit 1
+
+if [ "$OS" = freebsd ]; then
+    printf 'label: dos\nstart=2048, type=c\n' | sfdisk -q "$WORK/res.raw" >/dev/null 2>&1 || exit 1
+    RES_IMG="$WORK/res.raw@@1M"
+else
+    RES_IMG="$WORK/res.raw"
+fi
+# The volume label is RES and the key file is a lowercase "keys": the action
+# does `copyFileSync(publicKey, mountPath + '/keys')` on a disk labelled RES,
+# and the guests' provision.sh reads that path.  Spelling it KEYS gets the
+# guest booting happily but never authorised, which looks like a hang.
+mformat -i "$RES_IMG" -F -v RES :: || exit 1
+mcopy -i "$RES_IMG" "$WORK/key.pub" ::/keys || exit 1
+
+# --- boot -------------------------------------------------------------------
+# Disk, network and firmware flags are per-guest, matching what the action's
+# operating_systems/<os>/qemu_vm.ts sets up:
+#
+#   FreeBSD  virtio-blk (it looks for vtbd0; SCSI drops it at mountroot>)
+#   OpenBSD  scsi + e1000 nic + UEFI, and -pdpe1gb to disable huge pages,
+#            without which it will not boot (qemu issue 1091)
+#   NetBSD   scsi, and ipv6 off on the user network
+case $OS in
+freebsd)
+    DISK_FLAGS="-device virtio-blk-pci,drive=drive0,bootindex=0
+                -drive if=none,file=$WORK/disk.qcow2,id=drive0,cache=unsafe,format=qcow2
+                -device virtio-blk-pci,drive=drive1,bootindex=1
+                -drive if=none,file=$WORK/res.raw,id=drive1,cache=unsafe,format=raw"
+    NET_DEV=virtio-net-pci
+    NETDEV="user,id=user.0,hostfwd=tcp::$PORT-:22"
+    CPU_FLAGS=host
+    FIRMWARE=
+    ;;
+*)
+    DISK_FLAGS="-device virtio-scsi-pci
+                -device scsi-hd,drive=drive0,bootindex=0
+                -drive if=none,file=$WORK/disk.qcow2,id=drive0,cache=unsafe,format=qcow2
+                -device scsi-hd,drive=drive1,bootindex=1
+                -drive if=none,file=$WORK/res.raw,id=drive1,cache=unsafe,format=raw"
+    if [ "$OS" = openbsd ]; then
+        NET_DEV=e1000
+        NETDEV="user,id=user.0,hostfwd=tcp::$PORT-:22"
+        CPU_FLAGS=host,-pdpe1gb
+        OVMF=${OVMF:-/usr/share/OVMF/OVMF_CODE_4M.fd}
+        if [ ! -r "$OVMF" ]; then
+            say "need UEFI firmware; set OVMF=/path/to/OVMF_CODE.fd"
+            exit 1
+        fi
+        FIRMWARE="-drive if=pflash,format=raw,unit=0,file=$OVMF,readonly=on"
+    else
+        NET_DEV=virtio-net-pci
+        NETDEV="user,id=user.0,ipv6=off,hostfwd=tcp::$PORT-:22"
+        CPU_FLAGS=host
+        FIRMWARE=
+    fi
+    ;;
+esac
+
+say "booting vm (ssh port $PORT)"
+# shellcheck disable=SC2086
+qemu-system-x86_64 \
+    -machine type=q35,accel=kvm -cpu "$CPU_FLAGS" \
+    -smp "${VM_CPUS:-2}" -m "${VM_RAM:-2048}" \
+    -device "$NET_DEV,netdev=user.0,addr=0x03" -netdev "$NETDEV" \
+    -display none -monitor none -serial "file:$WORK/serial.log" \
+    -boot strict=off \
+    $FIRMWARE $DISK_FLAGS >"$WORK/qemu.log" 2>&1 &
+QEMU_PID=$!
+
+SSHOPT="-i $WORK/key -p $PORT -o StrictHostKeyChecking=no
+        -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR
+        -o ConnectTimeout=5 -o ServerAliveInterval=30"
+
+# Wait for sshd.  OpenBSD and NetBSD boot a good deal slower than FreeBSD,
+# and slower again when several VMs are competing for the same disk, so this
+# waits generously.  NetBSD keeps its console on vga rather than serial, so
+# an empty serial.log there is normal and not a sign of trouble.
+say "waiting for ssh"
+i=0
+until ssh $SSHOPT runner@127.0.0.1 true 2>/dev/null; do
+    i=$((i + 1))
+    if [ "$i" -gt "${VM_BOOT_TRIES:-200}" ]; then
+        say "vm did not come up after $((i * 3))s"
+        [ -s "$WORK/serial.log" ] && { say "last serial output:"; tail -25 "$WORK/serial.log"; }
+        exit 1
+    fi
+    kill -0 "$QEMU_PID" 2>/dev/null || { say "qemu died"; cat "$WORK/qemu.log"; exit 1; }
+    sleep 3
+done
+say "up after $((i * 3))s"
+
+# --- build ------------------------------------------------------------------
+say "syncing work tree"
+rsync -az --delete -e "ssh $SSHOPT" \
+      --exclude '.git' --exclude 'build*' --exclude '.ci-local' \
+      --exclude 'android/obj' --exclude 'android/libs' \
+      "$REPO/" runner@127.0.0.1:wildmidi/ || exit 1
+
+if [ "$NEED_PACKAGES" = 1 ]; then
+    say "installing cmake (first run for $OS; caching the result)"
+    ssh $SSHOPT runner@127.0.0.1 "$SETUP_CMD" >>"$WORK/build.log" 2>&1
+    ssh $SSHOPT runner@127.0.0.1 "$INSTALL_CMD" >>"$WORK/build.log" 2>&1 || {
+        say "could not install cmake"; tail -20 "$WORK/build.log"; exit 1
+    }
+    SAVE_PREPARED=1
+else
+    say "cmake already in the cached image"
+    SAVE_PREPARED=0
+fi
+
+say "building"
+ssh $SSHOPT runner@127.0.0.1 "
+    export PATH=/usr/pkg/sbin:/usr/pkg/bin:/sbin:\$PATH
+    cd wildmidi &&
+    cmake -B build -DCMAKE_INSTALL_PREFIX=build/out \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DWANT_PLAYER=ON -DWANT_STATIC=ON $CMAKE_OPTS &&
+    cmake --build build --config Release &&
+    ctest --test-dir build --output-on-failure &&
+    cmake --install build
+" 2>&1 || { say "build failed"; exit 1; }
+
+# Keep the guest as it is now, minus the work tree, so the next run starts
+# with cmake already installed.  Only done once the build has succeeded: an
+# image built from a broken run is worse than no cache at all.
+if [ "$SAVE_PREPARED" = 1 ]; then
+    say "saving prepared image for future runs"
+    ssh $SSHOPT runner@127.0.0.1 "rm -rf wildmidi" >/dev/null 2>&1
+
+    # Shut down cleanly so the guest filesystem is consistent, then let qemu
+    # release the disk before touching it.
+    ssh $SSHOPT runner@127.0.0.1 "sudo shutdown -p now || sudo shutdown -h now" \
+        >/dev/null 2>&1
+    i=0
+    while kill -0 "$QEMU_PID" 2>/dev/null && [ "$i" -lt 60 ]; do
+        i=$((i + 1)); sleep 2
+    done
+    kill -0 "$QEMU_PID" 2>/dev/null && { kill "$QEMU_PID" 2>/dev/null; sleep 3; }
+    QEMU_PID=
+
+    # Flatten the overlay so the cached image does not depend on $WORK.  -c
+    # matters: without it the result is written out uncompressed and ends up
+    # several times the size of the image it came from.
+    if qemu-img convert -q -c -O qcow2 "$WORK/disk.qcow2" "$PREPARED.part" 2>/dev/null; then
+        mv "$PREPARED.part" "$PREPARED"
+        say "cached $(basename "$PREPARED")"
+    else
+        rm -f "$PREPARED.part"
+        say "could not save prepared image; runs stay slow but correct"
+    fi
+fi
+
+say "ok"
+exit 0

--- a/.gitignore
+++ b/.gitignore
@@ -6,10 +6,20 @@
 *.dxe
 *.a
 *.exe
+*.lib
+*.exp
 
 # build dirs
 build/
 cmake-build*/
+
+# ci-local.sh working files
+build-ci-*/
+.ci-local/
+
+# ndk-build output
+android/libs/
+android/obj/
 
 # stray in-source cmake configure (should always use -B build)
 CMakeCache.txt

--- a/README.md
+++ b/README.md
@@ -42,6 +42,15 @@ Requirements:
 
 CHANGELOG
 
+0.5.1 (unreleased)
+* Player: playlist support. A filename given to the player may now be a
+  directory, which is searched recursively for files to play (bug #215.)
+* Player: new `-S/--shuffle` switch plays the files in random order.
+* Player: new `-L/--loop` switch repeats playback at the end. With a single
+  file the file itself is looped at end-of-track; with several files, or a
+  directory, the whole playlist is repeated instead, reshuffling each pass
+  when combined with `-S`.
+
 0.5.0 (2026-07-24)
 * SoundFont2 (SF2) rendering support via TinySoundFont. Enabled by default,
   cmake configuration: `WANT_SF2=ON`. Pass either an `.sf2` file, or a config

--- a/README.md
+++ b/README.md
@@ -42,12 +42,13 @@ Requirements:
 
 TESTING YOUR CHANGES:
 
-Besides cmake, six hand-maintained makefiles (mingw/, djgpp/, amiga/,
+Besides cmake, eight hand-maintained makefiles (amiga/Makefile,
+amiga/Makefile.vbcc, djgpp/Makefile, macosx/Makefile, mingw/Makefile,
 os2/makefile.emx, os2/makefile.wat, win32wat/makefile) each keep their own list
 of objects, so a change that builds fine under cmake can still break them.
 ci-local.sh runs the GitHub CI jobs locally to catch that before you push:
 
-```
+```sh
 ./ci-local.sh --docker              compile jobs, in a container
 ./ci-local.sh --all                 those plus the BSD VMs
 ./ci-local.sh --docker native       run only named jobs

--- a/README.md
+++ b/README.md
@@ -40,6 +40,35 @@ Requirements:
 * Nintendo Switch port: devkitA64
 * PSVita port: Vitasdk
 
+TESTING YOUR CHANGES:
+
+Besides cmake, six hand-maintained makefiles (mingw/, djgpp/, amiga/,
+os2/makefile.emx, os2/makefile.wat, win32wat/makefile) each keep their own list
+of objects, so a change that builds fine under cmake can still break them.
+ci-local.sh runs the GitHub CI jobs locally to catch that before you push:
+
+```
+./ci-local.sh --docker              compile jobs, in a container
+./ci-local.sh --all                 those plus the BSD VMs
+./ci-local.sh --docker native       run only named jobs
+./ci-local.sh --list                show all job names
+```
+
+The first run builds a ~5GB image from .ci/Dockerfile with every toolchain the
+workflows use, then caches it. Exits 0 on success, 1 on failure with the failing
+job and a log tail; full logs in .ci-local/. Without --docker it uses whatever
+is installed on the host and reports the rest as SKIP.
+
+--qemu (implied by --all) additionally boots FreeBSD, OpenBSD and NetBSD under
+qemu/kvm, the same way the bsd.yml workflow does, all three at once. It needs
+qemu, mtools, rsync, sfdisk, OVMF firmware (for OpenBSD) and access to
+/dev/kvm, which is why it is opt-in. The first run per OS installs cmake in
+the guest and saves the result, so later runs take about half a minute for all
+three; pass --refresh to .ci/bsd-vm.sh to rebuild those cached images.
+
+This does not replace CI: the macOS and Windows jobs need runners a Linux host
+cannot provide.
+
 CHANGELOG
 
 0.5.1 (unreleased)
@@ -50,6 +79,8 @@ CHANGELOG
   file the file itself is looped at end-of-track; with several files, or a
   directory, the whole playlist is repeated instead, reshuffling each pass
   when combined with `-S`.
+* Added `ci-local.sh` to run the GitHub CI jobs locally before pushing,
+  including the BSD builds under qemu.
 
 0.5.0 (2026-07-24)
 * SoundFont2 (SF2) rendering support via TinySoundFont. Enabled by default,

--- a/amiga/Makefile
+++ b/amiga/Makefile
@@ -56,7 +56,7 @@ endif
 
 # Objects
 LIB_OBJ= wm_error.o file_io.o lock.o wildmidi_lib.o reverb.o gus_pat.o f_xmidi.o f_mus.o f_hmp.o f_midi.o f_hmi.o mus2mid.o xmi2mid.o hmp2mid.o hmi2mid.o internal_midi.o patches.o sample.o sf2.o synth.o opl3.o
-PLAYER_OBJ= amiga.o wm_tty.o msleep.o getopt_long.o out_none.o out_wave.o out_ahi.o wildmidi.o
+PLAYER_OBJ= amiga.o wm_tty.o playlist.o msleep.o getopt_long.o out_none.o out_wave.o out_ahi.o wildmidi.o
 
 # Build targets
 .PHONY: clean distclean

--- a/amiga/Makefile.vbcc
+++ b/amiga/Makefile.vbcc
@@ -35,7 +35,7 @@ endif
 
 # Objects
 LIB_OBJ= wm_error.o file_io.o lock.o wildmidi_lib.o reverb.o gus_pat.o f_xmidi.o f_mus.o f_hmp.o f_midi.o f_hmi.o mus2mid.o xmi2mid.o hmp2mid.o hmi2mid.o internal_midi.o patches.o sample.o sf2.o synth.o opl3.o
-PLAYER_OBJ= amiga.o wm_tty.o msleep.o getopt_long.o out_none.o out_wave.o out_ahi.o wildmidi.o
+PLAYER_OBJ= amiga.o wm_tty.o playlist.o msleep.o getopt_long.o out_none.o out_wave.o out_ahi.o wildmidi.o
 
 # Build targets
 .PHONY: clean distclean

--- a/ci-local.sh
+++ b/ci-local.sh
@@ -1,0 +1,489 @@
+#!/bin/sh
+#
+# ci-local.sh -- run the GitHub CI jobs locally.
+#
+# Mirrors the jobs in .github/workflows so changes can be validated before
+# committing and pushing.  Toolchains that are not installed are reported as
+# SKIP rather than failing the run, so this is useful even on a machine that
+# only has the native compilers.
+#
+# Usage:
+#   ./ci-local.sh --all           everything, including the BSD VMs
+#   ./ci-local.sh --docker        run the compile jobs in the toolchain container
+#   ./ci-local.sh --qemu          also run the FreeBSD/OpenBSD/NetBSD VMs
+#   ./ci-local.sh                 run on the host, using whatever is installed
+#   ./ci-local.sh native zig      run only the named jobs
+#   ./ci-local.sh --list          show the job names and their workflow
+#   ./ci-local.sh --docker-build  build (or rebuild) the toolchain image
+#   ./ci-local.sh --strict        treat unavailable toolchains as failures
+#   ./ci-local.sh --keep          keep build trees for inspection
+#
+# The BSD jobs boot real VMs under qemu/kvm and are much slower than the rest
+# (minutes, not seconds), which is why they need --qemu or --all.  All three
+# boot at once.  They need qemu, mtools, rsync, sfdisk and access to /dev/kvm.
+#
+# --docker is the recommended way to run this: it supplies the cross
+# toolchains, so jobs are actually exercised instead of skipped.  The image is
+# built once from .ci/Dockerfile.  The AmigaOS job always uses the same
+# amigadev/crosstools image that upstream CI uses, in or out of --docker.
+#
+# Environment:
+#   WATCOM      OpenWatcom install root, for the os2/windows Watcom jobs
+#   DJGPP_DIR   DJGPP install root (default /opt/djgpp)
+#   NDK         Android NDK root (falls back to ANDROID_NDK_LATEST_HOME)
+#   JOBS        parallel make/cmake jobs (default: nproc)
+#   CI_IMAGE    toolchain image name (default wildmidi-ci:local)
+#
+# This file is part of WildMIDI and shares its license.
+
+set -u
+
+REPO=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+cd "$REPO" || exit 1
+
+: "${DJGPP_DIR:=/opt/djgpp}"
+: "${NDK:=${ANDROID_NDK_LATEST_HOME:-}}"
+: "${JOBS:=$(nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo 2)}"
+: "${CI_IMAGE:=wildmidi-ci:local}"
+
+STRICT=0
+KEEP=0
+USE_DOCKER=0
+USE_QEMU=0
+LOGDIR="$REPO/.ci-local"
+
+# --- output helpers ---------------------------------------------------------
+# Colour when writing to a terminal.  Inside the container stdout is a pipe,
+# so CI_COLOR carries the host's decision in rather than losing it -- without
+# that, the jobs run in docker print plain text while the ones run on the host
+# come out coloured.
+if [ "${CI_COLOR:-}" = 1 ] || { [ -z "${CI_COLOR:-}" ] && [ -t 1 ]; }; then
+    C_RED=$(printf '\033[31m'); C_GRN=$(printf '\033[32m')
+    C_YEL=$(printf '\033[33m'); C_BLD=$(printf '\033[1m')
+    C_RST=$(printf '\033[0m')
+else
+    C_RED=; C_GRN=; C_YEL=; C_BLD=; C_RST=
+fi
+
+PASSED=; FAILED=; SKIPPED=
+
+pass()  { PASSED="$PASSED $1";  printf '%s  PASS%s  %s\n' "$C_GRN" "$C_RST" "$1"; }
+fail()  { FAILED="$FAILED $1";  printf '%s  FAIL%s  %s   (log: %s)\n' "$C_RED" "$C_RST" "$1" "$2"; }
+skip()  {
+    if [ "$STRICT" -eq 1 ]; then
+        FAILED="$FAILED $1"
+        printf '%s  FAIL%s  %s   (missing: %s)\n' "$C_RED" "$C_RST" "$1" "$2"
+    else
+        SKIPPED="$SKIPPED $1"
+        printf '%s  SKIP%s  %s   (missing: %s)\n' "$C_YEL" "$C_RST" "$1" "$2"
+    fi
+}
+
+have() { command -v "$1" >/dev/null 2>&1; }
+
+# --- docker -----------------------------------------------------------------
+docker_build() {
+    have docker || { printf 'docker is not installed\n' >&2; return 1; }
+    printf '%s>> building %s from .ci/Dockerfile%s\n' "$C_BLD" "$CI_IMAGE" "$C_RST"
+    docker build -t "$CI_IMAGE" -f "$REPO/.ci/Dockerfile" "$REPO/.ci"
+}
+
+# Re-run this script inside the toolchain image.  The repo is bind-mounted and
+# we run as the caller's uid so build products are not left owned by root.
+docker_run() {
+    have docker || { printf 'docker is not installed\n' >&2; return 1; }
+
+    if ! docker image inspect "$CI_IMAGE" >/dev/null 2>&1; then
+        printf '%simage %s not found, building it once%s\n' \
+               "$C_YEL" "$CI_IMAGE" "$C_RST"
+        docker_build || return 1
+    fi
+
+    # The amiga job shells out to docker itself, which we cannot nest, so it
+    # is run on the host afterwards instead.
+    _inner=$(printf '%s ' "$@")
+    docker run --rm \
+        -v "$REPO":/src \
+        -u "$(id -u):$(id -g)" \
+        -e HOME=/tmp \
+        -e "JOBS=$JOBS" \
+        -e "CI_COLOR=$([ -n "$C_GRN" ] && echo 1 || echo 0)" \
+        -w /src \
+        "$CI_IMAGE" \
+        ./ci-local.sh --no-amiga $_inner
+    return $?
+}
+
+# Run a job: run_job <name> <command-string>.  Output goes to a log; only
+# failures print it, so a clean run stays readable.
+run_job() {
+    _name=$1
+    _cmd=$2
+    _log="$LOGDIR/$_name.log"
+
+    printf '%s>> %s%s\n' "$C_BLD" "$_name" "$C_RST"
+    if ( eval "$_cmd" ) >"$_log" 2>&1; then
+        pass "$_name"
+        return 0
+    fi
+    fail "$_name" "$_log"
+    printf '     --- last 20 lines ---\n'
+    tail -20 "$_log" | sed 's/^/     /'
+    return 1
+}
+
+# --- job definitions --------------------------------------------------------
+# Each job is <name>:<workflow>:<description>.  Keep in sync with .github/workflows.
+JOB_LIST="
+native:main.yml:cmake build + ctest with gcc and clang
+zig:zig.yml:zig build and zig build test
+mingw32:cross.yml:MinGW-w64 i686 static+shared
+mingw64:cross.yml:MinGW-w64 x86_64 static+shared
+djgpp:cross.yml:DJGPP DOS build
+amiga:cross.yml:AmigaOS m68k library (docker)
+os2emx:cross.yml:OS/2 EMX cross build
+android:cross.yml:Android NDK build
+watcom-os2:watcom.yml:OpenWatcom OS/2 build
+watcom-win32:watcom.yml:OpenWatcom Win32 build
+freebsd:bsd.yml:FreeBSD 14.4 in qemu (--qemu)
+openbsd:bsd.yml:OpenBSD 7.9 in qemu (--qemu)
+netbsd:bsd.yml:NetBSD 10.1 in qemu (--qemu)
+"
+
+list_jobs() {
+    printf '%sAvailable jobs%s\n' "$C_BLD" "$C_RST"
+    echo "$JOB_LIST" | while IFS=: read -r n w d; do
+        [ -n "$n" ] || continue
+        printf '  %-14s %-12s %s\n' "$n" "$w" "$d"
+    done
+}
+
+# --- individual jobs --------------------------------------------------------
+
+# main.yml: cmake configure, build, ctest, install -- once per compiler.
+job_native() {
+    _rc=0
+    for cc in gcc clang; do
+        if ! have "$cc"; then
+            skip "native($cc)" "$cc"
+            continue
+        fi
+        _b="$REPO/build-ci-$cc"
+        rm -rf "$_b"
+        run_job "native($cc)" "
+            CC=$cc cmake -B '$_b' \
+                -DWANT_PLAYER=ON -DWANT_STATIC=ON -DWANT_ALSA=ON -DWANT_OSS=ON \
+                -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX='$_b/out' &&
+            cmake --build '$_b' -j$JOBS --config Release &&
+            ctest --test-dir '$_b' --output-on-failure -C Release &&
+            cmake --install '$_b'
+        " || _rc=1
+        [ "$KEEP" -eq 1 ] || rm -rf "$_b"
+    done
+    return $_rc
+}
+
+# zig.yml.  CI installs a current zig; an older local one fails on the
+# language itself rather than on anything in this repo, so check first.
+job_zig() {
+    have zig || { skip zig zig; return 0; }
+
+    _need=$(sed -n 's/.*minimum_zig_version[^"]*"\([^"]*\)".*/\1/p' build.zig.zon 2>/dev/null)
+    _got=$(zig version 2>/dev/null)
+    if [ -n "$_need" ] && [ -n "$_got" ]; then
+        # Sort the two versions and see if ours is the lower one.
+        _low=$(printf '%s\n%s\n' "$_need" "$_got" | sort -V | head -1)
+        if [ "$_low" = "$_got" ] && [ "$_got" != "$_need" ]; then
+            skip zig "zig >= $_need (have $_got)"
+            return 0
+        fi
+    fi
+    run_job zig "zig build --summary all && zig build test --summary all"
+}
+
+# cross.yml: mingw.  CI runs 'static shared'.
+job_mingw32() { _mingw i686-w64-mingw32 mingw32; }
+job_mingw64() { _mingw x86_64-w64-mingw32 mingw64; }
+_mingw() {
+    _cross=$1; _name=$2
+    have "$_cross-gcc" || { skip "$_name" "$_cross-gcc"; return 0; }
+    run_job "$_name" "
+        make -C '$REPO/mingw' CROSS=$_cross clean >/dev/null 2>&1;
+        make -C '$REPO/mingw' -j$JOBS CROSS=$_cross static shared &&
+        make -C '$REPO/mingw' CROSS=$_cross distclean
+    "
+}
+
+# cross.yml: djgpp
+job_djgpp() {
+    _dj=$DJGPP_DIR/bin
+    if ! have i586-pc-msdosdjgpp-gcc && [ ! -x "$_dj/i586-pc-msdosdjgpp-gcc" ]; then
+        skip djgpp "i586-pc-msdosdjgpp-gcc (set DJGPP_DIR)"
+        return 0
+    fi
+    run_job djgpp "
+        PATH='$DJGPP_DIR/i586-pc-msdosdjgpp/bin:$_dj':\$PATH;
+        export PATH;
+        make -C '$REPO/djgpp' CROSS=i586-pc-msdosdjgpp USE_DXE=0 clean >/dev/null 2>&1;
+        make -C '$REPO/djgpp' -j$JOBS CROSS=i586-pc-msdosdjgpp USE_DXE=0 &&
+        make -C '$REPO/djgpp' CROSS=i586-pc-msdosdjgpp USE_DXE=0 distclean
+    "
+}
+
+# cross.yml: amiga-m68k, which CI runs inside a container.  Library only --
+# the player does not link there (clib2 libm gap), same as CI.
+job_amiga() {
+    have docker || { skip amiga docker; return 0; }
+    run_job amiga "
+        docker run --rm -v '$REPO':/src -w /src/amiga \
+            amigadev/crosstools:m68k-amigaos \
+            sh -c 'make libWildMidi.a AOS3=1 CROSS=m68k-amigaos -j$JOBS && make distclean'
+    "
+}
+
+# The Amiga player sources are not built by CI, so compile them here to keep
+# that backend honest.  Only runs when the container image is already present.
+job_amiga_player() {
+    have docker || return 0
+    docker image inspect amigadev/crosstools:m68k-amigaos >/dev/null 2>&1 || return 0
+    run_job "amiga(playlist.c)" "
+        docker run --rm -v '$REPO':/src -w /src/amiga \
+            amigadev/crosstools:m68k-amigaos \
+            m68k-amigaos-gcc -c -o /tmp/playlist.o ../src/player/playlist.c \
+                -I. -I../include -DWILDMIDI_AMIGA -Wall -Wextra -Werror
+    "
+}
+
+# cross.yml: os2-emx
+job_os2emx() {
+    have i686-pc-os2-emx-gcc || { skip os2emx i686-pc-os2-emx-gcc; return 0; }
+    run_job os2emx "
+        make -C '$REPO/os2' -f makefile.emx -j$JOBS CROSS=i686-pc-os2-emx &&
+        make -C '$REPO/os2' -f makefile.emx distclean
+    "
+}
+
+# cross.yml: android.  CI builds through $ANDROID_NDK_LATEST_HOME.
+job_android() {
+    if [ -z "$NDK" ] || [ ! -x "$NDK/ndk-build" ]; then
+        skip android "Android NDK (set NDK)"
+        return 0
+    fi
+    run_job android "
+        '$NDK/ndk-build' -C '$REPO/android' \
+            NDK_PROJECT_PATH=. \
+            APP_BUILD_SCRIPT=jni/Android.mk \
+            NDK_APPLICATION_MK=jni/Application.mk &&
+        rm -rf '$REPO/android/libs' '$REPO/android/obj'
+    "
+}
+
+# watcom.yml.  wmake needs WATCOM set and its binaries on PATH.
+_watcom_env() {
+    [ -n "${WATCOM:-}" ] || return 1
+    for d in binl64 binl; do
+        [ -d "$WATCOM/$d" ] && PATH="$WATCOM/$d:$PATH"
+    done
+    export WATCOM PATH
+    export EDPATH="$WATCOM/eddat" WIPFC="$WATCOM/wipfc"
+    have wmake
+}
+
+job_watcom_os2() {
+    _watcom_env || { skip watcom-os2 "wmake (set WATCOM)"; return 0; }
+    run_job watcom-os2 "
+        cd '$REPO/os2' &&
+        wmake -f makefile.wat &&
+        wmake -f makefile.wat distclean
+    "
+}
+
+job_watcom_win32() {
+    _watcom_env || { skip watcom-win32 "wmake (set WATCOM)"; return 0; }
+    run_job watcom-win32 "
+        cd '$REPO/win32wat' &&
+        wmake &&
+        wmake distclean
+    "
+}
+
+# bsd.yml.  Each OS boots its own qemu VM, so they can all run at once; a VM
+# spends most of its wall time booting and fetching packages rather than using
+# the cpu.  Gated behind --qemu because it is far slower than the other jobs.
+BSD_CACHE="${BSD_CACHE:-$LOGDIR/vm-images}"
+
+bsd_missing() {
+    _m=
+    have qemu-system-x86_64 || _m="$_m qemu-system-x86_64"
+    have qemu-img           || _m="$_m qemu-img"
+    have mformat            || _m="$_m mtools"
+    have rsync              || _m="$_m rsync"
+    have sfdisk             || _m="$_m sfdisk"
+    [ -r /dev/kvm ] && [ -w /dev/kvm ] || _m="$_m /dev/kvm"
+    printf '%s' "${_m# }"
+}
+
+job_bsd() {
+    _want=$1              # space separated list of freebsd/openbsd/netbsd
+    _miss=$(bsd_missing)
+    if [ -n "$_miss" ]; then
+        for _o in $_want; do skip "$_o" "$_miss"; done
+        return 0
+    fi
+
+
+    # Fetch any missing images first.  Downloading half a gigabyte while the
+    # other VMs are trying to boot starves them of I/O and makes them look
+    # like they hung.
+    for _o in $_want; do
+        .ci/bsd-vm.sh "$_o" "$REPO" 0 "$BSD_CACHE" --fetch-only \
+            >>"$LOGDIR/$_o.log" 2>&1 || true
+    done
+
+    # Launch each VM in the background on its own ssh port.
+    _port=2222
+    _pids=
+    for _o in $_want; do
+        printf '%s>> %s (qemu)%s\n' "$C_BLD" "$_o" "$C_RST"
+        ( .ci/bsd-vm.sh "$_o" "$REPO" "$_port" "$BSD_CACHE" ) \
+            >"$LOGDIR/$_o.log" 2>&1 &
+        _pids="$_pids $_o:$!"
+        _port=$((_port + 1))
+    done
+
+    # Collect them.  Waiting on each in turn is fine: we need every result
+    # before the summary either way.
+    _rc=0
+    for _e in $_pids; do
+        _o=${_e%%:*}
+        _p=${_e##*:}
+        if wait "$_p"; then
+            pass "$_o"
+        else
+            fail "$_o" "$LOGDIR/$_o.log"
+            printf '     --- last 20 lines ---\n'
+            tail -20 "$LOGDIR/$_o.log" | sed 's/^/     /'
+            _rc=1
+        fi
+    done
+    return $_rc
+}
+
+# --- argument handling ------------------------------------------------------
+WANTED=
+NO_AMIGA=0
+ARGS_FOR_DOCKER=
+while [ $# -gt 0 ]; do
+    case $1 in
+        --list|-l) list_jobs; exit 0 ;;
+        --docker)  USE_DOCKER=1 ;;
+        --qemu)    USE_QEMU=1 ;;
+        --all)     USE_DOCKER=1; USE_QEMU=1 ;;
+        --docker-build)
+            docker_build; exit $? ;;
+        --no-amiga) NO_AMIGA=1 ;;
+        --strict)  STRICT=1; ARGS_FOR_DOCKER="$ARGS_FOR_DOCKER --strict" ;;
+        --keep)    KEEP=1;   ARGS_FOR_DOCKER="$ARGS_FOR_DOCKER --keep" ;;
+        -h|--help)
+            sed -n '3,33p' "$0" | sed 's/^# \{0,1\}//'
+            exit 0 ;;
+        -*) printf 'unknown option: %s\n' "$1" >&2; exit 2 ;;
+        *)  WANTED="$WANTED $1"; ARGS_FOR_DOCKER="$ARGS_FOR_DOCKER $1" ;;
+    esac
+    shift
+done
+
+# In --docker mode, hand off to the container for everything except the amiga
+# jobs, which need their own image and so cannot be nested; those run here on
+# the host afterwards, with their own short summary.
+if [ "$USE_DOCKER" -eq 1 ]; then
+    docker_run $ARGS_FOR_DOCKER
+    _drc=$?
+
+    if [ -z "$WANTED" ] || printf '%s' "$WANTED" | grep -q amiga; then
+        mkdir -p "$LOGDIR"
+        printf '\n%s>> amiga jobs (amigadev/crosstools image)%s\n' "$C_BLD" "$C_RST"
+        job_amiga
+        job_amiga_player
+    fi
+
+    # BSD VMs also stay outside the container: qemu needs /dev/kvm.
+    _bsds=
+    for _o in freebsd openbsd netbsd; do
+        { [ -z "$WANTED" ] || printf '%s' "$WANTED" | grep -q "$_o"; } \
+            && _bsds="$_bsds $_o"
+    done
+    if [ -n "$_bsds" ]; then
+        mkdir -p "$LOGDIR"
+        if [ "$USE_QEMU" -eq 1 ] || [ -n "$WANTED" ]; then
+            job_bsd "$_bsds"
+        else
+            for _o in $_bsds; do skip "$_o" "not requested (use --qemu)"; done
+        fi
+    fi
+
+    set -- $FAILED
+    if [ $# -ne 0 ]; then
+        _drc=1
+        printf '%shost-side failures:%s%s\n' "$C_RED" "$C_RST" "$FAILED"
+    fi
+
+    if [ "$_drc" -ne 0 ]; then
+        printf '\n%sCI would fail. Logs in %s%s\n' "$C_RED" "$LOGDIR" "$C_RST"
+    fi
+    exit $_drc
+fi
+
+wanted() {
+    [ -z "$WANTED" ] && return 0
+    for w in $WANTED; do
+        [ "$w" = "$1" ] && return 0
+    done
+    return 1
+}
+
+# --- run --------------------------------------------------------------------
+mkdir -p "$LOGDIR"
+printf '%sWildMIDI local CI%s  (repo: %s, jobs: %s)\n\n' "$C_BLD" "$C_RST" "$REPO" "$JOBS"
+
+wanted native       && job_native
+wanted zig          && job_zig
+wanted mingw32      && job_mingw32
+wanted mingw64      && job_mingw64
+wanted djgpp        && job_djgpp
+wanted amiga        && [ "$NO_AMIGA" -eq 0 ] && { job_amiga; job_amiga_player; }
+wanted os2emx       && job_os2emx
+wanted android      && job_android
+wanted watcom-os2   && job_watcom_os2
+wanted watcom-win32 && job_watcom_win32
+
+# BSD VMs run on the host: qemu needs /dev/kvm, which the toolchain container
+# does not get.  Only run when asked, and only when not already inside it.
+if [ "$NO_AMIGA" -eq 0 ]; then
+    _bsds=
+    for _o in freebsd openbsd netbsd; do
+        wanted "$_o" && _bsds="$_bsds $_o"
+    done
+    if [ -n "$_bsds" ]; then
+        if [ "$USE_QEMU" -eq 1 ] || [ -n "$WANTED" ]; then
+            job_bsd "$_bsds"
+        else
+            for _o in $_bsds; do skip "$_o" "not requested (use --qemu)"; done
+        fi
+    fi
+fi
+
+# --- summary ----------------------------------------------------------------
+echo
+printf '%s---- summary ----%s\n' "$C_BLD" "$C_RST"
+set -- $PASSED;  printf 'passed:  %s\n' "$#"
+set -- $SKIPPED; printf 'skipped: %s%s\n' "$#" "${SKIPPED:+ -$SKIPPED}"
+set -- $FAILED;  _nfail=$#
+printf 'failed:  %s%s\n' "$_nfail" "${FAILED:+ -$FAILED}"
+
+if [ "$_nfail" -ne 0 ]; then
+    printf '\n%sCI would fail. Logs in %s%s\n' "$C_RED" "$LOGDIR" "$C_RST"
+    exit 1
+fi
+printf '\n%sAll available jobs passed.%s\n' "$C_GRN" "$C_RST"
+exit 0

--- a/ci-local.sh
+++ b/ci-local.sh
@@ -385,12 +385,23 @@ while [ $# -gt 0 ]; do
         --strict)  STRICT=1; ARGS_FOR_DOCKER="$ARGS_FOR_DOCKER --strict" ;;
         --keep)    KEEP=1;   ARGS_FOR_DOCKER="$ARGS_FOR_DOCKER --keep" ;;
         -h|--help)
-            sed -n '3,33p' "$0" | sed 's/^# \{0,1\}//'
+            sed -n '3,35p' "$0" | sed 's/^# \{0,1\}//'
             exit 0 ;;
         -*) printf 'unknown option: %s\n' "$1" >&2; exit 2 ;;
         *)  WANTED="$WANTED $1"; ARGS_FOR_DOCKER="$ARGS_FOR_DOCKER $1" ;;
     esac
     shift
+done
+
+# Reject job names we do not have.  Without this a typo simply matches nothing
+# and the run ends with "All available jobs passed", which is the one answer a
+# checking tool must never give when it has checked nothing.
+for _w in $WANTED; do
+    if ! echo "$JOB_LIST" | grep -q "^$_w:"; then
+        printf 'unknown job: %s\n' "$_w" >&2
+        printf 'run "%s --list" to see the job names.\n' "$0" >&2
+        exit 2
+    fi
 done
 
 # In --docker mode, hand off to the container for everything except the amiga

--- a/djgpp/Makefile
+++ b/djgpp/Makefile
@@ -58,7 +58,7 @@ endif
 
 # Objects
 LIB_OBJ= wm_error.o file_io.o lock.o wildmidi_lib.o reverb.o gus_pat.o f_xmidi.o f_mus.o f_hmp.o f_midi.o f_hmi.o mus2mid.o xmi2mid.o hmp2mid.o hmi2mid.o internal_midi.o patches.o sample.o sf2.o synth.o opl3.o
-PLAYER_OBJ= wm_tty.o msleep.o getopt_long.o out_none.o dosirq.o dosdma.o dossb.o out_dossb.o out_wave.o wildmidi.o
+PLAYER_OBJ= wm_tty.o playlist.o msleep.o getopt_long.o out_none.o dosirq.o dosdma.o dossb.o out_dossb.o out_wave.o wildmidi.o
 
 # Build targets
 TARGETS = libWildMidi.a wildmidi.exe libWildMidi_dxe.a wildmidi.dxe

--- a/docs/man/man1/wildmidi.1
+++ b/docs/man/man1/wildmidi.1
@@ -18,7 +18,7 @@ This is a demonstration program to show the capabilities of libWildMidi.
 .PP
 You can have more than one \fImidifile\fP on the command line and \fBwildmidi\fP will pass them to libWildMidi for processing, one after the other. You can also use wildcards, for example: \fBwildmidi *.mid\fP
 .PP
-\fImidifile\fP may also be a directory, provided that it is not a symlink. Directories are searched recursively and every file whose name ends in .mid, .midi, .rmi, .kar, .mus, .xmi, .hmp or .hmi is added to the playlist. A file named directly on the command line is always played regardless of its name, since libWildMidi detects the format from the file contents. Use \fB\-S\fP to play the resulting playlist in random order, and \fB\-L\fP to repeat it once it ends.
+\fImidifile\fP may also be a directory, including a symlink to one. Directories are searched recursively and every file whose name ends in .mid, .midi, .rmi, .kar, .mus, .xmi, .hmp or .hmi is added to the playlist. Symlinked subdirectories found during that search are not followed, so that a link pointing back into its own parent cannot cause the same files to be added over and over. A file named directly on the command line is always played regardless of its name, since libWildMidi detects the format from the file contents. Use \fB\-S\fP to play the resulting playlist in random order, and \fB\-L\fP to repeat it once it ends.
 .PP
 .SH OPTIONS
 .IP "\fB\-0\fP"

--- a/docs/man/man1/wildmidi.1
+++ b/docs/man/man1/wildmidi.1
@@ -9,7 +9,7 @@ wildmidi \- example player for libWildMidi
 .B /etc/wildmidi/wildmidi.cfg
 .PP
 .SH SYNOPSIS
-.B wildmidi [\-0abehlnstvO] [\-c \fIconfig\-file\fB] [\-d \fIaudiodev\fB] [\-m \fIvolume\-level\fB] [\-P \fIplayback\-output\fB] [\-o \fIfile\fB] [\-f \fIfrequency\-Hz(MUS)\fB] [\-r \fIsample-rate\fB] [\-g \fIconvert-xmi-type\fB] [\-x \fIfile\fB] [\-i \fIseconds\fB] [\-j \fIseconds\fB] \fImidifile ...
+.B wildmidi [\-0abehlnstvLOS] [\-c \fIconfig\-file\fB] [\-d \fIaudiodev\fB] [\-m \fIvolume\-level\fB] [\-P \fIplayback\-output\fB] [\-o \fIfile\fB] [\-f \fIfrequency\-Hz(MUS)\fB] [\-r \fIsample-rate\fB] [\-g \fIconvert-xmi-type\fB] [\-x \fIfile\fB] [\-i \fIseconds\fB] [\-j \fIseconds\fB] \fImidifile ...
 .PP
 .SH DESCRIPTION
 This is a demonstration program to show the capabilities of libWildMidi.
@@ -17,6 +17,8 @@ This is a demonstration program to show the capabilities of libWildMidi.
 \fImidifile\fP can be a MIDI type file in the HMI, HMP, MIDI, MUS or XMI formats and is processed by libWildMidi and the resulting audio is output by the player.
 .PP
 You can have more than one \fImidifile\fP on the command line and \fBwildmidi\fP will pass them to libWildMidi for processing, one after the other. You can also use wildcards, for example: \fBwildmidi *.mid\fP
+.PP
+\fImidifile\fP may also be a directory, provided that it is not a symlink. Directories are searched recursively and every file whose name ends in .mid, .midi, .rmi, .kar, .mus, .xmi, .hmp or .hmi is added to the playlist. A file named directly on the command line is always played regardless of its name, since libWildMidi detects the format from the file contents. Use \fB\-S\fP to play the resulting playlist in random order, and \fB\-L\fP to repeat it once it ends.
 .PP
 .SH OPTIONS
 .IP "\fB\-0\fP"
@@ -58,6 +60,9 @@ Begin playback at \fIseconds\fP (fractions allowed) into the file.
 .IP "\fB\-j\fP \fIseconds\fP | \fB\-\-playto=\fIseconds\fP"
 Stop playback at \fIseconds\fP (fractions allowed) into the file.
 .PP
+.IP "\fB\-L\fP | \fB\-\-loop\fP"
+Repeat playback when the end is reached. With a single \fImidifile\fP the file itself is looped at end\-of\-track. With more than one file to play, whether given directly or found by searching a directory, the whole playlist is repeated instead, and each file plays through once per pass. When combined with \fB\-S\fP the playlist is shuffled again at the start of every pass.
+.PP
 .IP "\fB\-l\fP | \fB\-\-log_vol\fP"
 Some MIDI files have been recorded on hardware that uses a volume curve, making them sound really badly mixed on other MIDI devices. Use this option to use volume curves.
 .PP
@@ -75,6 +80,9 @@ Use the built\-in OPL3 FM synthesizer. No configuration file, GUS patch set or S
 .PP
 .IP "\fB\-r\fP \fIsndrate\fP | \fB\-\-rate=\fIsndrate\fP"
 Set the audio output rate to \fIsndrate\fP. The default rate is 32072.
+.PP
+.IP "\fB\-S\fP | \fB\-\-shuffle\fP"
+Play the files in random order. Combine with \fB\-L\fP to keep shuffling and repeating indefinitely, for example: \fBwildmidi \-S \-L ~/midi\fP
 .PP
 .IP "\fB\-n\fP | \fB\-\-roundtempo\fP"
 Round tempo to nearest whole number.
@@ -121,7 +129,7 @@ Turns volume curves on and off.
 Turns the final mix reverb on and off.
 .PP
 .IP \fBn\fP
-Play the next midi on the command line.
+Skip to the next midi in the playlist.
 .PP
 .IP \fBm\fP
 Save the currently playing file to a midi file. NOTE: This saves to the current directory.

--- a/include/playlist.h
+++ b/include/playlist.h
@@ -33,11 +33,18 @@ typedef struct {
 /* Adds an entry to the playlist.  If path names a directory it is scanned
  * recursively and every file with a known midi-ish extension is added,
  * otherwise path is added as-is without looking at its name.
+ *
  * Returns PLAYLIST_ADD_FILE or PLAYLIST_ADD_DIR on success, so the caller
  * can tell a directory apart from a plain file even when the directory
- * held a single entry, and PLAYLIST_ADD_ERROR on failure (out of memory,
- * or an unreadable directory).  Failing to add one entry leaves earlier
- * entries intact.  */
+ * held a single entry.
+ *
+ * PLAYLIST_ADD_ERROR means this argument gave us nothing -- an unreadable
+ * directory, say -- but whatever was collected before it is still good, so
+ * the caller may carry on with the remaining arguments.  PLAYLIST_ADD_FATAL
+ * means the playlist itself cannot be trusted (out of memory part-way
+ * through a tree) and building should stop.  Entries added before either
+ * failure remain valid and must still be freed.  */
+#define PLAYLIST_ADD_FATAL (-2)
 #define PLAYLIST_ADD_ERROR (-1)
 #define PLAYLIST_ADD_FILE  0
 #define PLAYLIST_ADD_DIR   1

--- a/include/playlist.h
+++ b/include/playlist.h
@@ -1,0 +1,54 @@
+/*
+ * playlist.h -- WildMidi player playlist header
+ *
+ * Copyright (C) WildMidi Developers 2026
+ *
+ * This file is part of WildMIDI.
+ *
+ * WildMIDI is free software: you can redistribute and/or modify the player
+ * under the terms of the GNU General Public License and you can redistribute
+ * and/or modify the library under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation, either version 3 of
+ * the licenses, or(at your option) any later version.
+ *
+ * WildMIDI is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License and
+ * the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License and the
+ * GNU Lesser General Public License along with WildMIDI.  If not,  see
+ * <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef PLAYLIST_H
+#define PLAYLIST_H
+
+typedef struct {
+    char **files;       /* owned, NULL when empty */
+    unsigned int count; /* entries in use */
+    unsigned int alloc; /* entries allocated */
+} playlist;
+
+/* Adds an entry to the playlist.  If path names a directory it is scanned
+ * recursively and every file with a known midi-ish extension is added,
+ * otherwise path is added as-is without looking at its name.
+ * Returns PLAYLIST_ADD_FILE or PLAYLIST_ADD_DIR on success, so the caller
+ * can tell a directory apart from a plain file even when the directory
+ * held a single entry, and PLAYLIST_ADD_ERROR on failure (out of memory,
+ * or an unreadable directory).  Failing to add one entry leaves earlier
+ * entries intact.  */
+#define PLAYLIST_ADD_ERROR (-1)
+#define PLAYLIST_ADD_FILE  0
+#define PLAYLIST_ADD_DIR   1
+extern int playlist_add(playlist *pl, const char *path);
+
+/* Randomizes the order of the entries.  Call playlist_seed_random() once
+ * before the first shuffle.  */
+extern void playlist_shuffle(playlist *pl);
+extern void playlist_seed_random(void);
+
+/* Frees every entry and resets the playlist to empty.  */
+extern void playlist_free(playlist *pl);
+
+#endif /* PLAYLIST_H */

--- a/macosx/Makefile
+++ b/macosx/Makefile
@@ -69,7 +69,7 @@ LDLIBS_EXE+=-L. -l$(LIBNAME)
 # Objects
 LIB_OBJ = wm_error.o file_io.o lock.o wildmidi_lib.o reverb.o gus_pat.o
 LIB_OBJ+= f_xmidi.o f_mus.o f_hmp.o f_midi.o f_hmi.o mus2mid.o xmi2mid.o hmp2mid.o hmi2mid.o internal_midi.o patches.o sample.o sf2.o synth.o opl3.o
-PLAYER_OBJ = wm_tty.o msleep.o out_none.o out_wave.o out_coreaudio.o wildmidi.o
+PLAYER_OBJ = wm_tty.o playlist.o msleep.o out_none.o out_wave.o out_coreaudio.o wildmidi.o
 # out_openal.o
 
 .PHONY: clean distclean
@@ -123,6 +123,8 @@ out_openal.o: ../src/player/out_openal.c
 msleep.o: ../src/player/msleep.c
 	$(CC) -c $(CFLAGS_EXE) -o $@ $<
 wm_tty.o: ../src/player/wm_tty.c
+	$(CC) -c $(CFLAGS_EXE) -o $@ $<
+playlist.o: ../src/player/playlist.c
 	$(CC) -c $(CFLAGS_EXE) -o $@ $<
 
 clean:

--- a/mingw/Makefile
+++ b/mingw/Makefile
@@ -53,7 +53,7 @@ LDLIBS_EXE+=-L. -l$(LIBNAME)
 # Objects
 LIB_OBJ = wm_error.o file_io.o lock.o wildmidi_lib.o reverb.o gus_pat.o
 LIB_OBJ+= f_xmidi.o f_mus.o f_hmp.o f_midi.o f_hmi.o mus2mid.o xmi2mid.o hmp2mid.o hmi2mid.o internal_midi.o patches.o sample.o sf2.o synth.o opl3.o
-PLAYER_OBJ = wm_tty.o msleep.o getopt_long.o out_none.o out_wave.o out_win32mm.o wildmidi.o
+PLAYER_OBJ = wm_tty.o playlist.o msleep.o getopt_long.o out_none.o out_wave.o out_win32mm.o wildmidi.o
 # out_openal.o
 
 .PHONY: clean distclean
@@ -103,6 +103,8 @@ out_openal.o: ../src/player/out_openal.c
 msleep.o: ../src/player/msleep.c
 	$(CC) -c $(CFLAGS_EXE) -o $@ $<
 wm_tty.o: ../src/player/wm_tty.c
+	$(CC) -c $(CFLAGS_EXE) -o $@ $<
+playlist.o: ../src/player/playlist.c
 	$(CC) -c $(CFLAGS_EXE) -o $@ $<
 getopt_long.o: ../src/getopt_long.c
 	$(CC) -c $(CFLAGS_EXE) -o $@ $<

--- a/os2/makefile.emx
+++ b/os2/makefile.emx
@@ -45,7 +45,7 @@ CFLAGS_LIB= $(CFLAGS) -DWILDMIDI_BUILD
 CFLAGS_EXE= $(CFLAGS)
 
 OBJ=wm_error.o file_io.o lock.o wildmidi_lib.o reverb.o gus_pat.o f_xmidi.o f_mus.o f_hmp.o f_midi.o f_hmi.o mus2mid.o xmi2mid.o hmp2mid.o hmi2mid.o internal_midi.o patches.o sample.o sf2.o synth.o opl3.o
-PLAYER_OBJ=wm_tty.o msleep.o getopt_long.o out_none.o out_wave.o out_dart.o wildmidi.o
+PLAYER_OBJ=wm_tty.o playlist.o msleep.o getopt_long.o out_none.o out_wave.o out_dart.o wildmidi.o
 
 all: $(LIB_DLL) $(IMPLIB_A) $(IMPLIB_OMF) $(LIBSTATIC) $(PLAYER)
 
@@ -76,6 +76,8 @@ out_wave.o: ../src/player/out_wave.c
 out_dart.o: ../src/player/out_dart.c
 	$(CC) -c $(CFLAGS_EXE) -o $@ $<
 wm_tty.o: ../src/player/wm_tty.c
+	$(CC) -c $(CFLAGS_EXE) -o $@ $<
+playlist.o: ../src/player/playlist.c
 	$(CC) -c $(CFLAGS_EXE) -o $@ $<
 wildmidi.o: ../src/player/wildmidi.c
 	$(CC) -c $(CFLAGS_EXE) -o $@ $<

--- a/os2/makefile.wat
+++ b/os2/makefile.wat
@@ -39,7 +39,7 @@ INCPATH=-I"$(%WATCOM)/h/os2" -I"$(%WATCOM)/h"
 INCLUDES=$(INCPATH) -I. -I"../include"
 
 OBJ=wm_error.obj file_io.obj lock.obj wildmidi_lib.obj reverb.obj gus_pat.obj f_xmidi.obj f_mus.obj f_hmp.obj f_midi.obj f_hmi.obj mus2mid.obj xmi2mid.obj hmp2mid.obj hmi2mid.obj internal_midi.obj patches.obj sample.obj sf2.obj synth.obj opl3.obj
-PLAYER_OBJ=wm_tty.obj msleep.obj getopt_long.obj out_none.obj out_wave.obj out_dart.obj wildmidi.obj
+PLAYER_OBJ=wm_tty.obj playlist.obj msleep.obj getopt_long.obj out_none.obj out_wave.obj out_dart.obj wildmidi.obj
 
 all: $(BLD_TARGET)
 
@@ -69,6 +69,8 @@ sf2.obj: sf2.c
 getopt_long.obj: getopt_long.c
 	wcc386 $(CFLAGS_EXE) $(INCLUDES) -fo=$^@ $<
 wm_tty.obj: wm_tty.c
+	wcc386 $(CFLAGS_EXE) $(INCLUDES) -fo=$^@ $<
+playlist.obj: playlist.c
 	wcc386 $(CFLAGS_EXE) $(INCLUDES) -fo=$^@ $<
 wildmidi.obj: wildmidi.c
 	wcc386 $(CFLAGS_EXE) $(INCLUDES) -fo=$^@ $<

--- a/src/player/CMakeLists.txt
+++ b/src/player/CMakeLists.txt
@@ -19,6 +19,7 @@ SET(wildmidi_executable_SRCS
     out_wave.c
     out_win32mm.c
     wm_tty.c
+    playlist.c
     wildmidi.c
 )
 

--- a/src/player/playlist.c
+++ b/src/player/playlist.c
@@ -162,8 +162,15 @@ static int is_dot_entry(const char *name) {
 #endif
 
 #ifdef PLAYLIST_HAVE_DIRSCAN
-/* Recursively adds the playable files under dir.  Returns 0 on success,
- * -1 if dir itself could not be read. */
+/* Results of a directory walk.  A subdirectory we cannot read is worth a
+ * message but not worth abandoning the rest of the tree for; running out of
+ * memory is, since carrying on would silently hand back a short playlist. */
+#define SCAN_OK        0
+#define SCAN_UNREADABLE (-1)
+#define SCAN_FATAL      (-2)
+
+/* Recursively adds the playable files under dir.  Returns one of the SCAN_
+ * codes above. */
 static int scan_directory(playlist *pl, const char *dir);
 #endif
 
@@ -192,11 +199,11 @@ static int is_walkable_directory(const char *path) {
 static int scan_directory(playlist *pl, const char *dir) {
     DIR *dh = opendir(dir);
     struct dirent *ent;
-    int ret = 0;
+    int ret = SCAN_OK;
 
     if (dh == NULL) {
         fprintf(stderr, "ERROR: cannot read directory %s\r\n", dir);
-        return (-1);
+        return (SCAN_UNREADABLE);
     }
 
     while ((ent = readdir(dh)) != NULL) {
@@ -207,20 +214,20 @@ static int scan_directory(playlist *pl, const char *dir) {
         full = join_path(dir, ent->d_name);
         if (full == NULL) {
             fprintf(stderr, "ERROR: out of memory building playlist\r\n");
-            ret = -1;
+            ret = SCAN_FATAL;
             break;
         }
 
         if (is_walkable_directory(full)) {
             /* An unreadable subdirectory is not fatal: keep collecting the
-             * rest of the tree.  */
-            scan_directory(pl, full);
+             * rest of the tree.  Anything worse aborts the whole walk.  */
+            if (scan_directory(pl, full) == SCAN_FATAL) ret = SCAN_FATAL;
         } else if (has_midi_extension(ent->d_name)) {
-            if (playlist_append(pl, full) < 0) ret = -1;
+            if (playlist_append(pl, full) < 0) ret = SCAN_FATAL;
         }
 
         free(full);
-        if (ret < 0) break;
+        if (ret == SCAN_FATAL) break;
     }
 
     closedir(dh);
@@ -239,18 +246,18 @@ static int scan_directory(playlist *pl, const char *dir) {
     WIN32_FIND_DATAA fd;
     HANDLE h;
     char *pattern = join_path(dir, "*");
-    int ret = 0;
+    int ret = SCAN_OK;
 
     if (pattern == NULL) {
         fprintf(stderr, "ERROR: out of memory building playlist\r\n");
-        return (-1);
+        return (SCAN_FATAL);
     }
 
     h = FindFirstFileA(pattern, &fd);
     free(pattern);
     if (h == INVALID_HANDLE_VALUE) {
         fprintf(stderr, "ERROR: cannot read directory %s\r\n", dir);
-        return (-1);
+        return (SCAN_UNREADABLE);
     }
 
     do {
@@ -261,18 +268,18 @@ static int scan_directory(playlist *pl, const char *dir) {
         full = join_path(dir, fd.cFileName);
         if (full == NULL) {
             fprintf(stderr, "ERROR: out of memory building playlist\r\n");
-            ret = -1;
+            ret = SCAN_FATAL;
             break;
         }
 
         if (fd.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) {
-            scan_directory(pl, full);
+            if (scan_directory(pl, full) == SCAN_FATAL) ret = SCAN_FATAL;
         } else if (has_midi_extension(fd.cFileName)) {
-            if (playlist_append(pl, full) < 0) ret = -1;
+            if (playlist_append(pl, full) < 0) ret = SCAN_FATAL;
         }
 
         free(full);
-        if (ret < 0) break;
+        if (ret == SCAN_FATAL) break;
     } while (FindNextFileA(h, &fd));
 
     FindClose(h);
@@ -293,18 +300,18 @@ static int scan_directory(playlist *pl, const char *dir) {
     HDIR h = HDIR_CREATE;
     ULONG cnt = 1;
     char *pattern = join_path(dir, "*");
-    int ret = 0;
+    int ret = SCAN_OK;
 
     if (pattern == NULL) {
         fprintf(stderr, "ERROR: out of memory building playlist\r\n");
-        return (-1);
+        return (SCAN_FATAL);
     }
 
     if (DosFindFirst((PCSZ)pattern, &h, FILE_NORMAL | FILE_DIRECTORY,
                      &fb, sizeof(fb), &cnt, FIL_STANDARD) != NO_ERROR) {
         free(pattern);
         fprintf(stderr, "ERROR: cannot read directory %s\r\n", dir);
-        return (-1);
+        return (SCAN_UNREADABLE);
     }
     free(pattern);
 
@@ -316,18 +323,18 @@ static int scan_directory(playlist *pl, const char *dir) {
         full = join_path(dir, fb.achName);
         if (full == NULL) {
             fprintf(stderr, "ERROR: out of memory building playlist\r\n");
-            ret = -1;
+            ret = SCAN_FATAL;
             break;
         }
 
         if (fb.attrFile & FILE_DIRECTORY) {
-            scan_directory(pl, full);
+            if (scan_directory(pl, full) == SCAN_FATAL) ret = SCAN_FATAL;
         } else if (has_midi_extension(fb.achName)) {
-            if (playlist_append(pl, full) < 0) ret = -1;
+            if (playlist_append(pl, full) < 0) ret = SCAN_FATAL;
         }
 
         free(full);
-        if (ret < 0) break;
+        if (ret == SCAN_FATAL) break;
         cnt = 1;
     } while (DosFindNext(h, &fb, sizeof(fb), &cnt) == NO_ERROR);
 
@@ -357,25 +364,25 @@ static int path_is_directory(const char *path) {
 static int scan_directory(playlist *pl, const char *dir) {
     BPTR lock = Lock((const STRPTR) dir, ACCESS_READ);
     struct FileInfoBlock *fib;
-    int ret = 0;
+    int ret = SCAN_OK;
 
     if (!lock) {
         fprintf(stderr, "ERROR: cannot read directory %s\r\n", dir);
-        return (-1);
+        return (SCAN_UNREADABLE);
     }
 
     fib = (struct FileInfoBlock *) AllocDosObject(DOS_FIB, NULL);
     if (fib == NULL) {
         UnLock(lock);
         fprintf(stderr, "ERROR: out of memory building playlist\r\n");
-        return (-1);
+        return (SCAN_FATAL);
     }
 
     if (!Examine(lock, fib)) {
         FreeDosObject(DOS_FIB, fib);
         UnLock(lock);
         fprintf(stderr, "ERROR: cannot read directory %s\r\n", dir);
-        return (-1);
+        return (SCAN_UNREADABLE);
     }
 
     while (ExNext(lock, fib)) {
@@ -383,18 +390,18 @@ static int scan_directory(playlist *pl, const char *dir) {
 
         if (full == NULL) {
             fprintf(stderr, "ERROR: out of memory building playlist\r\n");
-            ret = -1;
+            ret = SCAN_FATAL;
             break;
         }
 
         if (fib->fib_DirEntryType > 0) {
-            scan_directory(pl, full);
+            if (scan_directory(pl, full) == SCAN_FATAL) ret = SCAN_FATAL;
         } else if (has_midi_extension((const char *) fib->fib_FileName)) {
-            if (playlist_append(pl, full) < 0) ret = -1;
+            if (playlist_append(pl, full) < 0) ret = SCAN_FATAL;
         }
 
         free(full);
-        if (ret < 0) break;
+        if (ret == SCAN_FATAL) break;
     }
 
     FreeDosObject(DOS_FIB, fib);
@@ -407,13 +414,17 @@ static int scan_directory(playlist *pl, const char *dir) {
 int playlist_add(playlist *pl, const char *path) {
 #ifdef PLAYLIST_HAVE_DIRSCAN
     if (path_is_directory(path)) {
-        if (scan_directory(pl, path) < 0)
-            return PLAYLIST_ADD_ERROR;
-        return PLAYLIST_ADD_DIR;
+        /* A tree we could only read part of still gives us something to
+         * play; only a fatal failure means the playlist cannot be trusted. */
+        switch (scan_directory(pl, path)) {
+        case SCAN_FATAL:      return PLAYLIST_ADD_FATAL;
+        case SCAN_UNREADABLE: return PLAYLIST_ADD_ERROR;
+        default:              return PLAYLIST_ADD_DIR;
+        }
     }
 #endif
     if (playlist_append(pl, path) < 0)
-        return PLAYLIST_ADD_ERROR;
+        return PLAYLIST_ADD_FATAL;
     return PLAYLIST_ADD_FILE;
 }
 

--- a/src/player/playlist.c
+++ b/src/player/playlist.c
@@ -1,0 +1,445 @@
+/*
+ * playlist.c -- WildMidi player playlist handling
+ *
+ * Builds the list of files to play from the command line, expanding any
+ * directory into the midi files found under it, and optionally shuffles it.
+ *
+ * Copyright (C) WildMidi Developers 2026
+ *
+ * This file is part of WildMIDI.
+ *
+ * WildMIDI is free software: you can redistribute and/or modify the player
+ * under the terms of the GNU General Public License and you can redistribute
+ * and/or modify the library under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation, either version 3 of
+ * the licenses, or(at your option) any later version.
+ *
+ * WildMIDI is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License and
+ * the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License and the
+ * GNU Lesser General Public License along with WildMIDI.  If not,  see
+ * <http://www.gnu.org/licenses/>.
+ */
+
+#include "config.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <limits.h>
+#include <time.h>
+
+/* Directory scanning needs a platform backend.  Where we have none, a
+ * directory argument is simply passed through as a file name and the
+ * library reports that it cannot be opened. */
+#if defined(_WIN32)
+#define PLAYLIST_HAVE_DIRSCAN 1
+#include <windows.h>
+
+#elif defined(WILDMIDI_AMIGA)
+#define PLAYLIST_HAVE_DIRSCAN 1
+#include <proto/exec.h>
+#include <proto/dos.h>
+#ifdef __amigaos4__
+#include <dos/obsolete.h>
+#endif
+
+#elif defined(__OS2__) || defined(__EMX__)
+#define PLAYLIST_HAVE_DIRSCAN 1
+#define INCL_DOS
+#define INCL_DOSERRORS
+#include <os2.h>
+
+#elif defined(__DJGPP__) || defined(_3DS) || defined(GEKKO) || \
+      defined(__vita__) || defined(__SWITCH__) || defined(__riscos__) || \
+      defined(__unix) || defined(__unix__) || defined(__APPLE__)
+#define PLAYLIST_HAVE_DIRSCAN 1
+#define PLAYLIST_USE_DIRENT 1
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <dirent.h>
+#endif
+
+#include "playlist.h"
+#include "filenames.h"
+
+#ifdef PLAYLIST_HAVE_DIRSCAN
+/* Extensions we queue when walking a directory.  Files named explicitly on
+ * the command line bypass this: the library sniffs content, not names, so a
+ * deliberately named file still plays.  */
+static const char *const midi_extensions[] = {
+    "mid", "midi", "rmi", "kar", "mus", "xmi", "hmp", "hmi", NULL
+};
+
+static int has_midi_extension(const char *name) {
+    const char *ext = strrchr(name, '.');
+    int i;
+
+    if (ext == NULL) return 0;
+    ext++;
+
+    for (i = 0; midi_extensions[i] != NULL; i++) {
+        const char *a = ext;
+        const char *b = midi_extensions[i];
+        while (*a && *b) {
+            int ca = *a, cb = *b;
+            if (ca >= 'A' && ca <= 'Z') ca += 'a' - 'A';
+            if (cb >= 'A' && cb <= 'Z') cb += 'a' - 'A';
+            if (ca != cb) break;
+            a++; b++;
+        }
+        if (!*a && !*b) return 1;
+    }
+    return 0;
+}
+#endif /* PLAYLIST_HAVE_DIRSCAN */
+
+/* Appends path verbatim, growing the array as needed. */
+static int playlist_append(playlist *pl, const char *path) {
+    char *copy;
+
+    if (pl->count == pl->alloc) {
+        /* Cap growth so neither the doubling nor the byte count can wrap. */
+        size_t limit = (size_t)-1 / sizeof(char *);
+        unsigned int maxalloc;
+        unsigned int newalloc;
+        char **grown;
+
+        if (limit > (size_t)(UINT_MAX / 2)) limit = (size_t)(UINT_MAX / 2);
+        maxalloc = (unsigned int) limit;
+        if (pl->alloc >= maxalloc) {
+            fprintf(stderr, "ERROR: playlist is too large\r\n");
+            return (-1);
+        }
+        newalloc = pl->alloc ? pl->alloc * 2 : 64;
+        if (newalloc > maxalloc) newalloc = maxalloc;
+
+        grown = (char **) realloc(pl->files, (size_t) newalloc * sizeof(char *));
+        if (grown == NULL) {
+            fprintf(stderr, "ERROR: out of memory building playlist\r\n");
+            return (-1);
+        }
+        pl->files = grown;
+        pl->alloc = newalloc;
+    }
+
+    copy = (char *) malloc(strlen(path) + 1);
+    if (copy == NULL) {
+        fprintf(stderr, "ERROR: out of memory building playlist\r\n");
+        return (-1);
+    }
+    strcpy(copy, path);
+    pl->files[pl->count++] = copy;
+    return (0);
+}
+
+#ifdef PLAYLIST_HAVE_DIRSCAN
+/* Joins dir and name into a freshly allocated path. */
+static char *join_path(const char *dir, const char *name) {
+    size_t dirlen = strlen(dir);
+    size_t namelen = strlen(name);
+    int need_sep = (dirlen != 0 && !IS_DIR_SEPARATOR(dir[dirlen - 1]));
+    char *out = (char *) malloc(dirlen + (need_sep ? 1 : 0) + namelen + 1);
+
+    if (out == NULL) return NULL;
+    memcpy(out, dir, dirlen);
+    if (need_sep) out[dirlen++] = DIR_SEPARATOR_CHAR;
+    memcpy(out + dirlen, name, namelen + 1);
+    return out;
+}
+#endif /* PLAYLIST_HAVE_DIRSCAN */
+
+#if defined(PLAYLIST_HAVE_DIRSCAN) && !defined(WILDMIDI_AMIGA)
+/* True for the "." and ".." entries every directory carries.  AmigaDOS
+ * does not report them, so its scanner has no need for this. */
+static int is_dot_entry(const char *name) {
+    return (name[0] == '.' && (name[1] == '\0' ||
+           (name[1] == '.' && name[2] == '\0')));
+}
+#endif
+
+#ifdef PLAYLIST_HAVE_DIRSCAN
+/* Recursively adds the playable files under dir.  Returns 0 on success,
+ * -1 if dir itself could not be read. */
+static int scan_directory(playlist *pl, const char *dir);
+#endif
+
+#if defined(PLAYLIST_USE_DIRENT)
+
+static int path_is_directory(const char *path) {
+    struct stat st;
+    if (stat(path, &st) != 0) return 0;
+    return S_ISDIR(st.st_mode);
+}
+
+/* A directory we should descend into.  Symlinks are not followed: a link
+ * pointing at one of its own ancestors would otherwise make us recurse
+ * until the OS runs out of path, collecting duplicates along the way. */
+static int is_walkable_directory(const char *path) {
+#ifdef S_ISLNK
+    struct stat st;
+    if (lstat(path, &st) != 0) return 0;
+    if (S_ISLNK(st.st_mode)) return 0;
+    return S_ISDIR(st.st_mode);
+#else
+    return path_is_directory(path);
+#endif
+}
+
+static int scan_directory(playlist *pl, const char *dir) {
+    DIR *dh = opendir(dir);
+    struct dirent *ent;
+    int ret = 0;
+
+    if (dh == NULL) {
+        fprintf(stderr, "ERROR: cannot read directory %s\r\n", dir);
+        return (-1);
+    }
+
+    while ((ent = readdir(dh)) != NULL) {
+        char *full;
+
+        if (is_dot_entry(ent->d_name)) continue;
+
+        full = join_path(dir, ent->d_name);
+        if (full == NULL) {
+            fprintf(stderr, "ERROR: out of memory building playlist\r\n");
+            ret = -1;
+            break;
+        }
+
+        if (is_walkable_directory(full)) {
+            /* An unreadable subdirectory is not fatal: keep collecting the
+             * rest of the tree.  */
+            scan_directory(pl, full);
+        } else if (has_midi_extension(ent->d_name)) {
+            if (playlist_append(pl, full) < 0) ret = -1;
+        }
+
+        free(full);
+        if (ret < 0) break;
+    }
+
+    closedir(dh);
+    return (ret);
+}
+
+#elif defined(_WIN32)
+
+static int path_is_directory(const char *path) {
+    DWORD attr = GetFileAttributesA(path);
+    if (attr == INVALID_FILE_ATTRIBUTES) return 0;
+    return (attr & FILE_ATTRIBUTE_DIRECTORY) != 0;
+}
+
+static int scan_directory(playlist *pl, const char *dir) {
+    WIN32_FIND_DATAA fd;
+    HANDLE h;
+    char *pattern = join_path(dir, "*");
+    int ret = 0;
+
+    if (pattern == NULL) {
+        fprintf(stderr, "ERROR: out of memory building playlist\r\n");
+        return (-1);
+    }
+
+    h = FindFirstFileA(pattern, &fd);
+    free(pattern);
+    if (h == INVALID_HANDLE_VALUE) {
+        fprintf(stderr, "ERROR: cannot read directory %s\r\n", dir);
+        return (-1);
+    }
+
+    do {
+        char *full;
+
+        if (is_dot_entry(fd.cFileName)) continue;
+
+        full = join_path(dir, fd.cFileName);
+        if (full == NULL) {
+            fprintf(stderr, "ERROR: out of memory building playlist\r\n");
+            ret = -1;
+            break;
+        }
+
+        if (fd.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) {
+            scan_directory(pl, full);
+        } else if (has_midi_extension(fd.cFileName)) {
+            if (playlist_append(pl, full) < 0) ret = -1;
+        }
+
+        free(full);
+        if (ret < 0) break;
+    } while (FindNextFileA(h, &fd));
+
+    FindClose(h);
+    return (ret);
+}
+
+#elif defined(__OS2__) || defined(__EMX__)
+
+static int path_is_directory(const char *path) {
+    FILESTATUS3 fs;
+    if (DosQueryPathInfo((PCSZ)path, FIL_STANDARD, &fs, sizeof(fs)) != NO_ERROR)
+        return 0;
+    return (fs.attrFile & FILE_DIRECTORY) != 0;
+}
+
+static int scan_directory(playlist *pl, const char *dir) {
+    FILEFINDBUF3 fb;
+    HDIR h = HDIR_CREATE;
+    ULONG cnt = 1;
+    char *pattern = join_path(dir, "*");
+    int ret = 0;
+
+    if (pattern == NULL) {
+        fprintf(stderr, "ERROR: out of memory building playlist\r\n");
+        return (-1);
+    }
+
+    if (DosFindFirst((PCSZ)pattern, &h, FILE_NORMAL | FILE_DIRECTORY,
+                     &fb, sizeof(fb), &cnt, FIL_STANDARD) != NO_ERROR) {
+        free(pattern);
+        fprintf(stderr, "ERROR: cannot read directory %s\r\n", dir);
+        return (-1);
+    }
+    free(pattern);
+
+    do {
+        char *full;
+
+        if (is_dot_entry(fb.achName)) continue;
+
+        full = join_path(dir, fb.achName);
+        if (full == NULL) {
+            fprintf(stderr, "ERROR: out of memory building playlist\r\n");
+            ret = -1;
+            break;
+        }
+
+        if (fb.attrFile & FILE_DIRECTORY) {
+            scan_directory(pl, full);
+        } else if (has_midi_extension(fb.achName)) {
+            if (playlist_append(pl, full) < 0) ret = -1;
+        }
+
+        free(full);
+        if (ret < 0) break;
+        cnt = 1;
+    } while (DosFindNext(h, &fb, sizeof(fb), &cnt) == NO_ERROR);
+
+    DosFindClose(h);
+    return (ret);
+}
+
+#elif defined(WILDMIDI_AMIGA)
+
+static int path_is_directory(const char *path) {
+    BPTR lock = Lock((const STRPTR) path, ACCESS_READ);
+    int isdir = 0;
+
+    if (lock) {
+        struct FileInfoBlock *fib = (struct FileInfoBlock *)
+                              AllocDosObject(DOS_FIB, NULL);
+        if (fib != NULL) {
+            if (Examine(lock, fib))
+                isdir = (fib->fib_DirEntryType > 0);
+            FreeDosObject(DOS_FIB, fib);
+        }
+        UnLock(lock);
+    }
+    return isdir;
+}
+
+static int scan_directory(playlist *pl, const char *dir) {
+    BPTR lock = Lock((const STRPTR) dir, ACCESS_READ);
+    struct FileInfoBlock *fib;
+    int ret = 0;
+
+    if (!lock) {
+        fprintf(stderr, "ERROR: cannot read directory %s\r\n", dir);
+        return (-1);
+    }
+
+    fib = (struct FileInfoBlock *) AllocDosObject(DOS_FIB, NULL);
+    if (fib == NULL) {
+        UnLock(lock);
+        fprintf(stderr, "ERROR: out of memory building playlist\r\n");
+        return (-1);
+    }
+
+    if (!Examine(lock, fib)) {
+        FreeDosObject(DOS_FIB, fib);
+        UnLock(lock);
+        fprintf(stderr, "ERROR: cannot read directory %s\r\n", dir);
+        return (-1);
+    }
+
+    while (ExNext(lock, fib)) {
+        char *full = join_path(dir, (const char *) fib->fib_FileName);
+
+        if (full == NULL) {
+            fprintf(stderr, "ERROR: out of memory building playlist\r\n");
+            ret = -1;
+            break;
+        }
+
+        if (fib->fib_DirEntryType > 0) {
+            scan_directory(pl, full);
+        } else if (has_midi_extension((const char *) fib->fib_FileName)) {
+            if (playlist_append(pl, full) < 0) ret = -1;
+        }
+
+        free(full);
+        if (ret < 0) break;
+    }
+
+    FreeDosObject(DOS_FIB, fib);
+    UnLock(lock);
+    return (ret);
+}
+
+#endif /* platform directory scanners */
+
+int playlist_add(playlist *pl, const char *path) {
+#ifdef PLAYLIST_HAVE_DIRSCAN
+    if (path_is_directory(path)) {
+        if (scan_directory(pl, path) < 0)
+            return PLAYLIST_ADD_ERROR;
+        return PLAYLIST_ADD_DIR;
+    }
+#endif
+    if (playlist_append(pl, path) < 0)
+        return PLAYLIST_ADD_ERROR;
+    return PLAYLIST_ADD_FILE;
+}
+
+void playlist_seed_random(void) {
+    srand((unsigned int) time(NULL));
+}
+
+void playlist_shuffle(playlist *pl) {
+    unsigned int i;
+
+    /* Fisher-Yates */
+    for (i = pl->count; i > 1; i--) {
+        unsigned int j = (unsigned int) (rand() % (int) i);
+        char *tmp = pl->files[i - 1];
+        pl->files[i - 1] = pl->files[j];
+        pl->files[j] = tmp;
+    }
+}
+
+void playlist_free(playlist *pl) {
+    unsigned int i;
+
+    for (i = 0; i < pl->count; i++)
+        free(pl->files[i]);
+    free(pl->files);
+    pl->files = NULL;
+    pl->count = 0;
+    pl->alloc = 0;
+}

--- a/src/player/wildmidi.c
+++ b/src/player/wildmidi.c
@@ -40,6 +40,7 @@
 
 #include "wildplay.h"
 #include "filenames.h"
+#include "playlist.h"
 #include "wm_tty.h"
 
 /* available outputs */
@@ -266,6 +267,7 @@ static struct option const long_options[] = {
     { "playto", 1, NULL, 'j'},
     { "opl3", 0, NULL, 'O' },
     { "loop", 0, NULL, 'L' },
+    { "shuffle", 0, NULL, 'S' },
     { NULL, 0, NULL, 0 }
 };
 
@@ -305,7 +307,12 @@ static void do_help(void) {
     printf("  -O    --opl3        Use built-in OPL3 FM synth (no cfg/sf2 needed)\n");
     printf("  -m V  --mastervol=V Set the master volume (0..127), default is 100\n");
     printf("  -b    --reverb      Enable final output reverb engine\n");
-    printf("  -L    --loop        Loop the file at end-of-track\n\n");
+    printf("Playlist Options:\n");
+    printf("  -L    --loop        Loop a single file at end-of-track, or repeat\n");
+    printf("                      the playlist when more than one file is given\n");
+    printf("  -S    --shuffle     Play the files in random order\n\n");
+    printf("A filename may also be a directory, which is searched recursively\n");
+    printf("for playable files.\n\n");
 }
 
 static void do_available_outputs(void) {
@@ -330,7 +337,7 @@ static void do_version(void) {
 }
 
 static void do_syntax(void) {
-    printf("Usage: wildmidi [options] filename.mid\n\n");
+    printf("Usage: wildmidi [options] <filename.mid|directory> ...\n\n");
 }
 
 static char config_file[1024];
@@ -376,6 +383,13 @@ int main(int argc, char **argv) {
     unsigned long int play_from = 0;
     unsigned long int play_to = 0;
 
+    playlist pl = { NULL, 0, 0 };
+    unsigned int pl_index = 0;
+    int want_loop = 0;
+    int want_shuffle = 0;
+    int played_any = 0;
+    int from_directory = 0;
+
     memset(lyrics,' ',MAX_LYRIC_CHAR);
     memset(display_lyrics,' ',MAX_DISPLAY_LYRICS);
 
@@ -386,7 +400,7 @@ int main(int argc, char **argv) {
 
     do_version();
     while (1) {
-        i = getopt_long(argc, argv, "0vho:tx:g:P:f:lr:c:m:btak:p:ed:nsi:j:OL", long_options,
+        i = getopt_long(argc, argv, "0vho:tx:g:P:f:lr:c:m:btak:p:ed:nsi:j:OLS", long_options,
                 &option_index);
         if (i == -1)
             break;
@@ -426,8 +440,11 @@ int main(int argc, char **argv) {
         case 'b': /* Reverb */
             mixer_options |= WM_MO_REVERB;
             break;
-        case 'L': /* Loop the file */
-            mixer_options |= WM_MO_LOOP;
+        case 'L': /* Loop a single file, or repeat the playlist */
+            want_loop = 1;
+            break;
+        case 'S': /* Shuffle the playlist */
+            want_shuffle = 1;
             break;
         case 'm': /* Master Volume */
             master_volume = (uint8_t) atoi(optarg);
@@ -547,6 +564,37 @@ int main(int argc, char **argv) {
         return (0);
     }
 
+    /* Build the playlist, expanding any directory into the files under it. */
+    if (!test_midi) {
+        for (i = optind; i < argc; i++) {
+            /* An unusable argument is not fatal as long as something else
+             * on the command line gave us files to play.  */
+            if (playlist_add(&pl, argv[i]) == PLAYLIST_ADD_DIR)
+                from_directory = 1;
+        }
+
+        if (pl.count == 0) {
+            fprintf(stderr, "ERROR: No files to play\r\n");
+            playlist_free(&pl);
+            do_syntax();
+            return (1);
+        }
+
+        if (want_shuffle) {
+            playlist_seed_random();
+            playlist_shuffle(&pl);
+        }
+
+        /* With a single named file -L loops it at end-of-track, which the
+         * library does for us.  Anything that came from a directory is a
+         * playlist and repeats here instead, even when it holds one file,
+         * or we would never reach the next file. */
+        if (want_loop && pl.count == 1 && !from_directory)
+            mixer_options |= WM_MO_LOOP;
+    } else if (want_loop) {
+        mixer_options |= WM_MO_LOOP;
+    }
+
     if (!config_file[0]) {
         strncpy(config_file, WILDMIDI_CFG, sizeof(config_file));
         config_file[sizeof(config_file) - 1] = 0;
@@ -591,22 +639,23 @@ int main(int argc, char **argv) {
 
     WildMidi_MasterVolume(master_volume);
 
-    while (optind < argc || test_midi) {
+    while (pl_index < pl.count || test_midi) {
         WildMidi_ClearError();
         if (!test_midi) {
-            const char *real_file = FIND_LAST_DIRSEP(argv[optind]);
+            const char *real_file = FIND_LAST_DIRSEP(pl.files[pl_index]);
 
-            if (!real_file) real_file = argv[optind];
+            if (!real_file) real_file = pl.files[pl_index];
             else real_file++;
             printf("\rPlaying %s ", real_file);
 
-            midi_ptr = WildMidi_Open(argv[optind]);
-            optind++;
+            midi_ptr = WildMidi_Open(pl.files[pl_index]);
+            pl_index++;
             if (midi_ptr == NULL) {
                 ret_err = WildMidi_GetError();
                 printf(" Skipping: %s\r\n",ret_err);
-                continue;
+                goto NEXTFILE;
             }
+            played_any = 1;
         } else {
             if (test_count == midi_test_max) {
                 break;
@@ -745,8 +794,10 @@ int main(int argc, char **argv) {
                         fprintf(stderr, "%s\r\n",ret_err);
                         WildMidi_ClearError();
                     } else {
-                        char *real_file = FIND_LAST_DIRSEP(argv[optind-1]);
-                        if (!real_file) real_file = argv[optind-1];
+                        char *cur_file = test_midi ? (char *)"testmidi" :
+                                                     pl.files[pl_index-1];
+                        char *real_file = FIND_LAST_DIRSEP(cur_file);
+                        if (!real_file) real_file = cur_file;
                         else real_file++;
                         mk_midifile_name(real_file);
                         printf("\rWriting %s: %u bytes.\r\n", midi_file, getmidisize);
@@ -840,6 +891,20 @@ int main(int argc, char **argv) {
         }
         memset(output_buffer, 0, 16384);
         available_outputs[playback_id]->send_out(output_buffer, 16384);
+
+        NEXTFILE:
+        /* -L with more than one file repeats the whole playlist.  Give up if
+         * a full pass played nothing, so a list of bad files cannot spin. */
+        if (want_loop && !test_midi && pl_index >= pl.count) {
+            if (!played_any) {
+                fprintf(stderr, "Nothing in the playlist could be played.\r\n");
+                break;
+            }
+            played_any = 0;
+            pl_index = 0;
+            if (want_shuffle)
+                playlist_shuffle(&pl);
+        }
     }
 
 end1:
@@ -850,6 +915,7 @@ end1:
 end2:
     available_outputs[playback_id]->close_out();
     free(output_buffer);
+    playlist_free(&pl);
     if (WildMidi_Shutdown() == -1) {
         ret_err = WildMidi_GetError();
         fprintf(stderr, "OOPS: failure shutting down libWildMidi\r\n%s\r\n", ret_err);

--- a/src/player/wildmidi.c
+++ b/src/player/wildmidi.c
@@ -567,9 +567,15 @@ int main(int argc, char **argv) {
     /* Build the playlist, expanding any directory into the files under it. */
     if (!test_midi) {
         for (i = optind; i < argc; i++) {
-            /* An unusable argument is not fatal as long as something else
-             * on the command line gave us files to play.  */
-            if (playlist_add(&pl, argv[i]) == PLAYLIST_ADD_DIR)
+            /* An unusable argument is not fatal as long as something else on
+             * the command line gave us files to play, but running out of
+             * memory means we can no longer trust what we collected. */
+            res = playlist_add(&pl, argv[i]);
+            if (res == PLAYLIST_ADD_FATAL) {
+                playlist_free(&pl);
+                return (1);
+            }
+            if (res == PLAYLIST_ADD_DIR)
                 from_directory = 1;
         }
 

--- a/win32wat/makefile
+++ b/win32wat/makefile
@@ -41,7 +41,7 @@ INCPATH=-I"$(%WATCOM)/h/nt" -I"$(%WATCOM)/h"
 INCLUDES=$(INCPATH) -I. -I"../include"
 
 OBJ=wm_error.obj file_io.obj lock.obj wildmidi_lib.obj reverb.obj gus_pat.obj f_xmidi.obj f_mus.obj f_hmp.obj f_midi.obj f_hmi.obj mus2mid.obj xmi2mid.obj hmp2mid.obj hmi2mid.obj internal_midi.obj patches.obj sample.obj sf2.obj synth.obj opl3.obj
-PLAYER_OBJ=wm_tty.obj msleep.obj getopt_long.obj out_none.obj out_wave.obj out_openal.obj out_win32mm.obj wildmidi.obj
+PLAYER_OBJ=wm_tty.obj playlist.obj msleep.obj getopt_long.obj out_none.obj out_wave.obj out_openal.obj out_win32mm.obj wildmidi.obj
 
 all: $(BLD_TARGET)
 
@@ -71,6 +71,8 @@ sf2.obj: sf2.c
 getopt_long.obj: getopt_long.c
 	wcc386 $(CFLAGS_EXE) $(INCLUDES) -fo=$^@ $<
 wm_tty.obj: wm_tty.c
+	wcc386 $(CFLAGS_EXE) $(INCLUDES) -fo=$^@ $<
+playlist.obj: playlist.c
 	wcc386 $(CFLAGS_EXE) $(INCLUDES) -fo=$^@ $<
 wildmidi.obj: wildmidi.c
 	wcc386 $(CFLAGS_EXE) $(INCLUDES) -fo=$^@ $<


### PR DESCRIPTION
A filename given to the player may now be a directory, which is searched recursively for files to play.  Directory entries are filtered by extension (.mid .midi .rmi .kar .mus .xmi .hmp .hmi, case-insensitive) so a large music folder does not queue its cover art and readme files. Files named directly on the command line are still played regardless of their name, since the library detects the format from file contents.

New -S/--shuffle plays the collected files in random order.

-L/--loop is now context-sensitive: with a single file it sets WM_MO_LOOP and the library loops it at end-of-track as before, but with a playlist it repeats the playlist instead, reshuffling each pass when combined with -S.  WM_MO_LOOP is deliberately not set in the multi-file case, as it is a global mixer option that would loop the first song forever and never advance.  A pass that plays nothing ends the loop so a playlist of unreadable files cannot spin.

Playlist collection lives in a new playlist.c: dirent for unix/djgpp, FindFirstFileA for Win32, DosFindFirst for OS/2.  Other targets report an error for directory arguments; explicit file lists and shuffle still work everywhere.

Also fixes an out-of-bounds read in the 'm' (save as midi) key handler, which indexed argv[optind-1] past the arguments in --test_midi mode.

Closes: https://github.com/Mindwerks/wildmidi/issues/215