### PR TITLE
Add CC1 modulation wheel (vibrato) support

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,9 @@ CHANGELOG
 * Yamaha MA-series FM synthesis for SMAF: a file carrying a custom FM voice
   bank plays with its own instruments and embedded ADPCM percussion instead
   of a General MIDI approximation. `WANT_MAFM=ON`; see `docs/SMAF_FM.md`.
+* Modulation wheel (CC 1) support, previously parsed but discarded: GUS
+  patches gain a 5Hz vibrato LFO, while SF2 voices and the MA FM synth
+  route the wheel to their vibrato LFO depth (bug #143.)
 * Player: playlist support. A filename given to the player may now be a
   directory, which is searched recursively for files to play (bug #215.)
 * Player: new `-S/--shuffle` switch plays the files in random order.

--- a/include/internal_midi.h
+++ b/include/internal_midi.h
@@ -24,6 +24,26 @@
 #ifndef __INTERNAL_MIDI_H
 #define __INTERNAL_MIDI_H
 
+/*
+ * Vibrato LFO (CC1 modulation wheel).
+ *
+ * GUS patches carry no usable LFO rate, so - like TiMidity++ does when an
+ * instrument has no intrinsic vibrato - we run a fixed 5Hz triangle LFO and
+ * scale its depth by the wheel position. Depth at full wheel defaults to
+ * 50 cents, matching the SF2.01 s8.4.4 default CC1->vibLfoToPitch modulator
+ * that FluidSynth installs, and is settable via RPN 5.
+ *
+ * The LFO is updated once per VIB_BLOCK output samples rather than per sample:
+ * at 5Hz a 64 sample block is ~1.5ms of phase error at 44.1kHz, inaudible,
+ * and it keeps the mixer inner loop cheap on slow targets (DOS, Amiga).
+ */
+#define VIB_RATE_HZ      5
+#define VIB_BLOCK        64
+#define VIB_PHASE_BITS   16
+#define VIB_PHASE_MASK   0xFFFF
+#define VIB_DEPTH_DEFAULT 50   /* cents at full wheel */
+#define VIB_DEPTH_MAX    600   /* clamp, same ceiling as TiMidity++ */
+
 struct _channel {
     uint8_t bank;
     struct _patch *patch;
@@ -41,6 +61,8 @@ struct _channel {
     uint16_t reg_data;
     uint8_t reg_non;
     uint8_t isdrum;
+    uint8_t modulation;      /* CC1 modulation wheel, 0-127 */
+    int16_t mod_depth_range; /* RPN 5, vibrato depth at full wheel, in cents */
 };
 
 struct _event_data {
@@ -70,6 +92,11 @@ struct _note {
     uint32_t right_mix_volume;
     uint8_t is_off;
     uint8_t ignore_chan_events;
+    /* Vibrato LFO. When vib_depth is zero the mixers skip all LFO work and
+       sample_inc stays the plain unmodulated increment. */
+    int32_t vib_depth;    /* pitch swing at full LFO travel, in cents */
+    uint16_t vib_phase;   /* 0..VIB_PHASE_MASK, wraps freely */
+    uint16_t vib_inc;     /* phase advance per LFO update block */
 };
 
 struct _mdi;
@@ -81,6 +108,7 @@ enum _event_type {
     ev_note_on,
     ev_aftertouch,
     ev_control_bank_select,
+    ev_control_channel_modulation,
     ev_control_data_entry_course,
     ev_control_channel_volume,
     ev_control_channel_balance,
@@ -160,6 +188,10 @@ struct _mdi {
 
     uint8_t is_type2;
 
+    /* counts output samples toward the next vibrato LFO update; kept on the
+       mdi so LFO phase stays continuous across output buffer boundaries */
+    uint32_t vib_block_count;
+
     char *lyric;
 
     void *sf2_synth; /* per-mdi TinySoundFont instance, NULL unless a soundfont is loaded */
@@ -180,6 +212,13 @@ extern void _WM_do_note_off(struct _mdi *mdi, struct _event_data *data);
 extern void _WM_do_note_on(struct _mdi *mdi, struct _event_data *data);
 extern void _WM_do_aftertouch(struct _mdi *mdi, struct _event_data *data);
 extern void _WM_do_control_bank_select(struct _mdi *mdi, struct _event_data *data);
+extern void _WM_do_control_channel_modulation(struct _mdi *mdi, struct _event_data *data);
+/* Advances a note's vibrato LFO one VIB_BLOCK and updates its sample_inc.
+   Only call when nte->vib_depth is non-zero. */
+extern void _WM_update_note_vibrato(struct _mdi *mdi, struct _note *nte);
+/* As above but without advancing the LFO, for re-applying a pitch bend at the
+   current phase. Only call when nte->vib_depth is non-zero. */
+extern void _WM_update_note_vibrato_at_phase(struct _mdi *mdi, struct _note *nte);
 extern void _WM_do_control_data_entry_course(struct _mdi *mdi, struct _event_data *data);
 extern void _WM_do_control_channel_volume(struct _mdi *mdi, struct _event_data *data);
 extern void _WM_do_control_channel_balance(struct _mdi *mdi, struct _event_data *data);

--- a/src/f_midi.c
+++ b/src/f_midi.c
@@ -579,6 +579,14 @@ _WM_Event2Midi(struct _mdi *mdi, uint8_t **out, uint32_t *outsize) {
             (*out)[out_ofs++] = 0;
             (*out)[out_ofs++] = event->event_data.data.value & 0xff;
             break;
+        case ev_control_channel_modulation:
+            if (running_event != (0xb0 | event->event_data.channel)) {
+                (*out)[out_ofs++] = 0xb0 | event->event_data.channel;
+                running_event = (*out)[out_ofs - 1];
+            }
+            (*out)[out_ofs++] = 1;
+            (*out)[out_ofs++] = event->event_data.data.value & 0xff;
+            break;
         case ev_control_data_entry_course:
             /* DEBUG */
             /* fprintf(stderr,"Control Data Entry Course: %u %.4x\r\n",event->event_data.channel, event->event_data.data); */

--- a/src/internal_midi.c
+++ b/src/internal_midi.c
@@ -656,7 +656,10 @@ void _WM_do_note_off(struct _mdi *mdi, struct _event_data *data) {
     }
 }
 
-static inline uint32_t get_inc(struct _mdi *mdi, struct _note *nte) {
+/* cents_adjust is an extra detune applied on top of the channel pitch bend,
+   used by the vibrato LFO. Pass 0 for the unmodulated increment. */
+static inline uint32_t get_inc_detune(struct _mdi *mdi, struct _note *nte,
+                                      int32_t cents_adjust) {
     int ch = nte->noteid >> 8;
     int32_t note_f;
     uint32_t freq;
@@ -666,7 +669,7 @@ static inline uint32_t get_inc(struct _mdi *mdi, struct _note *nte) {
     } else {
         note_f = (nte->noteid & 0x7f) * 100;
     }
-    note_f += mdi->channel[ch].pitch_adjust;
+    note_f += mdi->channel[ch].pitch_adjust + cents_adjust;
     {
         /* Apply GUS keyboard frequency scaling (Ultrasound SDK 13.4).
            int64 intermediate: guards against int32 overflow on corrupt
@@ -683,6 +686,102 @@ static inline uint32_t get_inc(struct _mdi *mdi, struct _note *nte) {
     freq = _WM_freq_table[(note_f % 1200)] >> (10 - (note_f / 1200));
     return (((freq / ((_WM_SampleRate * 100) / 1024)) * 1024
              / nte->sample->inc_div));
+}
+
+static inline uint32_t get_inc(struct _mdi *mdi, struct _note *nte) {
+    return get_inc_detune(mdi, nte, 0);
+}
+
+/*
+ * Vibrato depth for a channel, in cents at full LFO travel. Zero means the
+ * note needs no LFO processing at all, which is the common case.
+ */
+static inline int32_t get_vib_depth(struct _mdi *mdi, uint8_t ch) {
+    int32_t depth;
+
+    if (mdi->channel[ch].modulation == 0)
+        return 0;
+
+    depth = ((int32_t)mdi->channel[ch].modulation
+             * mdi->channel[ch].mod_depth_range) / 127;
+
+    if (depth > VIB_DEPTH_MAX)
+        depth = VIB_DEPTH_MAX;
+    return depth;
+}
+
+/*
+ * Set up (or tear down) the LFO on a single note. Called when CC1 changes and
+ * at note-on. Resets LFO phase so vibrato always starts from centre pitch.
+ */
+static void set_note_vibrato(struct _mdi *mdi, struct _note *nte) {
+    uint8_t ch = nte->noteid >> 8;
+    int32_t depth = get_vib_depth(mdi, ch);
+
+    nte->vib_depth = depth;
+    /* Phase 0 is the centre of the triangle, so sample_inc is the plain
+       unmodulated increment either way; the LFO takes over from the next
+       block onwards. */
+    nte->vib_phase = 0;
+    nte->sample_inc = get_inc(mdi, nte);
+
+    if (depth == 0) {
+        nte->vib_inc = 0;
+        return;
+    }
+
+    /* phase advance per VIB_BLOCK samples for a VIB_RATE_HZ cycle, rounded
+       to nearest so the LFO rate stays accurate at any sample rate */
+    nte->vib_inc = (uint16_t)((((uint32_t)VIB_RATE_HZ * VIB_BLOCK
+                                * (VIB_PHASE_MASK + 1))
+                               + (_WM_SampleRate / 2)) / _WM_SampleRate);
+    if (nte->vib_inc == 0)
+        nte->vib_inc = 1;
+}
+
+/*
+ * Advance one note's LFO by a block and recompute its sample_inc.
+ * Triangle wave: cheap, and matches the GUS/TiMidity heritage.
+ */
+void _WM_update_note_vibrato_at_phase(struct _mdi *mdi, struct _note *nte) {
+    int32_t tri;
+    int32_t cents;
+
+    /* map phase to a symmetric bipolar triangle in [-32768, +32768] */
+    tri = (int32_t)nte->vib_phase;
+    if (tri < 16384) {
+        tri = tri * 2;                    /* rise 0 -> +32768 */
+    } else if (tri < 49152) {
+        tri = 65536 - (tri * 2);          /* fall +32768 -> -32768 */
+    } else {
+        tri = (tri * 2) - 131072;         /* rise -32768 -> 0 */
+    }
+
+    cents = (nte->vib_depth * tri) / 32768;
+    nte->sample_inc = get_inc_detune(mdi, nte, cents);
+}
+
+/*
+ * Advance the LFO one block, then apply it.
+ */
+void _WM_update_note_vibrato(struct _mdi *mdi, struct _note *nte) {
+    nte->vib_phase = (uint16_t)((nte->vib_phase + nte->vib_inc)
+                                & VIB_PHASE_MASK);
+    _WM_update_note_vibrato_at_phase(mdi, nte);
+}
+
+/*
+ * Re-evaluate vibrato for every active note on a channel.
+ */
+static void set_channel_vibrato(struct _mdi *mdi, uint8_t ch) {
+    struct _note *note_data = mdi->note;
+
+    while (note_data) {
+        if ((note_data->noteid >> 8) == ch) {
+            set_note_vibrato(mdi, note_data);
+        }
+        note_data = note_data->next;
+    }
 }
 
 void _WM_do_note_on(struct _mdi *mdi, struct _event_data *data) {
@@ -766,7 +865,8 @@ void _WM_do_note_on(struct _mdi *mdi, struct _event_data *data) {
     nte->patch = patch;
     nte->sample = sample;
     nte->sample_pos = 0;
-    nte->sample_inc = get_inc(mdi, nte);
+    /* sets base_inc, sample_inc and any vibrato state for this channel */
+    set_note_vibrato(mdi, nte);
     nte->velocity = velocity;
     nte->env = 0;
     nte->env_inc = nte->sample->env_rate[0];
@@ -807,6 +907,21 @@ void _WM_do_control_bank_select(struct _mdi *mdi, struct _event_data *data) {
     mdi->channel[ch].bank = data->data.value;
 }
 
+void _WM_do_control_channel_modulation(struct _mdi *mdi,
+                                       struct _event_data *data) {
+    uint8_t ch = data->channel;
+    MIDI_EVENT_DEBUG(_WM_FUNCTION,ch, data->data.value);
+
+    if (mdi->channel[ch].modulation == data->data.value)
+        return;
+
+    mdi->channel[ch].modulation = data->data.value;
+
+    /* Reset the LFO phase so vibrato starts from centre pitch instead of
+       jumping mid-cycle, as TiMidity++ does in update_modulation_wheel(). */
+    set_channel_vibrato(mdi, ch);
+}
+
 void _WM_do_control_data_entry_course(struct _mdi *mdi,
                                          struct _event_data *data) {
     uint8_t ch = data->channel;
@@ -819,6 +934,12 @@ void _WM_do_control_data_entry_course(struct _mdi *mdi,
         mdi->channel[ch].pitch_range = data->data.value * 100 + data_tmp;
     /*  printf("Data Entry Course: pitch_range: %i\n\r",mdi->channel[ch].pitch_range);*/
     /*  printf("Data Entry Course: data %li\n\r",data->data.value);*/
+    } else if ((mdi->channel[ch].reg_non == 0)
+        && (mdi->channel[ch].reg_data == 0x0005)) { /* Modulation Depth Range */
+        /* GM2/SF2: MSB is in semitones, so 1 unit == 100 cents of vibrato
+           depth at full wheel. */
+        mdi->channel[ch].mod_depth_range = (int16_t)(data->data.value * 100);
+        set_channel_vibrato(mdi, ch);
     }
 }
 
@@ -869,6 +990,13 @@ void _WM_do_control_data_entry_fine(struct _mdi *mdi,
         mdi->channel[ch].pitch_range = (data_tmp * 100) + data->data.value;
     /*  printf("Data Entry Fine: pitch_range: %i\n\r",mdi->channel[ch].pitch_range);*/
     /*  printf("Data Entry Fine: data: %li\n\r", data->data.value);*/
+    } else if ((mdi->channel[ch].reg_non == 0)
+      && (mdi->channel[ch].reg_data == 0x0005)) { /* Modulation Depth Range */
+        /* LSB refines the semitone MSB in 128ths, i.e. ~0.78 cents per unit */
+        data_tmp = (mdi->channel[ch].mod_depth_range / 100) * 100;
+        mdi->channel[ch].mod_depth_range =
+            (int16_t)(data_tmp + ((data->data.value * 100) / 128));
+        set_channel_vibrato(mdi, ch);
     }
 }
 
@@ -1028,6 +1156,9 @@ void _WM_do_control_channel_controllers_off(struct _mdi *mdi,
     mdi->channel[ch].pitch = 0;
     mdi->channel[ch].pitch_adjust = 0;
     mdi->channel[ch].hold = 0;
+    mdi->channel[ch].modulation = 0;
+    mdi->channel[ch].mod_depth_range = VIB_DEPTH_DEFAULT;
+    set_channel_vibrato(mdi, ch);
 
     _WM_AdjustChannelVolumes(mdi, ch);
 }
@@ -1121,7 +1252,14 @@ void _WM_do_pitch(struct _mdi *mdi, struct _event_data *data) {
     if (note_data) {
         do {
             if ((note_data->noteid >> 8) == ch) {
-                note_data->sample_inc = get_inc(mdi, note_data);
+                if (note_data->vib_depth == 0) {
+                    note_data->sample_inc = get_inc(mdi, note_data);
+                } else {
+                    /* Re-apply the bend at the LFO's current phase so the
+                       bend lands immediately rather than at the next block,
+                       without disturbing the vibrato cycle. */
+                    _WM_update_note_vibrato_at_phase(mdi, note_data);
+                }
             }
             note_data = note_data->next;
         } while (note_data);
@@ -1168,6 +1306,8 @@ void _WM_do_sysex_gm_reset(struct _mdi *mdi, struct _event_data *data) {
         mdi->channel[i].pitch_range = 200;
         mdi->channel[i].reg_data = 0xFFFF;
         mdi->channel[i].isdrum = 0;
+        mdi->channel[i].modulation = 0;
+        mdi->channel[i].mod_depth_range = VIB_DEPTH_DEFAULT;
     }
     /* I would not expect notes to be active when this event
      triggers but we'll adjust active notes as well just in case */
@@ -1571,6 +1711,10 @@ static int midi_setup_control(struct _mdi *mdi, uint8_t channel,
             ev = ev_control_bank_select;
             tmp_event = _WM_do_control_bank_select;
             mdi->channel[channel].bank = setting;
+            break;
+        case 1:
+            ev = ev_control_channel_modulation;
+            tmp_event = _WM_do_control_channel_modulation;
             break;
         case 6:
             ev = ev_control_data_entry_course;

--- a/src/internal_midi.c
+++ b/src/internal_midi.c
@@ -1308,6 +1308,9 @@ void _WM_do_sysex_gm_reset(struct _mdi *mdi, struct _event_data *data) {
         mdi->channel[i].isdrum = 0;
         mdi->channel[i].modulation = 0;
         mdi->channel[i].mod_depth_range = VIB_DEPTH_DEFAULT;
+        /* Clear vibrato on any sounding note too, the same way CC 121 does;
+           otherwise a note held across the reset keeps modulating. */
+        set_channel_vibrato(mdi, (uint8_t)i);
     }
     /* I would not expect notes to be active when this event
      triggers but we'll adjust active notes as well just in case */

--- a/src/mafm.c
+++ b/src/mafm.c
@@ -456,7 +456,9 @@ void _WM_MAFM_Reset(void *synth) {
         s->chan_expression[i] = 1.0f;
         s->chan_pitch[i] = 0x2000;
         s->chan_pan[i] = 0xff;       /* sentinel: use patch pan_default */
+        s->chan_modulation[i] = 0;
     }
+    s->vib_phase = 0.0;
 }
 
 int _WM_MAFM_ActiveVoices(void *synth) {
@@ -565,6 +567,18 @@ static void mafm_note_off(struct mafm_synth *s, int ch, int note) {
     }
 }
 
+/* Restore a channel's sounding voices to their unmodulated pitch.  Needed
+ * whenever vibrato stops, because the render loop then stops retuning them
+ * and would otherwise leave the last LFO offset frozen in. */
+static void mafm_clear_vibrato(struct mafm_synth *s, uint8_t ch) {
+    int i;
+    for (i = 0; i < MAFM_POLYPHONY; i++) {
+        struct mafm_voice *v = &s->voices[i];
+        if (_WM_MAFM_VoiceActive(v) && v->channel == ch)
+            _WM_MAFM_VoiceSetPitch(v, mafm_note_hz(v->note, s->chan_pitch[ch]));
+    }
+}
+
 void _WM_MAFM_Event(void *synth, struct _mdi *mdi, struct _event *event) {
     struct mafm_synth *s = (struct mafm_synth *) synth;
     uint8_t ch = event->event_data.channel;
@@ -588,19 +602,23 @@ void _WM_MAFM_Event(void *synth, struct _mdi *mdi, struct _event *event) {
     case ev_control_bank_select:
         s->chan_bank[ch] = val & 0x7F;
         break;
-    case ev_control_channel_modulation: {
-        /* Depth is applied per render block in _WM_MAFM_Render; on release of
-         * the wheel restore the sounding voices to their unmodulated pitch,
-         * since the render loop then stops touching them. */
-        int i;
+    case ev_control_channel_modulation:
         s->chan_modulation[ch] = val & 0x7F;
-        if (s->chan_modulation[ch] == 0) {
-            for (i = 0; i < MAFM_POLYPHONY; i++) {
-                struct mafm_voice *v = &s->voices[i];
-                if (_WM_MAFM_VoiceActive(v) && v->channel == ch)
-                    _WM_MAFM_VoiceSetPitch(v,
-                        mafm_note_hz(v->note, s->chan_pitch[ch]));
-            }
+        if (s->chan_modulation[ch] == 0)
+            mafm_clear_vibrato(s, ch);
+        break;
+    case ev_control_channel_controllers_off:
+        s->chan_modulation[ch] = 0;
+        mafm_clear_vibrato(s, ch);
+        break;
+    case ev_sysex_gm_reset:
+    case ev_sysex_roland_reset:
+    case ev_sysex_yamaha_reset: {
+        /* A GM/GS/XG reset clears the wheel on every channel. */
+        int i;
+        for (i = 0; i < 16; i++) {
+            s->chan_modulation[i] = 0;
+            mafm_clear_vibrato(s, (uint8_t)i);
         }
     } break;
     case ev_pitch: {

--- a/src/mafm.c
+++ b/src/mafm.c
@@ -56,6 +56,8 @@ typedef char mafm_char20[20]; /* no empty source. */
 #define MAFM_MAX_WAVES  32      /* decoded ADPCM waves kept from one file */
 #define MAFM_PCM_POOL   16      /* simultaneously sounding sampled voices */
 #define MAFM_MAX_TRIGS  1024    /* scheduled ATR wave hits */
+#define MAFM_VIB_RATE_HZ 5      /* CC1 vibrato LFO rate */
+#define MAFM_VIB_BLOCK   64     /* frames between vibrato LFO updates */
 
 /* One entry in the file's custom voice bank. */
 struct mafm_bank_entry {
@@ -111,6 +113,8 @@ struct mafm_synth {
     float   chan_expression[16];     /* CC 0x0B; multiplied with volume */
     int     chan_pitch[16];          /* 14-bit pitch wheel, centred 0x2000 */
     uint8_t chan_pan[16];            /* 0..127 pan CC, 64 = centre; 0xff = unset */
+    uint8_t chan_modulation[16];     /* CC 1 mod wheel, drives a 5Hz pitch LFO */
+    double  vib_phase;               /* shared vibrato LFO phase, 0..1 */
     double  lim_env;                 /* soft peak-limiter state, in mix units */
 
     struct mafm_voice voices[MAFM_POLYPHONY];
@@ -584,6 +588,21 @@ void _WM_MAFM_Event(void *synth, struct _mdi *mdi, struct _event *event) {
     case ev_control_bank_select:
         s->chan_bank[ch] = val & 0x7F;
         break;
+    case ev_control_channel_modulation: {
+        /* Depth is applied per render block in _WM_MAFM_Render; on release of
+         * the wheel restore the sounding voices to their unmodulated pitch,
+         * since the render loop then stops touching them. */
+        int i;
+        s->chan_modulation[ch] = val & 0x7F;
+        if (s->chan_modulation[ch] == 0) {
+            for (i = 0; i < MAFM_POLYPHONY; i++) {
+                struct mafm_voice *v = &s->voices[i];
+                if (_WM_MAFM_VoiceActive(v) && v->channel == ch)
+                    _WM_MAFM_VoiceSetPitch(v,
+                        mafm_note_hz(v->note, s->chan_pitch[ch]));
+            }
+        }
+    } break;
     case ev_pitch: {
         int i;
         s->chan_pitch[ch] = val & 0x3FFF;
@@ -661,6 +680,32 @@ void _WM_MAFM_Render(void *synth, int32_t *out, uint32_t frames) {
     }
     for (f = 0; f < frames; f++) {
         double l = 0.0, r = 0.0, pcm, peak, gain;
+
+        /* CC1 vibrato: advance a shared 5Hz triangle LFO and retune any voice
+         * whose channel has the mod wheel up.  Depth matches the other
+         * backends (50 cents at full wheel, SF2.01 8.4.4).  Updated once per
+         * MAFM_VIB_BLOCK frames to keep the inner mixing loop cheap. */
+        if ((s->cursor % MAFM_VIB_BLOCK) == 0) {
+            double tri;
+            s->vib_phase += (double)MAFM_VIB_RATE_HZ * MAFM_VIB_BLOCK / s->rate;
+            s->vib_phase -= floor(s->vib_phase);
+            /* unit triangle in [-1, 1] */
+            tri = (s->vib_phase < 0.5)
+                    ? (4.0 * s->vib_phase - 1.0)
+                    : (3.0 - 4.0 * s->vib_phase);
+            for (i = 0; i < MAFM_POLYPHONY; i++) {
+                struct mafm_voice *v = &s->voices[i];
+                if (!_WM_MAFM_VoiceActive(v)) continue;
+                if (s->chan_modulation[v->channel]) {
+                    double cents = 50.0 * s->chan_modulation[v->channel] / 127.0
+                                   * tri;
+                    _WM_MAFM_VoiceSetPitch(v,
+                        mafm_note_hz(v->note, s->chan_pitch[v->channel])
+                            * pow(2.0, cents / 1200.0));
+                }
+            }
+        }
+
         for (i = 0; i < MAFM_POLYPHONY; i++) {
             struct mafm_voice *v = &s->voices[i];
             if (_WM_MAFM_VoiceActive(v)) {

--- a/src/sf2.c
+++ b/src/sf2.c
@@ -172,6 +172,9 @@ void _WM_SF2_Event(void *synth, struct _mdi *mdi, struct _event *event) {
         if (!mdi->channel[ch].isdrum) /* drum kits select via patch, not bank */
             tsf_channel_midi_control(f, ch, 0, val & 0x7F);
         break;
+    case ev_control_channel_modulation:
+        tsf_channel_midi_control(f, ch, 1, val & 0x7F);
+        break;
     case ev_control_data_entry_course:
         tsf_channel_midi_control(f, ch, 6, val & 0x7F);
         break;

--- a/src/tsf/tsf.h
+++ b/src/tsf/tsf.h
@@ -2113,7 +2113,10 @@ TCMC_SET_DATA:
 	else if (c->midiRPN == 2 && controller == 6) tsf_channel_set_tuning(f, channel, ((float)control_value - 64.0f) + (c->tuning - (int)c->tuning)); //coarse tune
 	else if (c->midiRPN == 5) /* WildMIDI: modulation depth range, MSB in semitones */
 	{
-		c->modDepthRange = (c->midiData >> 7) * 100.0f + (c->midiData & 0x7F) * (100.0f / 128.0f);
+		/* Clamped to the same 600 cent ceiling the GUS path applies in
+		   get_vib_depth(), so a bogus RPN 5 cannot detune by octaves. */
+		float depth = (c->midiData >> 7) * 100.0f + (c->midiData & 0x7F) * (100.0f / 128.0f);
+		c->modDepthRange = (depth > 600.0f ? 600.0f : depth);
 		tsf_channel_apply_modulation(f, channel, c);
 	}
 	return 1;

--- a/src/tsf/tsf.h
+++ b/src/tsf/tsf.h
@@ -501,12 +501,20 @@ struct tsf_voice
 	struct tsf_voice_envelope ampenv, modenv;
 	struct tsf_voice_lowpass lowpass;
 	struct tsf_voice_lfo modlfo, viblfo;
+	/* WildMIDI: extra vib-LFO-to-pitch depth in cents contributed by the CC1
+	   modulation wheel. Kept per voice so the shared region data stays
+	   read-only; see SF2.01 section 8.4.4. */
+	float vibLfoToPitchCC;
 };
 
 struct tsf_channel
 {
 	unsigned short presetIndex, bank, pitchWheel, midiPan, midiVolume, midiExpression, midiRPN, midiData : 14, sustain : 1;
 	float panOffset, gainDB, pitchRange, tuning;
+	/* WildMIDI: CC1 modulation wheel (0-127) and its depth range in cents at
+	   full wheel (RPN 5, default 50 per SF2.01 section 8.4.4). */
+	unsigned char midiModulation;
+	float modDepthRange;
 };
 
 struct tsf_channels
@@ -1275,7 +1283,9 @@ static void tsf_voice_render(tsf* f, struct tsf_voice* v, float* outputBuffer, i
 	// Cache some values, to give them at least some chance of ending up in registers.
 	TSF_BOOL updateModEnv = (region->modEnvToPitch || region->modEnvToFilterFc);
 	TSF_BOOL updateModLFO = (v->modlfo.delta && (region->modLfoToPitch || region->modLfoToFilterFc || region->modLfoToVolume));
-	TSF_BOOL updateVibLFO = (v->viblfo.delta && (region->vibLfoToPitch));
+	/* WildMIDI: vibLfoToPitchCC (CC1) also drives the vib LFO */
+	float vibLfoToPitchTotal = (float)region->vibLfoToPitch + v->vibLfoToPitchCC;
+	TSF_BOOL updateVibLFO = (v->viblfo.delta && (vibLfoToPitchTotal != 0.0f));
 	TSF_BOOL isLooping    = (v->loopStart < v->loopEnd);
 	unsigned int tmpLoopStart = v->loopStart, tmpLoopEnd = v->loopEnd;
 	double tmpSampleEndDbl = (double)region->end, tmpLoopEndDbl = (double)tmpLoopEnd + 1.0;
@@ -1285,7 +1295,7 @@ static void tsf_voice_render(tsf* f, struct tsf_voice* v, float* outputBuffer, i
 	TSF_BOOL dynamicLowpass = (region->modLfoToFilterFc || region->modEnvToFilterFc);
 	float tmpSampleRate = f->outSampleRate, tmpInitialFilterFc, tmpModLfoToFilterFc, tmpModEnvToFilterFc;
 
-	TSF_BOOL dynamicPitchRatio = (region->modLfoToPitch || region->modEnvToPitch || region->vibLfoToPitch);
+	TSF_BOOL dynamicPitchRatio = (region->modLfoToPitch || region->modEnvToPitch || vibLfoToPitchTotal != 0.0f);
 	double pitchRatio;
 	float tmpModLfoToPitch, tmpVibLfoToPitch, tmpModEnvToPitch;
 
@@ -1295,7 +1305,7 @@ static void tsf_voice_render(tsf* f, struct tsf_voice* v, float* outputBuffer, i
 	if (dynamicLowpass) tmpInitialFilterFc = (float)region->initialFilterFc, tmpModLfoToFilterFc = (float)region->modLfoToFilterFc, tmpModEnvToFilterFc = (float)region->modEnvToFilterFc;
 	else tmpInitialFilterFc = 0, tmpModLfoToFilterFc = 0, tmpModEnvToFilterFc = 0;
 
-	if (dynamicPitchRatio) pitchRatio = 0, tmpModLfoToPitch = (float)region->modLfoToPitch, tmpVibLfoToPitch = (float)region->vibLfoToPitch, tmpModEnvToPitch = (float)region->modEnvToPitch;
+	if (dynamicPitchRatio) pitchRatio = 0, tmpModLfoToPitch = (float)region->modLfoToPitch, tmpVibLfoToPitch = vibLfoToPitchTotal, tmpModEnvToPitch = (float)region->modEnvToPitch;
 	else pitchRatio = tsf_timecents2Secsd(v->pitchInputTimecents) * v->pitchOutputFactor, tmpModLfoToPitch = 0, tmpVibLfoToPitch = 0, tmpModEnvToPitch = 0;
 
 	if (dynamicGain) tmpModLfoToVolume = (float)region->modLfoToVolume * 0.1f;
@@ -1797,6 +1807,8 @@ static void tsf_channel_setup_voice(tsf* f, struct tsf_voice* v)
 	float newpan = v->region->pan + c->panOffset;
 	v->playingChannel = f->channels->activeChannel;
 	v->noteGainDB += c->gainDB;
+	/* WildMIDI: CC1 vibrato depth for this channel (SF2.01 8.4.4) */
+	v->vibLfoToPitchCC = c->modDepthRange * c->midiModulation / 127.0f;
 	tsf_voice_calcpitchratio(v, (c->pitchWheel == 8192 ? c->tuning : ((c->pitchWheel / 16383.0f * c->pitchRange * 2.0f) - c->pitchRange + c->tuning)), f->outSampleRate);
 	if      (newpan <= -0.5f) { v->panFactorLeft = 1.0f; v->panFactorRight = 0.0f; }
 	else if (newpan >=  0.5f) { v->panFactorLeft = 0.0f; v->panFactorRight = 1.0f; }
@@ -1835,8 +1847,22 @@ static struct tsf_channel* tsf_channel_init(tsf* f, int channel)
 		c->gainDB = 0.0f;
 		c->pitchRange = 2.0f;
 		c->tuning = 0.0f;
+		c->midiModulation = 0;
+		c->modDepthRange = 50.0f; /* WildMIDI: SF2.01 8.4.4 default */
 	}
 	return &f->channels->channels[channel];
+}
+
+/* WildMIDI: push a CC1 / RPN 5 change onto the channel's sounding voices.
+   The vib LFO itself keeps running; only its pitch depth changes, so a wheel
+   move mid-note takes effect without restarting the note. */
+static void tsf_channel_apply_modulation(tsf* f, int channel, struct tsf_channel* c)
+{
+	struct tsf_voice *v, *vEnd;
+	float depth = c->modDepthRange * c->midiModulation / 127.0f;
+	for (v = f->voices, vEnd = v ? v + f->voiceNum : TSF_NULL; v != vEnd; v++)
+		if (v->playingPreset != -1 && v->playingChannel == channel)
+			v->vibLfoToPitchCC = depth;
 }
 
 static void tsf_channel_applypitch(tsf* f, int channel, struct tsf_channel* c)
@@ -2051,6 +2077,10 @@ TSFDEF int tsf_channel_midi_control(tsf* f, int channel, int controller, int con
 		case 100 /*RPN_LSB*/         : c->midiRPN = (unsigned short)(((c->midiRPN == 0xFFFF ? 0 : c->midiRPN) & 0x3F80) |  control_value); return 1;
 		case  98 /*NRPN_LSB*/        : c->midiRPN = 0xFFFF; return 1;
 		case  99 /*NRPN_MSB*/        : c->midiRPN = 0xFFFF; return 1;
+		case   1 /*MODULATION_MSB*/  : /* WildMIDI: CC1 -> vib LFO pitch depth */
+			c->midiModulation = (unsigned char)control_value;
+			tsf_channel_apply_modulation(f, channel, c);
+			return 1;
 		case  64 /*SUSTAIN*/         : tsf_channel_set_sustain(f, channel, (int)(control_value >= 64)); return 1;
 		case 120 /*ALL_SOUND_OFF*/   : tsf_channel_sounds_off_all(f, channel); return 1;
 		case 123 /*ALL_NOTES_OFF*/   : tsf_channel_note_off_all(f, channel);   return 1;
@@ -2060,6 +2090,9 @@ TSFDEF int tsf_channel_midi_control(tsf* f, int channel, int controller, int con
 			c->bank = 0;
 			c->midiRPN = 0xFFFF;
 			c->midiData = 0;
+			c->midiModulation = 0; /* WildMIDI */
+			c->modDepthRange = 50.0f;
+			tsf_channel_apply_modulation(f, channel, c);
 			tsf_channel_set_volume(f, channel, 1.0f);
 			tsf_channel_set_pan(f, channel, 0.5f);
 			tsf_channel_set_pitchrange(f, channel, 2.0f);
@@ -2078,6 +2111,11 @@ TCMC_SET_DATA:
 	if      (c->midiRPN == 0) tsf_channel_set_pitchrange(f, channel, (c->midiData >> 7) + 0.01f * (c->midiData & 0x7F));
 	else if (c->midiRPN == 1) tsf_channel_set_tuning(f, channel, (int)c->tuning + ((float)c->midiData - 8192.0f) / 8192.0f); //fine tune
 	else if (c->midiRPN == 2 && controller == 6) tsf_channel_set_tuning(f, channel, ((float)control_value - 64.0f) + (c->tuning - (int)c->tuning)); //coarse tune
+	else if (c->midiRPN == 5) /* WildMIDI: modulation depth range, MSB in semitones */
+	{
+		c->modDepthRange = (c->midiData >> 7) * 100.0f + (c->midiData & 0x7F) * (100.0f / 128.0f);
+		tsf_channel_apply_modulation(f, channel, c);
+	}
 	return 1;
 }
 

--- a/src/wildmidi_lib.c
+++ b/src/wildmidi_lib.c
@@ -1027,6 +1027,20 @@ static int WM_GetOutput_Linear(midi * handle, int8_t *buffer, uint32_t size) {
             note_data = mdi->note;
             left_mix = right_mix = 0;
             RESAMPLE_DEBUGI("SAMPLES_TO_MIX",count);
+
+            /* Vibrato LFO tick. Runs once per VIB_BLOCK samples and only
+               touches notes that actually have modulation applied. */
+            if (__builtin_expect((++mdi->vib_block_count >= VIB_BLOCK), 0)) {
+                struct _note *vib_note = mdi->note;
+                mdi->vib_block_count = 0;
+                while (vib_note) {
+                    if (vib_note->vib_depth) {
+                        _WM_update_note_vibrato(mdi, vib_note);
+                    }
+                    vib_note = vib_note->next;
+                }
+            }
+
             if (__builtin_expect((note_data != NULL), 1)) {
                 RESAMPLE_DEBUGS("Processing Notes");
                 while (note_data) {
@@ -1366,6 +1380,20 @@ static int WM_GetOutput_Gauss(midi * handle, int8_t *buffer, uint32_t size) {
         do {
             note_data = mdi->note;
             left_mix = right_mix = 0;
+
+            /* Vibrato LFO tick. Runs once per VIB_BLOCK samples and only
+               touches notes that actually have modulation applied. */
+            if (__builtin_expect((++mdi->vib_block_count >= VIB_BLOCK), 0)) {
+                struct _note *vib_note = mdi->note;
+                mdi->vib_block_count = 0;
+                while (vib_note) {
+                    if (vib_note->vib_depth) {
+                        _WM_update_note_vibrato(mdi, vib_note);
+                    }
+                    vib_note = vib_note->next;
+                }
+            }
+
             if (__builtin_expect((note_data != NULL), 1)) {
                 while (note_data) {
                     /*


### PR DESCRIPTION
CC1 was parsed then discarded, and the GUS engine had no LFO at all. Adds a 5Hz triangle vibrato LFO (TiMidity++ style) for GUS patches, wires CC1 to vibLfoToPitch for SF2 (50 cents at full wheel, per SF2.01 8.4.4 as FluidSynth does), and adds an LFO to the MA-FM synth.  RPN 5 rescales depth; CC121 and the resets clear it.  Also fixes -o MIDI export, which would otherwise drop the new event type.

Files without CC1 render bit-for-bit identical to before.

Closes #143

Test files
[modulation_testing.zip](https://github.com/user-attachments/files/30389432/modulation_testing.zip)
