### PR TITLE
Fix signed-integer-overflow UB in big-endian 32-bit reads across the format parsers

### DIFF
--- a/src/f_hmi.c
+++ b/src/f_hmi.c
@@ -143,7 +143,7 @@ _WM_ParseNewHmi(const uint8_t *hmi_data, uint32_t hmi_size) {
         hmi_track_offset[i] = *hmi_data++;
         hmi_track_offset[i] += (*hmi_data++ << 8);
         hmi_track_offset[i] += (*hmi_data++ << 16);
-        hmi_track_offset[i] += (*hmi_data++ << 24);
+        hmi_track_offset[i] += ((uint32_t)*hmi_data++ << 24);
 
         if (hmi_size < (hmi_track_offset[i] + 0x5a + 4)) {
             _WM_GLOBAL_ERROR(WM_ERR_NOT_HMI, "file too short", 0);
@@ -160,7 +160,7 @@ _WM_ParseNewHmi(const uint8_t *hmi_data, uint32_t hmi_size) {
         hmi_track_header_length[i] = hmi_addr[0x57];
         hmi_track_header_length[i] += (hmi_addr[0x58] << 8);
         hmi_track_header_length[i] += (hmi_addr[0x59] << 16);
-        hmi_track_header_length[i] += (hmi_addr[0x5a] << 24);
+        hmi_track_header_length[i] += ((uint32_t)hmi_addr[0x5a] << 24);
 
         /* GHSA-f2xg-2rq9-xvhm: header length is file-controlled; bound it
          * against the remaining buffer so the pointer advance below cannot

--- a/src/f_hmp.c
+++ b/src/f_hmp.c
@@ -111,7 +111,7 @@ _WM_ParseNewHmp(const uint8_t *hmp_data, uint32_t hmp_size) {
     hmp_file_length = *hmp_data++;
     hmp_file_length += (*hmp_data++ << 8);
     hmp_file_length += (*hmp_data++ << 16);
-    hmp_file_length += (*hmp_data++ << 24);
+    hmp_file_length += ((uint32_t)*hmp_data++ << 24);
     hmp_size -= 4;
 
     WMIDI_UNUSED(hmp_file_length);
@@ -123,7 +123,7 @@ _WM_ParseNewHmp(const uint8_t *hmp_data, uint32_t hmp_size) {
     hmp_chunks = *hmp_data++;
     hmp_chunks += (*hmp_data++ << 8);
     hmp_chunks += (*hmp_data++ << 16);
-    hmp_chunks += (*hmp_data++ << 24);
+    hmp_chunks += ((uint32_t)*hmp_data++ << 24);
     hmp_size -= 4;
 
     if (!hmp_chunks) {
@@ -135,7 +135,7 @@ _WM_ParseNewHmp(const uint8_t *hmp_data, uint32_t hmp_size) {
     hmp_unknown = *hmp_data++;
     hmp_unknown += (*hmp_data++ << 8);
     hmp_unknown += (*hmp_data++ << 16);
-    hmp_unknown += (*hmp_data++ << 24);
+    hmp_unknown += ((uint32_t)*hmp_data++ << 24);
     hmp_size -= 4;
 
     WMIDI_UNUSED(hmp_unknown);
@@ -147,7 +147,7 @@ _WM_ParseNewHmp(const uint8_t *hmp_data, uint32_t hmp_size) {
     hmp_bpm = *hmp_data++;
     hmp_bpm += (*hmp_data++ << 8);
     hmp_bpm += (*hmp_data++ << 16);
-    hmp_bpm += (*hmp_data++ << 24);
+    hmp_bpm += ((uint32_t)*hmp_data++ << 24);
     hmp_size -= 4;
 
     if (!hmp_bpm) {
@@ -171,7 +171,7 @@ _WM_ParseNewHmp(const uint8_t *hmp_data, uint32_t hmp_size) {
     hmp_song_time = *hmp_data++;
     hmp_song_time += (*hmp_data++ << 8);
     hmp_song_time += (*hmp_data++ << 16);
-    hmp_song_time += (*hmp_data++ << 24);
+    hmp_song_time += ((uint32_t)*hmp_data++ << 24);
     hmp_size -= 4;
 
     /* DEBUG */
@@ -211,7 +211,7 @@ _WM_ParseNewHmp(const uint8_t *hmp_data, uint32_t hmp_size) {
         chunk_num = *hmp_data++;
         chunk_num += (*hmp_data++ << 8);
         chunk_num += (*hmp_data++ << 16);
-        chunk_num += (*hmp_data++ << 24);
+        chunk_num += ((uint32_t)*hmp_data++ << 24);
         chunk_ofs[i] += 4;
 
         WMIDI_UNUSED(chunk_num);
@@ -219,7 +219,7 @@ _WM_ParseNewHmp(const uint8_t *hmp_data, uint32_t hmp_size) {
         chunk_length[i] = *hmp_data++;
         chunk_length[i] += (*hmp_data++ << 8);
         chunk_length[i] += (*hmp_data++ << 16);
-        chunk_length[i] += (*hmp_data++ << 24);
+        chunk_length[i] += ((uint32_t)*hmp_data++ << 24);
         chunk_ofs[i] += 4;
 
         if (chunk_length[i] > hmp_size) {
@@ -232,7 +232,7 @@ _WM_ParseNewHmp(const uint8_t *hmp_data, uint32_t hmp_size) {
         hmp_track = *hmp_data++;
         hmp_track += (*hmp_data++ << 8);
         hmp_track += (*hmp_data++ << 16);
-        hmp_track += (*hmp_data++ << 24);
+        hmp_track += ((uint32_t)*hmp_data++ << 24);
         chunk_ofs[i] += 4;
 
         WMIDI_UNUSED(hmp_track);

--- a/src/f_midi.c
+++ b/src/f_midi.c
@@ -88,7 +88,7 @@ _WM_ParseNewMidi(const uint8_t *midi_data, uint32_t midi_size) {
     /*
      * Get Midi Header Size - must always be 6
      */
-    tmp_val = *midi_data++ << 24;
+    tmp_val = (uint32_t)*midi_data++ << 24;
     tmp_val |= *midi_data++ << 16;
     tmp_val |= *midi_data++ << 8;
     tmp_val |= *midi_data++;
@@ -166,7 +166,7 @@ _WM_ParseNewMidi(const uint8_t *midi_data, uint32_t midi_size) {
         midi_size -= 4;
 
         /* track size */
-        tmp_val = *midi_data++ << 24;
+        tmp_val = (uint32_t)*midi_data++ << 24;
         tmp_val |= *midi_data++ << 16;
         tmp_val |= *midi_data++ << 8;
         tmp_val |= *midi_data++;

--- a/src/f_xmidi.c
+++ b/src/f_xmidi.c
@@ -73,7 +73,7 @@ struct _mdi *_WM_ParseNewXmi(const uint8_t *xmi_data, uint32_t xmi_size) {
     xmi_size -= 4;
 
     /* bytes until next entry */
-    xmi_tmpdata = *xmi_data++ << 24;
+    xmi_tmpdata = (uint32_t)*xmi_data++ << 24;
     xmi_tmpdata |= *xmi_data++ << 16;
     xmi_tmpdata |= *xmi_data++ << 8;
     xmi_tmpdata |= *xmi_data++;
@@ -125,7 +125,7 @@ struct _mdi *_WM_ParseNewXmi(const uint8_t *xmi_data, uint32_t xmi_size) {
     xmi_data += 4;
     xmi_size -= 4;
 
-    xmi_catlen = *xmi_data++ << 24;
+    xmi_catlen = (uint32_t)*xmi_data++ << 24;
     xmi_catlen |= *xmi_data++ << 16;
     xmi_catlen |= *xmi_data++ << 8;
     xmi_catlen |= *xmi_data++;
@@ -164,7 +164,7 @@ struct _mdi *_WM_ParseNewXmi(const uint8_t *xmi_data, uint32_t xmi_size) {
         xmi_data += 4;
         xmi_size -= 4;
 
-        xmi_subformlen = *xmi_data++ << 24;
+        xmi_subformlen = (uint32_t)*xmi_data++ << 24;
         xmi_subformlen |= *xmi_data++ << 16;
         xmi_subformlen |= *xmi_data++ << 8;
         xmi_subformlen |= *xmi_data++;
@@ -196,7 +196,7 @@ struct _mdi *_WM_ParseNewXmi(const uint8_t *xmi_data, uint32_t xmi_size) {
                 /*        hold patch events */
                 xmi_data += 4;
 
-                xmi_tmpdata = *xmi_data++ << 24;
+                xmi_tmpdata = (uint32_t)*xmi_data++ << 24;
                 xmi_tmpdata |= *xmi_data++ << 16;
                 xmi_tmpdata |= *xmi_data++ << 8;
                 xmi_tmpdata |= *xmi_data++;
@@ -216,7 +216,7 @@ struct _mdi *_WM_ParseNewXmi(const uint8_t *xmi_data, uint32_t xmi_size) {
                 /* FIXME: May not be needed for playback */
                 xmi_data += 4;
 
-                xmi_tmpdata = *xmi_data++ << 24;
+                xmi_tmpdata = (uint32_t)*xmi_data++ << 24;
                 xmi_tmpdata |= *xmi_data++ << 16;
                 xmi_tmpdata |= *xmi_data++ << 8;
                 xmi_tmpdata |= *xmi_data++;
@@ -234,7 +234,7 @@ struct _mdi *_WM_ParseNewXmi(const uint8_t *xmi_data, uint32_t xmi_size) {
 
                 xmi_evnt_cnt++;
 
-                xmi_evntlen = *xmi_data++ << 24;
+                xmi_evntlen = (uint32_t)*xmi_data++ << 24;
                 xmi_evntlen |= *xmi_data++ << 16;
                 xmi_evntlen |= *xmi_data++ << 8;
                 xmi_evntlen |= *xmi_data++;

--- a/src/gus_pat.c
+++ b/src/gus_pat.c
@@ -784,29 +784,29 @@ struct _sample * _WM_load_gus_pat(const char *filename, int fix_release) {
         }
 
         gus_sample->loop_fraction = gus_patch[gus_ptr + 7];
-        gus_sample->data_length = (gus_patch[gus_ptr + 11] << 24)
+        gus_sample->data_length = ((uint32_t)gus_patch[gus_ptr + 11] << 24)
                                 | (gus_patch[gus_ptr + 10] << 16)
                                 | (gus_patch[gus_ptr + 9]  <<  8)
                                 |  gus_patch[gus_ptr + 8];
-        gus_sample->loop_start  = (gus_patch[gus_ptr + 15] << 24)
+        gus_sample->loop_start  = ((uint32_t)gus_patch[gus_ptr + 15] << 24)
                                 | (gus_patch[gus_ptr + 14] << 16)
                                 | (gus_patch[gus_ptr + 13] <<  8)
                                 |  gus_patch[gus_ptr + 12];
-        gus_sample->loop_end    = (gus_patch[gus_ptr + 19] << 24)
+        gus_sample->loop_end    = ((uint32_t)gus_patch[gus_ptr + 19] << 24)
                                 | (gus_patch[gus_ptr + 18] << 16)
                                 | (gus_patch[gus_ptr + 17] <<  8)
                                 |  gus_patch[gus_ptr + 16];
         gus_sample->rate        = (gus_patch[gus_ptr + 21] << 8)
                                 |  gus_patch[gus_ptr + 20];
-        gus_sample->freq_low    = (gus_patch[gus_ptr + 25] << 24)
+        gus_sample->freq_low    = ((uint32_t)gus_patch[gus_ptr + 25] << 24)
                                 | (gus_patch[gus_ptr + 24] << 16)
                                 | (gus_patch[gus_ptr + 23] <<  8)
                                 |  gus_patch[gus_ptr + 22];
-        gus_sample->freq_high   = (gus_patch[gus_ptr + 29] << 24)
+        gus_sample->freq_high   = ((uint32_t)gus_patch[gus_ptr + 29] << 24)
                                 | (gus_patch[gus_ptr + 28] << 16)
                                 | (gus_patch[gus_ptr + 27] <<  8)
                                 |  gus_patch[gus_ptr + 26];
-        gus_sample->freq_root   = (gus_patch[gus_ptr + 33] << 24)
+        gus_sample->freq_root   = ((uint32_t)gus_patch[gus_ptr + 33] << 24)
                                 | (gus_patch[gus_ptr + 32] << 16)
                                 | (gus_patch[gus_ptr + 31] <<  8)
                                 |  gus_patch[gus_ptr + 30];

--- a/src/mus2mid.c
+++ b/src/mus2mid.c
@@ -211,7 +211,7 @@ static int32_t writevarlen(int32_t value, uint8_t *out)
 }
 
 #define READ_INT16(b) ((b)[0] | ((b)[1] << 8))
-#define READ_INT32(b) ((b)[0] | ((b)[1] << 8) | ((b)[2] << 16) | ((uint32_t)(b)[3] << 24))
+#define READ_INT32(b) ((uint32_t)(b)[0] | ((uint32_t)(b)[1] << 8) | ((uint32_t)(b)[2] << 16) | ((uint32_t)(b)[3] << 24))
 
 int _WM_mus2midi(const uint8_t *in, uint32_t insize,
                  uint8_t **out, uint32_t *outsize,

--- a/src/mus2mid.c
+++ b/src/mus2mid.c
@@ -211,7 +211,7 @@ static int32_t writevarlen(int32_t value, uint8_t *out)
 }
 
 #define READ_INT16(b) ((b)[0] | ((b)[1] << 8))
-#define READ_INT32(b) ((b)[0] | ((b)[1] << 8) | ((b)[2] << 16) | ((b)[3] << 24))
+#define READ_INT32(b) ((b)[0] | ((b)[1] << 8) | ((b)[2] << 16) | ((uint32_t)(b)[3] << 24))
 
 int _WM_mus2midi(const uint8_t *in, uint32_t insize,
                  uint8_t **out, uint32_t *outsize,


### PR DESCRIPTION
# Fix signed-integer-overflow UB in big-endian 32-bit reads across the format parsers

## What

The format parsers assemble 32-bit big-endian values a byte at a time, e.g.

```c
tmp_val  = *midi_data++ << 24;
tmp_val |= *midi_data++ << 16;
...
```

`*midi_data` is a `uint8_t`, which promotes to `int` before the shift. When the
top byte has its high bit set (value ≥ 128), `value << 24` shifts into / past the
sign bit of a 32-bit `int`, which is **undefined behavior** in C. UBSan reports:

```
runtime error: left shift of 255 by 24 places cannot be represented in type 'int'
```

This fires while parsing untrusted MIDI / XMI / MUS / HMP / HMI input (and when
reading GUS patch headers), i.e. on the normal file-loading paths. Found with
AFL++ + UndefinedBehaviorSanitizer.

## Fix

Cast the shifted byte to `uint32_t` so the shift is well-defined unsigned
arithmetic:

```c
tmp_val = (uint32_t)*midi_data++ << 24;
```

The computed value is unchanged on any two's-complement target — this only
removes the UB. Only the `<< 24` term can overflow; `<< 16` and `<< 8` on a
byte stay within `int` and are left as-is.

## Scope

25 sites across the parsers/readers:

| file | sites |
|------|-------|
| `src/f_hmp.c`  | 8 |
| `src/f_xmidi.c`| 6 |
| `src/gus_pat.c`| 6 |
| `src/f_midi.c` | 2 |
| `src/f_hmi.c`  | 2 |
| `src/mus2mid.c`| 1 |

## Verification

- Sanitized build (clang, ASan+UBSan) is clean on this class after the change.
- A MIDI header whose size field's top byte is `0xFF` (which drives the
  `f_midi.c` `<< 24`) previously UBSan-aborted and now parses without a finding.
- Existing seed inputs (SMF/XMI/MUS/HMP/HMI/SMAF) parse unchanged — no
  behavioural difference, purely UB removal.

Signed-off-by: glitchfox <glitchfox@benjaminali.com>
